### PR TITLE
kmod: fix snd_soc_rt5677 is not currently loaded error

### DIFF
--- a/tools/kmod/sof_insert.sh
+++ b/tools/kmod/sof_insert.sh
@@ -24,6 +24,7 @@ insert_module snd_soc_rt5640
 insert_module snd_soc_rt5645
 insert_module snd_soc_rt5651
 insert_module snd_soc_rt5670
+insert_module snd_soc_rt5677
 insert_module snd_soc_rt5677_spi
 insert_module snd_soc_rt5682
 


### PR DESCRIPTION
if `insert_modlue snd_soc_rt5677` is absent, we will get "rmmod: ERROR: Module snd_soc_rt5677 is not currently loaded" on helios.
This patch fix the issue above.