### PR TITLE
tools/sof-tplgreader: cleanup useless code

### DIFF
--- a/tools/sof-tplgreader.py
+++ b/tools/sof-tplgreader.py
@@ -2,13 +2,11 @@
 
 import subprocess
 import os
-import shutil
 import re
 from tplgtool import TplgParser
 
 class clsTPLGeader:
     def __init__(self):
-        self._cmd = shutil.which('tplgreader')
         self._pipeline_lst = []
         self._output_lst = []
         self._filed_lst = []


### PR DESCRIPTION
Since the binary tplgreader is replaced by tplgtool.py
remove binary  tplgreader check refer code

Signed-off-by: Wu, BinX <binx.wu@intel.com>