### PR TITLE
sof-test: split both type pipeline into playback and capture

### DIFF
--- a/test-case/check-capture.sh
+++ b/test-case/check-capture.sh
@@ -9,7 +9,7 @@
 ##    default duration is 10s
 ##    default loop count is 3
 ## Case step:
-##    1. Parse TPLG file to get pipeline with type of "record" and "both"
+##    1. Parse TPLG file to get pipeline with type of "record"
 ##    2. Specify the audio parameters
 ##    3. Run arecord on each pipeline with parameters
 ## Expect result:
@@ -55,7 +55,7 @@ file_prefix=${OPT_VALUE_lst['f']}
 
 func_lib_setup_kernel_last_line
 func_lib_check_sudo
-func_pipeline_export $tplg "type:capture,both"
+func_pipeline_export $tplg "type:capture"
 
 for round in $(seq 1 $round_cnt)
 do

--- a/test-case/check-kmod-load-unload-after-playback.sh
+++ b/test-case/check-kmod-load-unload-after-playback.sh
@@ -8,7 +8,7 @@
 ##    check kernel module removal/insert process with playback before and after
 ## Case step:
 ##    1. enter loop for module remove / insert test
-##    2. for each pcm type == playback or both:
+##    2. for each pcm type == playback:
 ##       start playback of duration OPT_VALUE_lst['d]'
 ##    3. check for playback errors
 ##    4. remove all loaded modules listed in sof_remove.sh
@@ -19,7 +19,7 @@
 ##       (only once, not per PCM)
 ##    8. check for successful sof-firmware boot
 ##    9. check for dmesg errors
-##    10. for each pcm type == playback or both:
+##    10. for each pcm type == playback:
 ##        start playback of duration OPT_VALUE_lst['d]'
 ##    11. check for playback errors
 ##    12. loop to beginning (max OPT_VALUE_lst['l'])
@@ -50,7 +50,7 @@ tplg=${OPT_VALUE_lst['t']}
 loop_cnt=${OPT_VALUE_lst['l']}
 pb_duration=${OPT_VALUE_lst['d']}
 
-func_pipeline_export $tplg "type:playback,both"
+func_pipeline_export $tplg "type:playback"
 
 func_lib_check_sudo
 # overwirte the subscript: test-case LOG_ROOT environment

--- a/test-case/check-pause-resume.sh
+++ b/test-case/check-pause-resume.sh
@@ -70,7 +70,7 @@ esac
 
 [[ -z $file_name ]] && file_name=$dummy_file
 
-func_pipeline_export $tplg "type:$test_mode,both"
+func_pipeline_export $tplg "type:$test_mode"
 func_lib_setup_kernel_last_line
 for idx in $(seq 0 $(expr $PIPELINE_COUNT - 1))
 do

--- a/test-case/check-playback.sh
+++ b/test-case/check-playback.sh
@@ -9,7 +9,7 @@
 ##    default duration is 10s
 ##    default loop count is 3
 ## Case step:
-##    1. Parse TPLG file to get pipeline with type of "play" and "both"
+##    1. Parse TPLG file to get pipeline with type of "play"
 ##    2. Specify the audio parameters
 ##    3. Run aplay on each pipeline with parameters
 ## Expect result:
@@ -63,7 +63,7 @@ fi
 
 func_lib_setup_kernel_last_line
 func_lib_check_sudo
-func_pipeline_export $tplg "type:playback,both"
+func_pipeline_export $tplg "type:playback"
 
 for round in $(seq 1 $round_cnt)
 do

--- a/test-case/check-runtime-pm-status.sh
+++ b/test-case/check-runtime-pm-status.sh
@@ -52,7 +52,7 @@ runtime_status="/sys/bus/pci/devices/0000:$(lspci |awk '/[Aa]udio/ {print $1;}')
 dlogc "Runtime status check: cat $runtime_status"
 
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
-func_pipeline_export $tplg "type:playback,both"
+func_pipeline_export $tplg "type:playback"
 func_lib_setup_kernel_last_line
 #TODO: need to go through both playback and capture
 for idx in $(seq 0 $(expr $PIPELINE_COUNT - 1))

--- a/test-case/check-signal-stop-start.sh
+++ b/test-case/check-signal-stop-start.sh
@@ -82,7 +82,7 @@ func_stop_start_pipeline()
     done
 }
 
-func_pipeline_export $tplg "type:$test_mode,both"
+func_pipeline_export $tplg "type:$test_mode"
 for idx in $(seq 0 $(expr $PIPELINE_COUNT - 1))
 do
     channel=$(func_pipeline_parse_value $idx channel)

--- a/test-case/check-suspend-resume-with-audio.sh
+++ b/test-case/check-suspend-resume-with-audio.sh
@@ -71,7 +71,7 @@ else
 fi
 [[ -z $file_name ]] && file_name=$dummy_file
 
-func_pipeline_export $tplg "type:${OPT_VALUE_lst['m']},both"
+func_pipeline_export $tplg "type:${OPT_VALUE_lst['m']}"
 
 if [ "${OPT_VALUE_lst['T']}" ]; then
     opt="-l ${OPT_VALUE_lst['l']} -T ${OPT_VALUE_lst['T']}"

--- a/test-case/check-xrun-injection.sh
+++ b/test-case/check-xrun-injection.sh
@@ -45,7 +45,7 @@ interval=${OPT_VALUE_lst['i']}
 
 func_lib_setup_kernel_last_line
 func_lib_check_sudo
