### PR TITLE
kmod: remove snd_soc_sof_sdw before removing snd_soc_hdac_hdmi

### DIFF
--- a/tools/kmod/sof_insert.sh
+++ b/tools/kmod/sof_insert.sh
@@ -35,6 +35,7 @@ insert_module snd_soc_max98090
 
 insert_module snd_soc_rt700
 insert_module snd_soc_rt711
+insert_module snd_soc_rt1308
 insert_module snd_soc_rt1308_sdw
 insert_module snd_soc_rt715
 insert_module snd_soc_rt1011

--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -63,6 +63,7 @@ remove_module snd_soc_rt286
 remove_module snd_soc_rt298
 remove_module snd_soc_rt700
 remove_module snd_soc_rt711
+remove_module snd_soc_rt1308
 remove_module snd_soc_rt1308_sdw
 remove_module snd_soc_rt715
 remove_module snd_soc_rt1011

--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -48,8 +48,7 @@ remove_module snd_soc_sst_cht_bsw_rt5672
 remove_module snd_soc_sst_glk_rt5682_max98357a
 remove_module snd_soc_cml_rt1011_rt5682
 remove_module snd_soc_skl_hda_dsp
-remove_module snd_soc_sdw_rt700
-remove_module snd_soc_sdw_rt711_rt1308_rt715
+remove_module snd_soc_sof_sdw
 
 remove_module snd_sof
 remove_module snd_sof_nocodec


### PR DESCRIPTION
This patch fixes "Module snd_soc_hdac_hdmi is in use
by: snd_soc_sof_sdw" when removing snd_soc_hdac_hdmi.

fixes #142 and #146

Signed-off-by: Amery Song <chao.song@intel.com>