### PR TITLE
case-lib: improve log readability

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -37,7 +37,7 @@ function exit()
     IFS="$OLD_IFS"
     # now force kill target process which maybe block the script quit
     if [ ${#cmd_lst[@]} -gt 0 ]; then
-        dlogw "${BASH_SOURCE[-1]} on exit, these processes still exist:"
+        dlogw "Process(es) started by ${BASH_SOURCE[-1]} are still active, kill these process(es):"
         for line in "${cmd_lst[@]}"
         do
             # remove '^[:space:]' because IFS change to keep the '^[:space:]' in variable
@@ -76,7 +76,7 @@ function exit()
             dlogi "Test Result: INCOMPLETE!"
         ;;
         *)
-            dlogi "Unknown test exit code: $exit_status"
+            dlogi "Unknown exit code: $exit_status"
         ;;
     esac
 
@@ -101,7 +101,7 @@ sudo()
             return $?
         ;;
         *)      # without sudo permission
-            dlogw "without permission to run $*"
+            dlogw "Need root privilege to run $*"
     esac
     return 2
 }

--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -23,11 +23,11 @@ if [ ! -f "$SOF_LOCK" ]; then # lock does not exist
     echo $$ > /tmp/sof-test.lock # write self pid into lock file
 elif [ ! "$(alias |grep -i 'Sub-Test')" ]; then # not the sub test-case
     if [ "$(ps -p $(cat $SOF_LOCK) --no-headers)" ]; then # lock exists
-        dloge "Find $SOF_LOCK already exist: $(ps -p $(cat $SOF_LOCK))"
+        dloge "Lock file $SOF_LOCK already exists: $(ps -p $(cat $SOF_LOCK))"
         # exit 2 # now skip to run the test-case
         exit 3 # mark test-case as incomplete
     else # without other case
-        dlogw "Prepare case exit is abnormal"
+        dlogw "Previous test case may exit abnormally"
         echo $$ > /tmp/sof-test.lock # write self pid into lock file
     fi
 fi
@@ -67,7 +67,7 @@ func_lib_check_sudo()
 {
     func_hijack_setup_sudo_level
     [[ $? -ne 0 ]] && \
-        dlogw "Next command needs root permission to run. If you haven't done so, please configure SUDO_PASSWD in case-lib/config.sh file" && \
+        dlogw "Command needs root privilege to run, please configure SUDO_PASSWD in case-lib/config.sh" && \
         exit 2
 }
 
@@ -111,11 +111,11 @@ func_lib_restore_pulseaudio()
         wait_t=$[ $wait_t + 1 ]
         sleep 1s
         if [ $wait_t -ge $timeout ]; then
-            dlogw "Restoring pulseaudio is taking too long: $timeout"
+            dlogw "Time out. Pulseaudio not restored in $timeout seconds"
             break
         fi
     done
-    dlogi "Restoring pulseaudio took $wait_t seconds"
+    dlogi "Restoring pulseaudio takes $wait_t seconds"
     unset PULSECMD_LST
     declare -ag PULSECMD_LST
 }

--- a/case-lib/pipeline.sh
+++ b/case-lib/pipeline.sh
@@ -4,7 +4,7 @@ func_pipeline_export()
 {
     # no parameter input the function
     if [ $# -lt 1 ]; then
-        dlogi "Missing target TPLG file name needed to run ${BASH_SOURCE[-1]}" && exit 1
+        dlogi "Topology file name is not specified, unable to run command: ${BASH_SOURCE[-1]}" && exit 1
     fi
 
     # got tplg_file, verify file exist
@@ -21,9 +21,9 @@ func_pipeline_export()
         elif [ -f "$f" ]; then
             f=$(realpath $f)    # relative path -> absolute path
         else
-            dlogw "Couldn't find target TPLG file $f needed to run $0" && exit 1
+            dlogw "Topology $f is not found, unable to run command: $0" && exit 1
         fi
-        dlogi "${BASH_SOURCE[-1]} using $f as target TPLG to run the test case"
+        dlogi "${BASH_SOURCE[-1]} will use topology $f to run the test case"
         tplg_file="$tplg_file$f,"
     done
     # remove the right last ','
@@ -45,7 +45,7 @@ func_pipeline_export()
         opt=$opt" -b"
         for key in ${!TPLG_IGNORE_LST[@]}
         do
-            dlogi "Catch ignore option from TPLG_IGNORE_LST will ignore '$key=${TPLG_IGNORE_LST[$key]}' for $tplg_str"
+            dlogi "Pipeline list to ignore is specified, will ignore '$key=${TPLG_IGNORE_LST[$key]}' in test case"
             opt=$opt" $key:'${TPLG_IGNORE_LST[$key]}'"
         done
     fi
@@ -53,14 +53,14 @@ func_pipeline_export()
     cmd=$(echo sof-tplgreader.py $tplg_str $opt -s $sofcard -e)
 
     OLD_IFS="$IFS" IFS=$'\n'
-    dlogi "Run command: '$cmd' to get BASH Array"
+    dlogi "Run command: '$cmd' to get pipeline parameters"
     for line in $(eval $cmd);
     do
         eval $line
     done
     IFS="$OLD_IFS"
     [[ ! "$PIPELINE_COUNT" ]] && dlogw "A problem occured while loading $tplg_str, please check '$cmd' command" && exit 1
-    [[ $PIPELINE_COUNT -eq 0 ]] && dlogw "Missing target PIPELINE for ${opt:3} needed to run ${BASH_SOURCE[-1]}" && exit 2
+    [[ $PIPELINE_COUNT -eq 0 ]] && dlogw "No pipeline found with option: ${opt:3}, unable to run ${BASH_SOURCE[-1]}" && exit 2
     return 0
 }
 


### PR DESCRIPTION
check the log for lib.sh, hijack.sh and pipeline.sh, refine some of the log to eliminate ambiguity and unclear expression.