-func_pipeline_export $tplg "type:playback,capture,both"
+func_pipeline_export $tplg "type:playback,capture"
 
 case $test_mode in
     "playback")
@@ -83,7 +83,7 @@ func_xrun_injection()
     done
 }
 
-func_pipeline_export $tplg "type:$test_mode,both"
+func_pipeline_export $tplg "type:$test_mode"
 for idx in $(seq 0 $(expr $PIPELINE_COUNT - 1))
 do
     channel=$(func_pipeline_parse_value $idx channel)

--- a/test-case/multiple-pipeline-capture.sh
+++ b/test-case/multiple-pipeline-capture.sh
@@ -8,11 +8,11 @@
 ##    Pick up pipelines from TPLG file for max count
 ##    Rule:
 ##      a. fill pipeline need match max count
-##      b. fill pipeline type order: capture & both > playback
+##      b. fill pipeline type order: capture > playback
 ##      c. if pipeline in TPLG is not enough of count, max count is pipeline count
 ## Case step:
 ##    1. Parse TPLG file to get pipeline count to decide max count is parameter or pipeline count
-##    2. load capture & both for arecord to fill pipeline count
+##    2. load capture for arecord to fill pipeline count
 ##    3. load playback for aplay fill pipeline count
 ##    4. wait for 0.5s for process already loaded
 ##    5. check process status & process count
@@ -57,8 +57,8 @@ func_lib_setup_kernel_last_line
 declare -A APP_LST DEV_LST
 APP_LST['playback']='aplay'
 DEV_LST['playback']='/dev/zero'
-APP_LST['capture,both']='arecord'
-DEV_LST['capture,both']='/dev/null'
+APP_LST['capture']='arecord'
+DEV_LST['capture']='/dev/null'
 
 tmp_count=$max_count
 
@@ -107,7 +107,7 @@ do
     sudo dmesg -C
 
     # start capture:
-    func_run_pipeline_with_type "capture,both"
+    func_run_pipeline_with_type "capture"
     func_run_pipeline_with_type "playback"
 
     dlogi "pipeline start sleep 0.5s for device wakeup"

--- a/test-case/multiple-pipeline-playback.sh
+++ b/test-case/multiple-pipeline-playback.sh
@@ -8,11 +8,11 @@
 ##    Pick up pipelines from TPLG file for max count
 ##    Rule:
 ##      a. fill pipeline need match max count
-##      b. fill pipeline type order: playback & both > capture
+##      b. fill pipeline type order: playback > capture
 ##      c. if pipeline in TPLG is not enough of count, max count is pipeline count
 ## Case step:
 ##    1. Parse TPLG file to get pipeline count to decide max count is parameter or pipeline count
-##    2. load playback & both for aplay to fill pipeline count
+##    2. load playback for aplay to fill pipeline count
 ##    3. load capture for arecord to fill pipeline count
 ##    4. wait for 0.5s for process already loaded
 ##    5. check process status & process count
@@ -55,8 +55,8 @@ func_lib_setup_kernel_last_line
 
 # now small function define
 declare -A APP_LST DEV_LST
-APP_LST['playback,both']='aplay'
-DEV_LST['playback,both']='/dev/zero'
+APP_LST['playback']='aplay'
+DEV_LST['playback']='/dev/zero'
 APP_LST['capture']='arecord'
 DEV_LST['capture']='/dev/null'
 
@@ -107,7 +107,7 @@ do
     sudo dmesg -C
 
     # start capture:
-    func_run_pipeline_with_type "playback,both"
+    func_run_pipeline_with_type "playback"
     func_run_pipeline_with_type "capture"
 
     dlogi "pipeline start sleep 0.5s for device wakeup"

--- a/test-case/test-speaker.sh
+++ b/test-case/test-speaker.sh
@@ -28,7 +28,7 @@ func_opt_parse_option $*
 tplg=${OPT_VALUE_lst['t']}
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
 
-func_pipeline_export $tplg "type:playback,both"
+func_pipeline_export $tplg "type:playback"
 tcnt=${OPT_VALUE_lst['l']}
 func_lib_setup_kernel_last_line
 for idx in $(seq 0 $(expr $PIPELINE_COUNT - 1))

--- a/test-case/volume-basic-test.sh
+++ b/test-case/volume-basic-test.sh
@@ -39,10 +39,10 @@ func_error_exit()
 }
 
 [[ -z $tplg ]] && dlogw "Missing tplg file needed to run" && exit 1
-func_pipeline_export $tplg "type:playback,both"
+func_pipeline_export $tplg "type:playback"
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
 
-[[ $PIPELINE_COUNT -eq 0 ]] && dlogw "Missing playback/both pipeline needed to run the aplay" && exit 1
+[[ $PIPELINE_COUNT -eq 0 ]] && dlogw "Missing playback pipeline for aplay to run" && exit 1
 channel=$(func_pipeline_parse_value 0 channel)
 rate=$(func_pipeline_parse_value 0 rate)
 fmt=$(func_pipeline_parse_value 0 fmt)


### PR DESCRIPTION
1. split both type pipeline into playback and capture pipelines
2.  remove "both" in test cases

@Bin-QA Wubin will modify the simultaneous-playback-capture.sh test case, and add logic to extract "both" type pipeline.

***DO NOT MERGE BEFORE PR #10 ***

