### PR TITLE
Add common opt at case-lib/opt.sh

### DIFF
--- a/case-lib/opt.sh
+++ b/case-lib/opt.sh
@@ -87,7 +87,7 @@ func_opt_parse_option()
             echo -e '    -h |  --help'
             echo -e "\tthis message"
             _func_case_dump_descption
-            exit 0
+            exit 2
         }
 
     # generate the command to load 'getopt'
@@ -101,7 +101,7 @@ func_opt_parse_option()
         [ ! "$idx" ] && idx="${_op_long_lst[$1]}"
         if [ "$idx" ]; then
             if [ ${OPT_PARM_lst[$idx]} -eq 1 ]; then
-                [ ! "$2" ] && echo "option: $1 missing parameter, parsing error" && exit 1
+                [ ! "$2" ] && echo "option: $1 missing parameter, parsing error" && exit 2
                 OPT_VALUE_lst[$idx]="$2"
                 shift 2
             else
@@ -136,4 +136,28 @@ func_opt_parse_option()
     fi
 
     unset _func_create_tmpbash _func_opt_dump_help _func_case_dump_descption
+}
+
+func_opt_add_common_TPLG()
+{
+    OPT_OPT_lst['t']='tplg'
+    OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
+    OPT_PARM_lst['t']=1
+    OPT_VALUE_lst['t']="$TPLG"
+}
+
+func_opt_add_common_sof_logger()
+{
+    OPT_OPT_lst['s']='sof-logger'
+    OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+    OPT_PARM_lst['s']=0
+    OPT_VALUE_lst['s']=1
+}
+
+func_opt_add_common_disable_pulse()
+{
+    OPT_OPT_lst['p']='pulseaudio'
+    OPT_DESC_lst['p']='disable pulseaudio on the test process'
+    OPT_PARM_lst['p']=0
+    OPT_VALUE_lst['p']=1
 }

--- a/test-case/check-alsabat.sh
+++ b/test-case/check-alsabat.sh
@@ -32,9 +32,7 @@ OPT_PARM_lst['f']=1             OPT_VALUE_lst['f']=997
 OPT_OPT_lst['n']='frames'     OPT_DESC_lst['n']='test frames'
 OPT_PARM_lst['n']=1             OPT_VALUE_lst['n']=240000
 
