### PR TITLE
test-case: check dsp status before module removal

### DIFF
--- a/test-case/check-kmod-load-unload.sh
+++ b/test-case/check-kmod-load-unload.sh
@@ -50,6 +50,26 @@ do
     ## - 1: remove module section
     func_lib_setup_kernel_last_line
 
+    # 1. check dsp status before removal, only remove module when dsp is suspended.
+    # 2. it will take some time (about 10s) for dsp to become suspended from active
+    # after module insertion on some platforms, here we check dsp status, and only continue
+    # next removal when dsp is suspended.
+    dlogi "wait dsp power status to become suspended"
+    declare I=0 # used to check if for loop is early exit
+    for i in $(seq 1 15)
+    do
+        # Here we pass a hardcoded 0 to python script, and need to ensure
+        # DSP is the first audio pci device in 'lspci', this is true unless
+        # we have a third-party pci sound card installed.
+        [[ $(sof-dump-status.py --dsp_status 0) == "suspended" ]] && break
+        let I=i
+        sleep 1
+    done
+    if [ $I -eq 15 ]; then
+        dlogi "dsp is not suspended after 15s, end test"
+        exit 1
+    fi
+
     dlogi "run kmod/sof-kmod-remove.sh"
     sudo sof_remove.sh
     [[ $? -ne 0 ]] && dloge "remove modules error" && exit 1
@@ -79,10 +99,10 @@ do
 
     # successful remove/insert module pass
     dlogi "==== completed boot firmware: $idx of $loop_cnt ===="
+
     # pulseaudio deamon will detect the snd_sof_pci device after 3s
     # so after 2s snd_sof_pci device will in used status which is block current case logic
     # here the logic is to check snd_sof_pci status is not in used status, the max delay is 10s
-    sleep 1
     for i in $(seq 1 10)
     do
         [[ "X$(awk '/^snd_sof_pci/ {print $3;}' /proc/modules)" == "X0" ]] && break

--- a/tools/sof-dump-status.py
+++ b/tools/sof-dump-status.py
@@ -303,6 +303,7 @@ if __name__ == "__main__":
     parser.add_argument('-s', '--short', type=int, help='just dump the short name of target id sound card')
     parser.add_argument('-l', '--longname', type=int, help='just dump the longname name of target id sound card')
     parser.add_argument('-P', '--fwpath', action='store_true', help='get firmware path according to DMI info')
+    parser.add_argument('-S', '--dsp_status', type=int, help='get current dsp power status, should specify sof card number')
     parser.add_argument('--version', action='version', version='%(prog)s 1.0')
 
     ret_args = vars(parser.parse_args())
@@ -342,6 +343,11 @@ if __name__ == "__main__":
         if card_info is None:
             exit(0)
         print(card_info['longname'])
+        exit(0)
+
+    if ret_args.get('dsp_status') is not None:
+        sysinfo.loadPower()
+        print(sysinfo.sys_power['run_status'][ret_args['dsp_status']]['status'])
         exit(0)
 
     # The kernel has changed the default firmware path when community


### PR DESCRIPTION
On some platforms, after module insertion, it will take
sometime for dsp to become suspended. If sleep time is too
short, we will remove module when dsp is active, this causes
error.

This patch checks dsp status before module removal.
