### PR TITLE
case-lib: fix sof-test.lock refer problem

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -69,6 +69,9 @@ function exit()
         2)
             dlogi "Test Result: SKIP!"
         ;;
+        3)
+            dlogi "Test Result: INCOMPLETE!"
+        ;;
         *)
             dlogi "Unknown test exit code: $exit_status"
         ;;

--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -22,8 +22,13 @@ SOF_LOCK="/tmp/sof-test.lock"
 if [ ! -f "$SOF_LOCK" ];then # lock is not exist
     echo $$ > /tmp/sof-test.lock # write self pid into lock file
 elif [ ! "$(alias |grep -i 'Sub-Test')" ]; then # not the sub test-case
-    echo "Find $SOF_LOCK already exist: $(ps -p $(cat $SOF_LOCK))"
-    exit 2 # now skip to run the test-case
+    if [ "$(ps -p $(cat $SOF_LOCK) --no-headers)" ]; then # Detect whether have other case
+        dloge "Find $SOF_LOCK already exist: $(ps -p $(cat $SOF_LOCK))"
+        exit 2 # now skip to run the test-case
+    else # without other case
+        dlogw "Prepare case exit is abnormal"
+        echo $$ > /tmp/sof-test.lock # write self pid into lock file
+    fi
 fi
 
 if [ ! "$DMESG_LOG_START_LINE" ];then

--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -24,7 +24,8 @@ if [ ! -f "$SOF_LOCK" ];then # lock is not exist
 elif [ ! "$(alias |grep -i 'Sub-Test')" ]; then # not the sub test-case
     if [ "$(ps -p $(cat $SOF_LOCK) --no-headers)" ]; then # Detect whether have other case
         dloge "Find $SOF_LOCK already exist: $(ps -p $(cat $SOF_LOCK))"
-        exit 2 # now skip to run the test-case
+        # exit 2 # now skip to run the test-case
+        exit 3 # mark test-case as incomplete
     else # without other case
         dlogw "Prepare case exit is abnormal"
         echo $$ > /tmp/sof-test.lock # write self pid into lock file


### PR DESCRIPTION
1. Add pid detect to avoid perpare case
abnormal exit without lock clean
2. follow Liam suggest change from 'skip' => 'Incomplete'
Add new exit status:3 for 'Incomplete'

Signed-off-by: Wu, BinX <binx.wu@intel.com>