### PR TITLE
tools: force remove snd_usb_audio

### DIFF
--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -14,7 +14,7 @@ remove_module() {
     fi
 }
 
-remove_module snd_usb_audio
+remove_module -f snd_usb_audio
 
 remove_module snd_hda_intel
 remove_module sof_pci_dev


### PR DESCRIPTION
snd_usb_audio remove failure on some platfroms, it shows in use
but ‘’by‘’ column is empty. So force remove it to avoid this issue.

Signed-off-by: Zhang Keqiao <keqiao.zhang@linux.intel.com>