### PR TITLE
test-case: remove verbose log for playback/capture

### DIFF
--- a/test-case/check-capture.sh
+++ b/test-case/check-capture.sh
@@ -88,8 +88,8 @@ do
                     dlogi "using $file as capture output"
                 fi
 
-                dlogc "arecord -D$dev -r $rate -c $channel -f $fmt_elem -d $duration $file -vv -q"
-                arecord -D$dev -r $rate -c $channel -f $fmt_elem -d $duration $file -vv -q
+                dlogc "arecord -D$dev -r $rate -c $channel -f $fmt_elem -d $duration $file -v -q"
+                arecord -D$dev -r $rate -c $channel -f $fmt_elem -d $duration $file -v -q
                 if [[ $? -ne 0 ]]; then
                     dmesg > $LOG_ROOT/arecord_error_${dev}_$i.txt
                     dloge "arecord on PCM $dev failed at $i/$loop_cnt."

--- a/test-case/check-playback.sh
+++ b/test-case/check-playback.sh
@@ -86,8 +86,8 @@ do
             for i in $(seq 1 $loop_cnt)
             do
                 dlogi "Testing: (Round: $round/$round_cnt) (PCM: $pcm [$dev]<$type>) (Loop: $i/$loop_cnt)"
-                dlogc "aplay -D$dev -r $rate -c $channel -f $fmt_elem -d $duration $file -vv -q"
-                aplay -D$dev -r $rate -c $channel -f $fmt_elem -d $duration $file -vv -q
+                dlogc "aplay -D$dev -r $rate -c $channel -f $fmt_elem -d $duration $file -v -q"
+                aplay -D$dev -r $rate -c $channel -f $fmt_elem -d $duration $file -v -q
                 if [[ $? -ne 0 ]]; then
                     dmesg > $LOG_ROOT/aplay_error_${dev}_$i.txt
                     dloge "aplay on PCM $dev failed at $i/$loop_cnt."


### PR DESCRIPTION
Only need to dump the HW params info. Remove verbose for
aplay/arecord.

Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>