### PR TITLE
Bug fix: dectect error TPLG file in verify-pcm-list

### DIFF
--- a/case-lib/pipeline.sh
+++ b/case-lib/pipeline.sh
@@ -16,10 +16,10 @@ func_pipeline_export()
         # expect left ',' 1st filed
         tplg_str=${tplg_str#*,}
         [ "$f" == "$tplg_str" ] && tplg_str=""
-        if [ -f "$f" ]; then
-            f="$f"
-        elif [ -f "$TPLG_ROOT/$f" ]; then
-            f="$TPLG_ROOT/$f"
+        if [ -f "$TPLG_ROOT/$(basename $f)" ]; then
+            f="$TPLG_ROOT/$(basename $f)"   # catch from TPLG_ROOT
+        elif [ -f "$f" ];then
+            f=$(realpath $f)    # relative path -> absolute path
         else
             dlogw "Couldn't find target TPLG file $f needed to run $0" && exit 1
         fi

--- a/test-case/verify-pcm-list.sh
+++ b/test-case/verify-pcm-list.sh
@@ -77,10 +77,10 @@ do
     # expect left ',' 1st filed
     tplg=${tplg#*,}
     [ "$tplg_file" == "$tplg" ] && tplg=""
-    if [ -f "$tplg_file" ]; then
-        tplg_file="$f"
-    elif [ -f "$TPLG_ROOT/$tplg_file" ]; then
-        tplg_file="$TPLG_ROOT/$tplg_file"
+    if [ -f "$TPLG_ROOT/$(basename $tplg_file)" ]; then
+        tplg_file="$TPLG_ROOT/$(basename $tplg_file)"   # catch from TPLG_ROOT
+    elif [ -f "$tplg_file" ];then
+        tplg_file=$(realpath $tplg_file)    # relative path -> absolute path
     else
         dloge "Couldn't find target TPLG file $tplg_file needed to run ${BASH_SOURCE[0]}" && exit 1
     fi

--- a/test-case/verify-tplg-binary.sh
+++ b/test-case/verify-tplg-binary.sh
@@ -33,14 +33,14 @@ do
     # expect left ',' 1st filed
     tplg_str=${tplg_str#*,}
     [ "$tplg_file" == "$tplg_str" ] && tplg_str=""
-    if [ -f "$tplg_file" ]; then
-        tplg_file="$tplg_file"
-    elif [ -f "$TPLG_ROOT/$tplg_file" ]; then
-        tplg_file="$TPLG_ROOT/$tplg_file"
+    if [ -f "$TPLG_ROOT/$(basename $tplg_file)" ]; then
+        tplg_file="$TPLG_ROOT/$(basename $tplg_file)"   # catch from TPLG_ROOT
+    elif [ -f "$tplg_file" ]; then
+        tplg_file=$(realpath $tplg_file) # relative path -> absolute path
     else
         dloge "Couldn't find target TPLG file $tplg_file"
-	((ret=1))
-	continue
+        ((ret=1))
+        continue
     fi
     dlogi "Found file: $(md5sum $tplg_file|awk '{print $2, $1;}')"
     tplgData=$(sof-tplgreader.py $tplg_file 2>/dev/null)


### PR DESCRIPTION
the root reason: when load command the WD (workdir) is $PWD,
from ssh the WD is $HOME

When have the same name TPLG file on the WD which is relative path
it can be detect, and verify the test case for this TPLG

now modify to load from TPLG_ROOT for the same name TPLG is 1st option
On the other hand convert the relative path TPLG to absolute path

So when review case log can finger out which TPLG verify by test-case

Signed-off-by: Wu, BinX <binx.wu@intel.com>