### PR TITLE
test-case: add manual instructions to pause-suspend-resume-release test

### DIFF
--- a/test-case/check-pause-release-suspend-resume.sh
+++ b/test-case/check-pause-release-suspend-resume.sh
@@ -22,6 +22,32 @@
 ## Expect result:
 ##    no errors occur
 ##
+##
+## To run test manually:
+## Preconditions
+##     1. Device has ability to fully suspend.
+##         - BYTs cannot enter necessary suspend state.
+## Test Description
+##     Check for errors during test cycle of:
+##         playback -> pause -> suspend -> resume -> release cycles
+##     * By changing aplay call to an arecord call, you can manual test capture
+##       via the same method.
+## Test Case:
+##     1. Run in terminal 1:
+##         aplay -Dhw:0,0 -fs16_le -c2 -r 48000 -vv -i /dev/zero
+##     2. Press the spacebar to pause playback
+##     3. Run in terminal 2:
+##         sudo rtcwake -m mem -s 10
+##     4. Device should suspend.
+##     5. Once device has resumed, press spacebar in terminal 1 to release audio
+##         playback from paused state.
+##     6. Playback should resume normally.
+##     7. Check dmesg for any unexpected errors.
+##     8. Repeat as necessary.
+## Expect result:
+##  * aplay process should continue to be active after suspend / resume cycle.
+##  * No unexpected errors should be present in dmesg during or after test
+##      completion.
 
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 


### PR DESCRIPTION
The manual instructions for this test should be kept with the test itself for
reference should problems arise and the test needs to be made manual again for a
period of time.

Signed-off-by: Kelly Ledford <kelly.ledford@intel.com>