### PR TITLE
case-lib: bugfix #54 for pulseaudio restore logic

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -19,9 +19,6 @@ function exit()
     [[ $DMESG_LOG_START_LINE -ne 0 ]] && \
         tail -n +$DMESG_LOG_START_LINE /var/log/kern.log |cut -f5- -d ' ' > $LOG_ROOT/dmesg.txt
 
-    # when exit force check the pulseaudio whether disabled
-    func_lib_restore_pulseaudio
-
     # get ps command result as list
     OLD_IFS="$IFS" IFS=$'\n'
     local -a cmd_lst
@@ -42,11 +39,14 @@ function exit()
         do
             # remove '^[:space:]' because IFS change to keep the '^[:space:]' in variable
             line=$(echo $line|xargs)
-            dlogw "Catch: $line"
-            dlogi "Kill cmd:'${line#* }' by kill -9"
+            dlogw "Catch pid: $line"
+            dlogw "Kill cmd:'${line#* }' by kill -9"
             kill -9 ${line%% *}
         done
     fi
+
+    # when exit force check the pulseaudio whether disabled
+    func_lib_restore_pulseaudio
 
     case $exit_status in
         0)

--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -80,8 +80,20 @@ func_lib_restore_pulseaudio()
     do
         user=${line%% *}
         cmd=${line#* }
-        sudo -u $user $cmd >/dev/null 2>&1 &
+        nohup sudo -u $user $cmd >/dev/null &
     done
+    # now wait for the pulseaudio restore in the ps process
+    wait_t=0 timeout=10
+    while [ ! "$(ps -C pulseaudio --no-header)" ];
+    do
+        wait_t=$[ $wait_t + 1 ]
+        sleep 1s
+        if [ $wait_t -ge $timeout ]; then
+            dlogw "Restore pulseaudio wait too long: $timeout"
+            break
+        fi
+    done
+    dlogi "Restoring  pulseaudio took $wait_t seconds"
     unset PULSECMD_LST
     declare -ag PULSECMD_LST
 }


### PR DESCRIPTION
1. move restore function after kill child process to avoid kill
pulseaudio again
2. add delay check for restore pulseaudio to confirm restore success
3. add nohup for restore pulseaudio to avoid pulseaudio killed
by ssh lost connect

fix issue #54 

Signed-off-by: Wu, BinX <binx.wu@intel.com>