### PR TITLE
Test case/add explicit pkill for aplay & arecord

### DIFF
--- a/test-case/check-capture.sh
+++ b/test-case/check-capture.sh
@@ -93,6 +93,7 @@ do
                 if [[ $? -ne 0 ]]; then
                     dmesg > $LOG_ROOT/arecord_error_${dev}_$i.txt
                     dloge "arecord on PCM $dev failed at $i/$loop_cnt."
+                    pkill -9 arecord
                     exit 1
                 fi
                 dmesg > $LOG_ROOT/arecord_${dev}_$i.txt
@@ -101,5 +102,6 @@ do
     done
 done
 
+pkill -9 arecord
 sof-kernel-log-check.sh $KERNEL_LAST_LINE
 exit $?

--- a/test-case/check-playback.sh
+++ b/test-case/check-playback.sh
@@ -91,6 +91,7 @@ do
                 if [[ $? -ne 0 ]]; then
                     dmesg > $LOG_ROOT/aplay_error_${dev}_$i.txt
                     dloge "aplay on PCM $dev failed at $i/$loop_cnt."
+                    pkill -9 aplay
                     exit 1
                 fi
                 dmesg > $LOG_ROOT/aplay_${dev}_$i.txt
@@ -99,5 +100,6 @@ do
     done
 done
 
+pkill -9 aplay
 sof-kernel-log-check.sh $KERNEL_LAST_LINE
 exit $?


### PR DESCRIPTION
In check-capture.sh & check-playback.sh to prevent further cascading CI failures due to in-use pcm device from previous tests.