### PR TITLE
tools: add 'PS_STATE=D' as normal state

### DIFF
--- a/tools/sof-process-state.sh
+++ b/tools/sof-process-state.sh
@@ -23,8 +23,8 @@ exit_code=1
 # process status detect
 for state in $(ps $opt $process -o state --no-header)
 do
-    # aplay playing: 'S'; aplay pause: 'R';
-    [[ "$state" == 'S' || "$state" == 'R' ]] && exit_code=0
+    # aplay prepare: 'D'; aplay playing: 'S'; aplay pause: 'R';
+    [[ "$state" == 'D' || "$state" == 'S' || "$state" == 'R' ]] && exit_code=0
     builtin echo process: $process status: ${PS_STATUS[$state]}
 done
 


### PR DESCRIPTION
Some commands or processes require some preparation time. At this
time, ps status will be 'uninterruptible sleep (usually IO)', this
is a normal status for us.

Signed-off-by: Zhang Keqiao <keqiao.zhang@linux.intel.com>