### PR TITLE
tools: make some methods in tplgtool.py static and public

### DIFF
--- a/tools/sof-tplgreader.py
+++ b/tools/sof-tplgreader.py
@@ -23,7 +23,6 @@ class clsTPLGReader:
     def loadFile(self, filename, sofcard=0):
         tplg_parser = TplgParser()
         parsed_tplg = tplg_parser.parse(filename)
-        tplg_formatter = TplgFormatter(parsed_tplg)
         # ignore the last element, for it is tplg name
         for item in parsed_tplg[:-1]:
             if "pcm" not in item:
@@ -32,16 +31,16 @@ class clsTPLGReader:
                 pipeline_dict = {}
                 pipeline_dict['pcm'] = pcm["pcm_name"]
                 pipeline_dict['id'] = str(pcm["pcm_id"])
-                pipeline_dict['type'] = tplg_formatter._get_pcm_type(pcm)
+                pipeline_dict['type'] = TplgFormatter.get_pcm_type(pcm)
                 # if we find None type pcm, there must be errors in topology
                 if pipeline_dict['type'] == "None":
                     print("type of %s is neither playback nor capture, please check your"
-                        "topology source file", pcm["pcm_name"])
+                        "topology source file" % pcm["pcm_name"])
                     exit(1)
                 cap = pcm["caps"][pcm['capture']]
                 # supported formats of playback pipeline in formats[0]
                 # supported formats of capture pipeline in formats[1]
-                formats = tplg_formatter._get_pcm_fmt(pcm)
+                formats = TplgFormatter.get_pcm_fmt(pcm)
                 pipeline_dict['fmts'] = " ".join(formats[pcm['capture']])
                 # use the first supported format for test
                 pipeline_dict['fmt'] = pipeline_dict['fmts'].split(' ')[0]

--- a/tools/tplgtool.py
+++ b/tools/tplgtool.py
@@ -538,7 +538,8 @@ class TplgFormatter:
         tplg["name"] = parsed_tplg[-1]
         return tplg
 
-    def _sort_by_id(self, item):
+    @staticmethod
+    def _sort_by_id(item):
         # for link sort
         if "id" in item.keys():
             return item["id"]
@@ -546,8 +547,10 @@ class TplgFormatter:
         if "pcm_id" in item.keys():
             return item["pcm_id"]
         return 0
+
     # transform number denoted pipeline format to string
-    def _to_fmt_string(self, fmt):
+    @staticmethod
+    def _to_fmt_string(fmt):
         fmts = []
         if fmt & (1 << 2) != 0:
             fmts.append("S16_LE")
@@ -562,14 +565,16 @@ class TplgFormatter:
     # always return a list, playback stream fmt in fmt_list[0]
     # capture stream fmt in fmt_list[1], the format of absense
     # stream is UNKNOWN
-    def _get_pcm_fmt(self, pcm):
+    @staticmethod
+    def get_pcm_fmt(pcm):
         fmt_list = []
         caps = pcm["caps"]
         for cap in caps:
-            fmt_list.append(self._to_fmt_string(cap["formats"]))
+            fmt_list.append(TplgFormatter._to_fmt_string(cap["formats"]))
         return fmt_list
 
-    def _get_pcm_type(self, item):
+    @staticmethod
+    def get_pcm_type(item):
         if item["playback"] == 1 and item["capture"] == 1:
             return "both"
         if item["playback"] == 1:
@@ -580,14 +585,16 @@ class TplgFormatter:
 
     # return a list of six elements, rate_min, rate_max and rates of playback
     # pipeline and rate_min, rate_max and rates of capture pipeline
-    def _get_pcm_rates(self, pcm):
+    @staticmethod
+    def get_pcm_rates(pcm):
         return [pcm["caps"][0]["rate_min"], pcm["caps"][0]["rate_max"], \
         pcm["caps"][0]["rates"], pcm["caps"][1]["rate_min"], \
         pcm["caps"][1]["rate_max"], pcm["caps"][1]["rates"]]
 
     # return a list of four elements, channels_min/channel_max
     # for playback and channels_min/channel_max for capture
-    def _get_pcm_channels(self, pcm):
+    @staticmethod
+    def get_pcm_channels(pcm):
         return [pcm["caps"][0]["channels_min"], pcm["caps"][0]["channels_max"],
             pcm["caps"][1]["channels_min"], pcm["caps"][1]["channels_max"]]
 
@@ -602,10 +609,10 @@ class TplgFormatter:
     def format_pcm(self):
         pcms = self._merge_pcm_list(self._tplg["pcm_list"])
         for pcm in pcms:
-            fmt_list = self._get_pcm_fmt(pcm)
-            pcm_type = self._get_pcm_type(pcm)
-            pcm_rates = self._get_pcm_rates(pcm)
-            pcm_channels = self._get_pcm_channels(pcm)
+            fmt_list = TplgFormatter.get_pcm_fmt(pcm)
+            pcm_type = TplgFormatter.get_pcm_type(pcm)
+            pcm_rates = TplgFormatter.get_pcm_rates(pcm)
+            pcm_channels = TplgFormatter.get_pcm_channels(pcm)
 
             fmt = fmt_list[0]
             rates = pcm_rates[:3]


### PR DESCRIPTION
Refine tplgtool and tplgreader:
- make some methods of TplgFormatter public and static, for outside program to call
- refine tplgreader with TplgFormatter's public methods, rather than initialize a instance of TplgFormatter
- fix a grammer error of print