### PR TITLE
Bug fix: verify-pcm-list typo error

### DIFF
--- a/test-case/verify-pcm-list.sh
+++ b/test-case/verify-pcm-list.sh
@@ -78,7 +78,7 @@ do
     tplg=${tplg#*,}
     [ "$tplg_file" == "$tplg" ] && tplg=""
     if [ -f "$tplg_file" ]; then
-        tplg_file="$f"
+        tplg_file="$tplg_file"
     elif [ -f "$TPLG_ROOT/$tplg_file" ]; then
         tplg_file="$TPLG_ROOT/$tplg_file"
     else


### PR DESCRIPTION
when find $tplg_file in current path should direct to use
the $f is not define so it will be empty value
which will cause the error:
when find $tplg_file but not use it, because tplg_file will
be overwrite with empty value

Signed-off-by: Wu, BinX <binx.wu@intel.com>