### PR TITLE
test case: check-kmod-load-unload-after-playback fix confuse log name

### DIFF
--- a/test-case/check-kmod-load-unload-after-playback.sh
+++ b/test-case/check-kmod-load-unload-after-playback.sh
@@ -57,24 +57,28 @@ func_lib_check_sudo
 # so when load the test-case in current script
 # the test-case will write the log to the store folder LOG_ROOT
 # which is current script log folder
-export LOG_ROOT=$LOG_ROOT
+log_root=$LOG_ROOT
 
 if [ ${OPT_VALUE_lst['p']} -eq 1 ];then
     func_lib_disable_pulseaudio
 fi
 
+export LOG_ROOT=$log_root/round-0
 $(dirname ${BASH_SOURCE[0]})/check-playback.sh -l 1 -t $tplg -d $pb_duration
 ret=$?
+export LOG_ROOT=$log_root
 [[ $ret -ne 0 ]] && dloge "aplay check failed" && exit $ret
 
 for counter in $(seq 1 $loop_cnt)
 do
     dlogi "Starting iteration $counter of $loop_cnt"
 
+    export LOG_ROOT=$log_root/round-$counter
     # logic: if this case disable pulseaudio, the sub case don't need to disable pulseaudio
     # if this case don't need to disable pulseaudio, the subcase also don't need to disable pluseaudio
     $(dirname ${BASH_SOURCE[0]})/check-kmod-load-unload.sh -l 1 -p
     ret=$?
+    export LOG_ROOT=$log_root
     [[ $ret -ne 0 ]] && dloge "kmod reload failed" && exit $ret
 
     dlogi "wait dsp power status to become suspended"
@@ -93,8 +97,10 @@ do
         fi
     done
 
+    export LOG_ROOT=$log_root/round-$counter
     $(dirname ${BASH_SOURCE[0]})/check-playback.sh -l 1 -t $tplg -d $pb_duration
     ret=$?
+    export LOG_ROOT=$log_root
     [[ $ret -ne 0 ]] && dloge "aplay check failed" && exit $ret
 done
 


### PR DESCRIPTION
fix issue #89
refind the LOG_ROOT to let each sub case write log to the different
log folder

Signed-off-by: Wu, BinX <binx.wu@intel.com>