-OPT_OPT_lst['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
-
+func_opt_add_common_sof_logger
 func_opt_parse_option $*
 
 pcm_p=${OPT_VALUE_lst['p']}

--- a/test-case/check-capture.sh
+++ b/test-case/check-capture.sh
@@ -18,9 +18,6 @@
 
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
-OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
-
 OPT_OPT_lst['r']='round'     OPT_DESC_lst['r']='round count'
 OPT_PARM_lst['r']=1         OPT_VALUE_lst['r']=1
 
@@ -36,9 +33,8 @@ OPT_PARM_lst['o']=1         OPT_VALUE_lst['o']="$LOG_ROOT/wavs"
 OPT_OPT_lst['f']='file'   OPT_DESC_lst['f']='file name prefix'
 OPT_PARM_lst['f']=1         OPT_VALUE_lst['f']=''
 
-OPT_OPT_lst['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
-
+func_opt_add_common_TPLG
+func_opt_add_common_sof_logger
 func_opt_parse_option $*
 
 tplg=${OPT_VALUE_lst['t']}

--- a/test-case/check-kmod-load-unload-after-playback.sh
+++ b/test-case/check-kmod-load-unload-after-playback.sh
@@ -32,9 +32,6 @@
 
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
-OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
-
 OPT_OPT_lst['l']='loop'
 OPT_DESC_lst['l']='loop of PCM aplay check - module remove / insert - PCM aplay check'
 OPT_PARM_lst['l']=1          OPT_VALUE_lst['l']=2
@@ -42,9 +39,8 @@ OPT_PARM_lst['l']=1          OPT_VALUE_lst['l']=2
 OPT_OPT_lst['d']='duration' OPT_DESC_lst['d']='duration of playback process'
 OPT_PARM_lst['d']=1         OPT_VALUE_lst['d']=3
 
-OPT_OPT_lst['p']='pulseaudio'   OPT_DESC_lst['p']='disable pulseaudio on the test process'
-OPT_PARM_lst['p']=0             OPT_VALUE_lst['p']=1
-
+func_opt_add_common_TPLG
+func_opt_add_common_disable_pulse
 func_opt_parse_option $*
 tplg=${OPT_VALUE_lst['t']}
 loop_cnt=${OPT_VALUE_lst['l']}

--- a/test-case/check-kmod-load-unload.sh
+++ b/test-case/check-kmod-load-unload.sh
@@ -26,9 +26,7 @@ OPT_OPT_lst['l']='loop_cnt'
 OPT_DESC_lst['l']='remove / insert module loop count -- per device'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=2
 
-OPT_OPT_lst['p']='pulseaudio'   OPT_DESC_lst['p']='disable pulseaudio on the test process'
-OPT_PARM_lst['p']=0             OPT_VALUE_lst['p']=1
-
+func_opt_add_common_disable_pulse
 func_opt_parse_option $*
 func_lib_setup_kernel_last_line
 

--- a/test-case/check-pause-resume.sh
+++ b/test-case/check-pause-resume.sh
@@ -17,9 +17,6 @@
 
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
-OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
-
 OPT_OPT_lst['m']='mode'    OPT_DESC_lst['m']='test mode'
 OPT_PARM_lst['m']=1         OPT_VALUE_lst['m']='playback'
 
@@ -35,9 +32,8 @@ OPT_PARM_lst['d']=1         OPT_VALUE_lst['d']=10
 OPT_OPT_lst['f']='file'     OPT_DESC_lst['f']='file name'
 OPT_PARM_lst['f']=1         OPT_VALUE_lst['f']=''
 
-OPT_OPT_lst['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
-
+func_opt_add_common_TPLG
+func_opt_add_common_sof_logger
 func_opt_parse_option $*
 
 tplg=${OPT_VALUE_lst['t']}

--- a/test-case/check-playback.sh
+++ b/test-case/check-playback.sh
@@ -18,9 +18,6 @@
 
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
-OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
-
 OPT_OPT_lst['r']='round'     OPT_DESC_lst['r']='round count'
 OPT_PARM_lst['r']=1         OPT_VALUE_lst['r']=1
 
@@ -33,9 +30,8 @@ OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=3
 OPT_OPT_lst['f']='file'   OPT_DESC_lst['f']='source file path'
 OPT_PARM_lst['f']=1         OPT_VALUE_lst['f']=''
 
-OPT_OPT_lst['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
-
+func_opt_add_common_TPLG
+func_opt_add_common_sof_logger
 func_opt_parse_option $*
 
 tplg=${OPT_VALUE_lst['t']}

--- a/test-case/check-runtime-pm-status.sh
+++ b/test-case/check-runtime-pm-status.sh
@@ -16,17 +16,13 @@
 
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
-OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
-
 OPT_OPT_lst['l']='loop'     OPT_DESC_lst['l']='loop count'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=3
 
-OPT_OPT_lst['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
-
-
+func_opt_add_common_TPLG
+func_opt_add_common_sof_logger
 func_opt_parse_option $*
+
 tplg=${OPT_VALUE_lst['t']}
 [[ -z $tplg ]] && dloge "Miss tplg file to run" && exit 1
 

--- a/test-case/multiple-pipeline-capture.sh
+++ b/test-case/multiple-pipeline-capture.sh
@@ -24,9 +24,6 @@
 
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
-OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
-
 OPT_OPT_lst['c']='count'    OPT_DESC_lst['c']='test pipeline count'
 OPT_PARM_lst['c']=1         OPT_VALUE_lst['c']=4
 
@@ -36,9 +33,8 @@ OPT_PARM_lst['w']=1         OPT_VALUE_lst['w']=5
 OPT_OPT_lst['r']='random'   OPT_DESC_lst['r']='random load pipeline'
 OPT_PARM_lst['r']=0         OPT_VALUE_lst['r']=0
 
-OPT_OPT_lst['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
-
+func_opt_add_common_TPLG
+func_opt_add_common_sof_logger
 func_opt_parse_option $*
 tplg=${OPT_VALUE_lst['t']}
 func_pipeline_export $tplg

--- a/test-case/multiple-pipeline-playback.sh
+++ b/test-case/multiple-pipeline-playback.sh
@@ -24,9 +24,6 @@
 
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
-OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
-
 OPT_OPT_lst['c']='count'    OPT_DESC_lst['c']='test pipeline count'
 OPT_PARM_lst['c']=1         OPT_VALUE_lst['c']=4
 
@@ -36,9 +33,8 @@ OPT_PARM_lst['w']=1         OPT_VALUE_lst['w']=5
 OPT_OPT_lst['r']='random'   OPT_DESC_lst['r']='random load pipeline'
 OPT_PARM_lst['r']=0         OPT_VALUE_lst['r']=0
 
-OPT_OPT_lst['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
-
+func_opt_add_common_TPLG
+func_opt_add_common_sof_logger
 func_opt_parse_option $*
 tplg=${OPT_VALUE_lst['t']}
 func_pipeline_export $tplg

--- a/test-case/simultaneous-playback-capture.sh
+++ b/test-case/simultaneous-playback-capture.sh
@@ -20,15 +20,11 @@
 
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
-OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
-
 OPT_OPT_lst['w']='wait'     OPT_DESC_lst['w']='sleep for wait duration'
 OPT_PARM_lst['w']=1         OPT_VALUE_lst['w']=5
 
-OPT_OPT_lst['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
-
+func_opt_add_common_TPLG
+func_opt_add_common_sof_logger
 func_opt_parse_option $*
 tplg=${OPT_VALUE_lst['t']}
 wait_time=${OPT_VALUE_lst['w']}

--- a/test-case/test-speaker.sh
+++ b/test-case/test-speaker.sh
@@ -15,15 +15,11 @@
 
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
-OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
-
 OPT_OPT_lst['l']='loop'     OPT_DESC_lst['l']='option of speaker-test'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=3
 
-OPT_OPT_lst['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
-
+func_opt_add_common_TPLG
+func_opt_add_common_sof_logger
 func_opt_parse_option $*
 tplg=${OPT_VALUE_lst['t']}
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect

--- a/test-case/verify-pcm-list.sh
+++ b/test-case/verify-pcm-list.sh
@@ -18,9 +18,7 @@
 # source from the relative path of current folder
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
-OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
-
+func_opt_add_common_TPLG
 func_opt_parse_option $*
 tplg=${OPT_VALUE_lst['t']}
 

--- a/test-case/verify-tplg-binary.sh
+++ b/test-case/verify-tplg-binary.sh
@@ -16,9 +16,7 @@
 # source from the relative path of current folder
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
-OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
-
+func_opt_add_common_TPLG
 func_opt_parse_option $*
 tplg=${OPT_VALUE_lst['t']}
 

--- a/test-case/volume-basic-test.sh
+++ b/test-case/volume-basic-test.sh
@@ -18,15 +18,12 @@
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
 volume_array=("0%" "10%" "20%" "30%" "40%" "50%" "60%" "70%" "80%" "90%" "100%")
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
-OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
 OPT_OPT_lst['l']='loop'     OPT_DESC_lst['l']='loop count'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=2
 
-OPT_OPT_lst['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
-
+func_opt_add_common_TPLG
+func_opt_add_common_sof_logger
 func_opt_parse_option $*
 tplg=${OPT_VALUE_lst['t']}
 maxloop=${OPT_VALUE_lst['l']}


### PR DESCRIPTION
1. As we have lot of same description option so move them
into the common function, so when modify/add can use it
this change is not refer the code logic

2. Change opt parse error exit code to exit 2
Current define exit code
0: pass; 1: fail;2: skip

Signed-off-by: Wu, BinX <binx.wu@intel.com>