### PR TITLE
add lsof device file check when aplay/arecord/speaker failed

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -133,3 +133,13 @@ func_lib_get_random()
     fi
 }
 
+func_lib_lsof_error_dump()
+{
+    local file=$1
+    [[ ! -f $file ]] && return
+    local ret=$(lsof $file)
+    if [ "$ret" ];then
+        dloge "Sound device file is in use:"
+        echo "$ret"
+    fi
+}

--- a/test-case/check-capture.sh
+++ b/test-case/check-capture.sh
@@ -67,6 +67,7 @@ do
         dev=$(func_pipeline_parse_value $idx dev)
         pcm=$(func_pipeline_parse_value $idx pcm)
         type=$(func_pipeline_parse_value $idx type)
+        snd=$(func_pipeline_parse_value $idx snd)
 
         if [ ${OPT_VALUE_lst['F']} = '1' ]; then
             fmt=$(func_pipeline_parse_value $idx fmts)
@@ -91,6 +92,7 @@ do
                 dlogc "arecord -D$dev -r $rate -c $channel -f $fmt_elem -d $duration $file -v -q"
                 arecord -D$dev -r $rate -c $channel -f $fmt_elem -d $duration $file -v -q
                 if [[ $? -ne 0 ]]; then
+                    func_lib_lsof_error_dump $snd
                     dmesg > $LOG_ROOT/arecord_error_${dev}_$i.txt
                     dloge "arecord on PCM $dev failed at $i/$loop_cnt."
                     exit 1

--- a/test-case/check-pause-resume.sh
+++ b/test-case/check-pause-resume.sh
@@ -78,6 +78,7 @@ do
     rate=$(func_pipeline_parse_value $idx rate)
     fmt=$(func_pipeline_parse_value $idx fmt)
     dev=$(func_pipeline_parse_value $idx dev)
+    snd=$(func_pipeline_parse_value $idx snd)
 
     dlogi "Entering expect script with: $cmd -D $dev -r $rate -c $channel -f $fmt -vv -i $file_name -q"
 
@@ -112,6 +113,7 @@ END
     #flush the output
     echo
     if [ $ret -ne 0 ]; then
+        func_lib_lsof_error_dump $snd
         sof-process-kill.sh
         [[ $? -ne 0 ]] && dlogw "Kill process catch error"
         exit $ret

--- a/test-case/check-playback.sh
+++ b/test-case/check-playback.sh
@@ -75,6 +75,7 @@ do
         dev=$(func_pipeline_parse_value $idx dev)
         pcm=$(func_pipeline_parse_value $idx pcm)
         type=$(func_pipeline_parse_value $idx type)
+        snd=$(func_pipeline_parse_value $idx snd)
 
         if [ ${OPT_VALUE_lst['F']} = '1' ]; then
             fmt=$(func_pipeline_parse_value $idx fmts)
@@ -89,6 +90,7 @@ do
                 dlogc "aplay -D$dev -r $rate -c $channel -f $fmt_elem -d $duration $file -v -q"
                 aplay -D$dev -r $rate -c $channel -f $fmt_elem -d $duration $file -v -q
                 if [[ $? -ne 0 ]]; then
+                    func_lib_lsof_error_dump $snd
                     dmesg > $LOG_ROOT/aplay_error_${dev}_$i.txt
                     dloge "aplay on PCM $dev failed at $i/$loop_cnt."
                     exit 1

--- a/test-case/check-signal-stop-start.sh
+++ b/test-case/check-signal-stop-start.sh
@@ -91,6 +91,7 @@ do
     dev=$(func_pipeline_parse_value $idx dev)
     pcm=$(func_pipeline_parse_value $idx pcm)
     pipeline_type=$(func_pipeline_parse_value $idx "type")
+    snd=$(func_pipeline_parse_value $idx snd)
 
     dlogi "Testing: run stop/start test on PCM:$pcm,$pipeline_type. Interval time: $interval"
     dlogc $cmd -D$dev -r $rate -c $channel -f $fmt $dummy_file -q &
@@ -105,6 +106,7 @@ do
     #     4. set params fails, etc
     sleep 0.5
     if [[ ! -d /proc/$pid ]]; then
+        lsof $snd
         dloge "$cmd process[$pid] is terminated too early"
         exit 1
     fi

--- a/test-case/check-suspend-resume-with-audio.sh
+++ b/test-case/check-suspend-resume-with-audio.sh
@@ -91,6 +91,7 @@ do
     fmt=$(func_pipeline_parse_value $idx fmt)
     dev=$(func_pipeline_parse_value $idx dev)
     pcm=$(func_pipeline_parse_value $idx pcm)
