### PR TITLE
case-lib: add DMIC16k to TPLG_BLOCK_LST

### DIFF
--- a/case-lib/config.sh
+++ b/case-lib/config.sh
@@ -16,7 +16,7 @@ PULSEAUDIO_CONFIG=${PULSEAUDIO_CONFIG:-/etc/pulse/client.conf}
 # example: block pcm is HDA Digital & HDA Analog
 # TPLG_BLOCK_LST['pcm']='HDA Digital,HDA Analog'
 declare -A TPLG_BLOCK_LST
-TPLG_BLOCK_LST['pcm']='HDA Digital,Media Playback'
+TPLG_BLOCK_LST['pcm']='HDA Digital,Media Playback,DMIC16k'
 
 # Will be set by the lib function, don't need to set
 # Catches the last line of /var/log/kern.log, which will be used by


### PR DESCRIPTION
For some platforms, wov pipeline is present as a capture pipeline,
this will cause some test cases failed.

This patch add DMIC16k to TPLG_BLOCK_LST, thus we can ignore wov
pipeline in test cases.

I checked all the tplgs, and wov pipeline names are unified to "DMIC16k".
@xiulipan @Bin-QA this patch will cause the  DMIC16kHz pipelines on some platforms left untested. we may need a discussion here