### PR TITLE
test case: simultaneous-playback-capture fix miss 'both'

### DIFF
--- a/test-case/simultaneous-playback-capture.sh
+++ b/test-case/simultaneous-playback-capture.sh
@@ -53,6 +53,7 @@ done
 # now all duplicate ids have already been caught
 unset tmp_id_lst tmp_tplg
 id_lst_str=${id_lst_str/,/} # remove 1st, which is not used
+[[ ${#id_lst_str} -eq 0 ]] && dlogw "no pipeline with both playback and capture capabilities found in $tplg" && exit 2
 func_pipeline_export $tplg "id:$id_lst_str"
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
 func_lib_setup_kernel_last_line


### PR DESCRIPTION
hot fix for when target tplg miss 'both' type pipeline
will load all pipeline in the case execute

Signed-off-by: Wu, BinX <binx.wu@intel.com>