### PR TITLE
case-lib: use -c to test sound device file

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -150,7 +150,7 @@ func_lib_get_random()
 func_lib_lsof_error_dump()
 {
     local file=$1
-    [[ ! -f $file ]] && return
+    [[ ! -c $file ]] && return
     local ret=$(lsof $file)
     if [ "$ret" ];then
         dloge "Sound device file is in use:"


### PR DESCRIPTION
All sound device files are character device, we
should use -c to test these files.