+    snd=$(func_pipeline_parse_value $idx snd)
     dlogi "Run $TYPE command for the background"
     dlogc "$cmd -D$dev -r $rate -c $channel -f $fmt $file_name -q"
     $cmd -D$dev -r $rate -c $channel -f $fmt $file_name -q 2>/dev/null & process_id=$!
@@ -99,6 +100,7 @@ do
     # check process status is correct
     sof-process-state.sh $process_id
     if [ $? -ne 0 ]; then
+        func_lib_lsof_error_dump $snd
         dloge "error process state of $cmd"
         dlogi "dump ps for aplay & arecord"
         ps -ef |grep -E 'aplay|arecord'
@@ -112,6 +114,7 @@ do
     # check process status is correct
     sof-process-state.sh $process_id
     if [ $? -ne 0 ]; then
+        func_lib_lsof_error_dump $snd
         dloge "process status is abnormal"
         dlogi "dump ps for aplay & arecord"
         ps -ef |grep -E 'aplay|arecord'

--- a/test-case/check-xrun-injection.sh
+++ b/test-case/check-xrun-injection.sh
@@ -92,6 +92,7 @@ do
     dev=$(func_pipeline_parse_value $idx dev)
     pcm=$(func_pipeline_parse_value $idx pcm)
     id=$(func_pipeline_parse_value $idx id)
+    snd=$(func_pipeline_parse_value $idx snd)
     pipeline_type=$(func_pipeline_parse_value $idx "type")
     pcm=pcm${id}${test_type}
     xrun_injection="/proc/asound/card0/$pcm/sub0/xrun_injection"
@@ -111,6 +112,7 @@ do
     #     4. set params fails, etc
     sleep 0.5
     if [[ ! -d /proc/$pid ]]; then
+        func_lib_lsof_error_dump $snd
         dloge "$cmd process[$pid] is terminated too early"
         exit 1
     fi

--- a/test-case/test-speaker.sh
+++ b/test-case/test-speaker.sh
@@ -37,6 +37,7 @@ do
     rate=$(func_pipeline_parse_value $idx rate)
     fmt=$(func_pipeline_parse_value $idx fmt)
     dev=$(func_pipeline_parse_value $idx dev)
+    snd=$(func_pipeline_parse_value $idx snd)
 
     dlogc "speaker-test -D $dev -r $rate -c $channel -f $fmt -l $tcnt -t wav -P 8"
     speaker-test -D $dev -r $rate -c $channel -f $fmt -l $tcnt -t wav -P 8 2>&1 |tee $LOG_ROOT/result_$idx.txt
@@ -45,6 +46,7 @@ do
     if [[ $resultRet -eq 0 ]]; then
         grep -nr -E "error|failed" $LOG_ROOT/result_$idx.txt
         if [[ $? -eq 0 ]]; then
+            func_lib_lsof_error_dump $snd
             dloge "speaker test failed"
             exit 1
         fi

--- a/tools/sof-tplgreader.py
+++ b/tools/sof-tplgreader.py
@@ -79,12 +79,19 @@ class clsTPLGReader:
                     self._pipeline_lst.append(pb_pipeline_dict)
                 self._pipeline_lst.append(pipeline_dict)
 
-        # format pipeline, this change for script direct access 'rate' 'channel' 'dev'
+        # format pipeline, this change for script direct access 'rate' 'channel' 'dev' 'snd'
         for pipeline in self._pipeline_lst:
             #pipeline['fmt']=pipeline['fmt'].upper().replace('LE', '_LE')
             pipeline['rate'] = pipeline['rate_min'] if int(pipeline['rate_min']) != 0 else pipeline['rate_max']
             pipeline['channel'] = pipeline['ch_min']
             pipeline['dev'] = "hw:" + str(sofcard) + ',' + pipeline['id']
+            # the character devices for PCM under /dev/snd take the form of
+            # "pcmC + card_number + D + device_number + capability", eg, pcmC0D0p.
+            pipeline['snd'] = "/dev/snd/pcmC" + str(sofcard) + "D" + pipeline['id']
+            if pipeline['type'] == "playback":
+                pipeline['snd'] += 'p'
+            else:
+                pipeline['snd'] += 'c'
         return 0
 
     def _setlist(self, orig_lst):


### PR DESCRIPTION
this PR include 2 patch

1. add 'snd' which mapping /dev/snd/pcm* in sof-tplgreader
2. add lsof check to confirm resource is not lock by other process

it can catch error like this : `aplay: main:788: audio open error: Device or resource busy`