### PR TITLE
[RFC] case-lib: add lock of sof-test

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -45,8 +45,19 @@ function exit()
         done
     fi
 
+    # check function already defined
     # when exit force check the pulseaudio whether disabled
-    func_lib_restore_pulseaudio
+    [[ $(declare -f func_lib_restore_pulseaudio) ]] && func_lib_restore_pulseaudio
+
+    if [ -f $SOF_LOCK ];then
+        # use string compare instead of int to confirm file content correct
+        # just remove the current pid lock file
+        if [ "X$$" == "X$(cat $SOF_LOCK)" ]; then
+            rm -rf $SOF_LOCK
+        fi
+    else
+        dlogw "Missing lock file: $SOF_LOCK"
+    fi
 
     case $exit_status in
         0)

--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -17,9 +17,19 @@ if [ ! "$SOFCARD" ];then
     SOFCARD=$(grep '\]: sof-[a-z]' /proc/asound/cards|awk '{print $1;}')
 fi
 
+# Add lock to protect current system just have one sof-test test-case to run
+SOF_LOCK="/tmp/sof-test.lock"
+if [ ! -f "$SOF_LOCK" ];then # lock is not exist
+    echo $$ > /tmp/sof-test.lock # write self pid into lock file
+elif [ ! $(alias |grep "Sub-Test") ]; then # not the sub test-case
+    echo "Find $SOF_LOCK already exist: $(ps -p $(cat $SOF_LOCK))"
+    exit 2 # now skip to run the test-case
+fi
+
 if [ ! "$DMESG_LOG_START_LINE" ];then
     declare -g DMESG_LOG_START_LINE=$(wc -l /var/log/kern.log|awk '{print $1;}')
 fi
+
 declare -g SOF_LOG_COLLECT=0
 
 func_lib_setup_kernel_last_line()


### PR DESCRIPTION
record current PID as lock file
from dlog* refer keyword to ignore sub-test case
when load exit will clean up the lock file for current PID

Signed-off-by: Wu, BinX <binx.wu@intel.com>