### PR TITLE
case-lib/opt.sh: Change exit code when calling func_opt_dump_help

### DIFF
--- a/case-lib/opt.sh
+++ b/case-lib/opt.sh
@@ -87,7 +87,7 @@ func_opt_parse_option()
             echo -e '    -h |  --help'
             echo -e "\tthis message"
             _func_case_dump_descption
-            exit 0
+            exit 2
         }
 
     # generate the command to load 'getopt'


### PR DESCRIPTION
* test will now report as `FAIL` after a problem processing parameters occurs as
  well as when user wants to view help menu via `-h` flag

Signed-off-by: Kelly Ledford <kelly.ledford@intel.com>