### PR TITLE
tools: pipeline filtering feature enhancement

### DIFF
--- a/tools/sof-tplgreader.py
+++ b/tools/sof-tplgreader.py
@@ -64,16 +64,16 @@ class clsTPLGReader:
                     pb_pipeline_dict = pipeline_dict.copy()
                     pb_pipeline_dict["type"] = "playback"
                     cap = pcm["caps"][pcm['playback']]
-                    pga = pgas[pcm['capture']]
+                    pga = pgas[0] # idx 0 is playback PGA
                     if pga != []:
                         pga_names = [i['name'] for i in pga]
-                        pipeline_dict['pga'] = " ".join(pga_names)
-                    eq = eqs[pcm['capture']]
+                        pb_pipeline_dict['pga'] = " ".join(pga_names)
+                    eq = eqs[0]
                     if eq != []:
                         eq_names = [i['name'] for i in eq]
-                        pipeline_dict['eq'] = " ".join(eq_names)
+                        pb_pipeline_dict['eq'] = " ".join(eq_names)
                     pb_pipeline_dict["fmts"] = " ".join(formats[pcm['playback']])
-                    pipeline_dict['fmt'] = pipeline_dict['fmts'].split(' ')[0]
+                    pb_pipeline_dict['fmt'] = pb_pipeline_dict['fmts'].split(' ')[0]
                     pb_pipeline_dict['rate_min'], pb_pipeline_dict['rate_max'] = self._key2str(cap, 'rate')
                     pb_pipeline_dict['ch_min'], pb_pipeline_dict['ch_max'] = self._key2str(cap, 'channels')
                     self._pipeline_lst.append(pb_pipeline_dict)

--- a/tools/sof-tplgreader.py
+++ b/tools/sof-tplgreader.py
@@ -194,11 +194,13 @@ class clsTPLGReader:
         if len(self._output_lst) != 0:
             self._output_lst.sort(key=self.__comp_pipeline)
 
-    def getPipeline(self):
+    def getPipeline(self, sort=False):
         self._output_lst = self._pipeline_lst[:]
         self._filterKeyword()
         self._ignoreKeyword()
         self._filterField()
+        if sort:
+            self.sortPipeline()
         return self._output_lst
 
 if __name__ == "__main__":
@@ -234,9 +236,7 @@ if __name__ == "__main__":
         if tplgObj.loadFile(tplgName, sdcard_id) != 0:
             print("tplgreader load file %s failed" %(tplgName))
             exit(1)
-        if sort:
-            tplgreader.sortPipeline()
-        return tplgObj.getPipeline()
+        return tplgObj.getPipeline(sort)
 
     import argparse
 


### PR DESCRIPTION
This patch fix a pga and eq assignment error, and enhance pipeline filtering feature. Now we can filter pipeline with specific component.

@fredoh9 Some usage listed below:
- all pipelines: `sof-tplgreader.py tplg-path -f "type:playback,capture"`
- capture pipelines with PGA:  `sof-tplgreader.py tplg-path -f "type:capture" "pga:any"`
- playback pipelines with EQ:  `sof-tplgreader.py tplg-path -f "type:playback" "eq:any"`
- all pipelines with PGA:  `sof-tplgreader.py tplg-path -f "pga:any"`
- all pipelines with PGA and EQ:  `sof-tplgreader.py tplg-path -f "pga:any" "eq:any" ` 