### PR TITLE
use case-insensitive grep for "topology"

### DIFF
--- a/tools/sof-get-default-tplg.sh
+++ b/tools/sof-get-default-tplg.sh
@@ -6,9 +6,9 @@
 # /var/log/syslog (sof-kernel-dump.sh)
 # Future: possibly be loaded from elsewhere
 # Notice: Only verified on Ubuntu 18.04
-tplg_file=$(dmesg |grep topology|awk -F ':' '/tplg/ {print $NF;}'|tail -n 1)
+tplg_file=$(dmesg |grep -i topology|awk -F ':' '/tplg/ {print $NF;}'|tail -n 1)
 [[ ! "$tplg_file" ]] && \
-    tplg_file=$(journalctl -k |grep topology |awk -F ':' '/tplg/ {print $NF;}'|tail -n 1)
+    tplg_file=$(journalctl -k |grep -i topology |awk -F ':' '/tplg/ {print $NF;}'|tail -n 1)
 [[ ! "$tplg_file" ]] && \
-    tplg_file=$(sof-kernel-dump.sh |grep topology|awk -F ':' '/tplg/ {print $NF;}'|tail -n 1)
+    tplg_file=$(sof-kernel-dump.sh |grep -i topology|awk -F ':' '/tplg/ {print $NF;}'|tail -n 1)
 [[ "$tplg_file" ]] && basename $tplg_file || echo ""


### PR DESCRIPTION
kernel v5.5 uses "Topology", previous versions use "topology"