### PR TITLE
case-lib: hijack exit() to add dmesg catch

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -16,8 +16,11 @@ function exit()
         sleep 1s
     fi
     # case quit to store current kernel log
-    [[ $DMESG_LOG_START_LINE -ne 0 ]] && \
+    if [ $DMESG_LOG_START_LINE -ne 0 ]; then
         tail -n +$DMESG_LOG_START_LINE /var/log/kern.log |cut -f5- -d ' ' > $LOG_ROOT/dmesg.txt
+    else
+        cat /var/log/kern.log |cut -f5- -d ' ' > $LOG_ROOT/dmesg.txt
+    fi
 
     # get ps command result as list
     OLD_IFS="$IFS" IFS=$'\n'


### PR DESCRIPTION
sometime OS will reset the kern.log file
it will let DMESG_LOG_START_LINE value is 0

fix issue: #106 

Signed-off-by: Wu, BinX <binx.wu@intel.com>