### PR TITLE
test-case: check return value of aplay or arecord

### DIFF
--- a/test-case/check-signal-stop-start.sh
+++ b/test-case/check-signal-stop-start.sh
@@ -94,7 +94,21 @@ do
 
     dlogi "Testing: run stop/start test on PCM:$pcm,$pipeline_type. Interval time: $interval"
     dlogc $cmd -D$dev -r $rate -c $channel -f $fmt $dummy_file -q &
-    $cmd -D$dev -r $rate -c $channel -f $fmt $dummy_file -q & pid=$!
+    $cmd -D$dev -r $rate -c $channel -f $fmt $dummy_file -q &
+    pid=$!
+
+    # If the process is terminated too early, this is error case.
+    # Typical root causes of the process early termination are,
+    #     1. soundcard is not enumerated
+    #     2. soundcard is enumerated but the PCM device($dev) is not available
+    #     3. the device is busy
+    #     4. set params fails, etc
+    sleep 0.5
+    if [[ ! -d /proc/$pid ]]; then
+        dloge "$cmd process[$pid] is terminated too early"
+        exit 1
+    fi
+
     # do stop/start test
     func_stop_start_pipeline
     # kill aplay/arecord process

--- a/test-case/check-xrun-injection.sh
+++ b/test-case/check-xrun-injection.sh
@@ -102,6 +102,19 @@ do
     dlogc $cmd -D$dev -r $rate -c $channel -f $fmt $dummy_file -q
     $cmd -D$dev -r $rate -c $channel -f $fmt $dummy_file -q &
     pid=$!
+
+    # If the process is terminated too early, this is error case.
+    # Typical root causes of the process early termination are
+    #     1. soundcard is not enumerated
+    #     2. soundcard is enumerated but the PCM device($dev) is not available
+    #     3. the device is busy
+    #     4. set params fails, etc
+    sleep 0.5
+    if [[ ! -d /proc/$pid ]]; then
+        dloge "$cmd process[$pid] is terminated too early"
+        exit 1
+    fi
+
     # do xrun injection
     dlogc "echo 1 > $xrun_injection"
     func_xrun_injection


### PR DESCRIPTION
If aplay or arecord is failed, no need to proceed to test.
Exit early to report for failure.

Signed-off-by: Fred Oh <fred.oh@linux.intel.com>