### PR TITLE
test-case: add delay for check playback

### DIFF
--- a/test-case/check-playback.sh
+++ b/test-case/check-playback.sh
@@ -39,6 +39,9 @@ OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 OPT_OPT_lst['F']='fmts'   OPT_DESC_lst['F']='Iterate all supported formats'
 OPT_PARM_lst['F']=0         OPT_VALUE_lst['F']=0
 
+OPT_OPT_lst['R']='sleep_ctl'   OPT_DESC_lst['R']="set wait/sleep time for runtime PM, sleep time according critical timeout, which is in sleep_lst"
+OPT_PARM_lst['R']=0         OPT_VALUE_lst['R']=0
+
 func_opt_parse_option $*
 
 tplg=${OPT_VALUE_lst['t']}
@@ -46,7 +49,7 @@ round_cnt=${OPT_VALUE_lst['r']}
 duration=${OPT_VALUE_lst['d']}
 loop_cnt=${OPT_VALUE_lst['l']}
 file=${OPT_VALUE_lst['f']}
-
+sleep_ctl=${OPT_VALUE_lst['R']}
 
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
 
@@ -64,6 +67,11 @@ fi
 func_lib_setup_kernel_last_line
 func_lib_check_sudo
 func_pipeline_export $tplg "type:playback"
+
+#Set sleep time array, sleeps time will go through and loop this for each playback. This array contains import timeout and +/- 0.1s. Now timeout is 3s for SOF PCI device, 2s for HDA codec in future (not merged).
+sleep_lst=(0.5 1.9 2 2.1 2.9 3 3.1 5)
+sleep_len=${#sleep_lst[@]}
+j=0
 
 for round in $(seq 1 $round_cnt)
 do
@@ -94,6 +102,17 @@ do
                     dmesg > $LOG_ROOT/aplay_error_${dev}_$i.txt
                     dloge "aplay on PCM $dev failed at $i/$loop_cnt."
                     exit 1
+                else
+                    #sleep ${sleep_lst[@]} seconds before running aplay, then aplay can be run under dsp active or suspended status
+                    if [[ $(sof-dump-status.py --dsp_status 0) != "unsupported" ]] && [ "$sleep_ctl" -eq 1 ]; then
+                        sleep_time=${sleep_lst[$((j++ % sleep_len))]}
+                    else
+                        dlogi "platform doesn't support runtime pm or sleep time is turned off, sleep period keeps ${sleep_lst[0]} second(s)"
+                        sleep_time=${sleep_lst[0]}
+                    fi
+                    sleep "$sleep_time"
+                    pm=$(sof-dump-status.py --dsp_status 0)
+                    dlogi "Sleep: $sleep_time second(s), PM status is $pm"
                 fi
                 dmesg > $LOG_ROOT/aplay_${dev}_$i.txt
             done


### PR DESCRIPTION
update to set sleep time array, sleeps time will go through and loop this for each playback. This array contains import timeout and +/- 0.1s. Now timeout is 3s for SOF PCI device, 2s for HDA codec in future (not merged).