### PR TITLE
tools: fix sof-kernel-log-check catch DSP reset

### DIFF
--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -3,7 +3,7 @@
 begin_line=${1:-1}
 declare err_str ignore_str project_key
 err_str="error|failed|timed out|panic|oops"
-ignore_str="no reply expected,|error: debugfs write failed to idle -16|error: status |error: cl_dsp_init"
+ignore_str="no reply expected,|error: debugfs write failed to idle -16|error: status |error: cl_dsp_init|iteration [01]"
 project_key="sof-audio"
 
 [[ ! "$err_str" ]] && echo "Missing error keyword list" && exit 0


### PR DESCRIPTION
refef issue: https://github.com/thesofproject/sof-test/issues/43
Catch DSP reset with keyword "failed"

Signed-off-by: Wu, BinX <binx.wu@intel.com>