### PR TITLE
kmod_scripts: add support for snd_soc_cml_rt1011_rt5682

### DIFF
--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -45,6 +45,7 @@ remove_module snd_soc_sst_cht_bsw_nau8824
 remove_module snd_soc_sst_cht_bsw_rt5645
 remove_module snd_soc_sst_cht_bsw_rt5672
 remove_module snd_soc_sst_glk_rt5682_max98357a
+remove_module snd_soc_cml_rt1011_rt5682
 remove_module snd_soc_skl_hda_dsp
 remove_module snd_soc_sdw_rt700
 remove_module snd_soc_sdw_rt711_rt1308_rt715


### PR DESCRIPTION
Add snd_soc_cml_rt1011_rt5682 module removal support for CML with rt1011 and rt5682 codecs.