### PR TITLE
Feature add: modify dlog* message output to more clean up

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -50,13 +50,13 @@ function exit()
 
     case $exit_status in
         0)
-            dlogi "Test PASS!"
+            dlogi "Test Result: PASS!"
         ;;
         1)
-            dlogi "Test FAIL!"
+            dlogi "Test Result: FAIL!"
         ;;
         2)
-            dlogi "Test SKIP!"
+            dlogi "Test Result: SKIP!"
         ;;
         *)
             dlogi "Unknown test exit code: $exit_status"

--- a/case-lib/logging_ctl.sh
+++ b/case-lib/logging_ctl.sh
@@ -28,9 +28,18 @@ _func_log_cmd()
     # writing functions
     shopt -s expand_aliases
     if [ "X1" ]; then
+        # PPID: The process ID of the shell's parent.
+        # get Current script parent process name
+        local ppcmd=$(ps -p $PPID -o cmd --noheader|awk '{print $2;}') ext_message=""
+        # confirm this script load by the script, Add the flag for it
+        [[ "$(file $ppcmd 2>/dev/null |grep 'shell script')" ]] && ext_message=" Sub-Test:"
+        _func_logcmd_add_timestamp()
+        {
+            echo $(date -u '+%Y-%m-%d %T %Z') $*
+        }
         for key in ${!LOG_LIST[@]};
         do
-            alias "$key"="echo \$(date -u '+%Y-%m-%d %T %Z') ${LOG_LIST[$key]}"
+            alias "$key"="_func_logcmd_add_timestamp $ext_message ${LOG_LIST[$key]}"
         done
     else
         _func_empty_function() { return 0; }


### PR DESCRIPTION
Current we support the test-case scripot load other test-case script
to finish the test-case, but from the test-case output information
the current script output will mix with sub-test-case script

Now add the 'Sub-Test' flag to the sub-test-case
when end-user catch the terminal output without confuse
for the script process

it will be helpful for maintenance the script

Signed-off-by: Wu, BinX <binx.wu@intel.com>