### PR TITLE
tools: fix direct load sof-kernel-dump.sh miss sof-get-kenrel-line.sh

### DIFF
--- a/tools/sof-kernel-dump.sh
+++ b/tools/sof-kernel-dump.sh
@@ -8,11 +8,20 @@ last_order=$[ $last_order + 1 ]
 log_file=${2:-"/var/log/kern.log"}
 # check whether target file exists
 [[ ! -f "$log_file" ]] && echo "$0 parameter 2 $log_file does not exist" && builtin exit 1
+# load helper script
+which sof-get-kernel-line.sh 2>&1 1>/dev/null
+if [ $? -eq 0 ]; then
+    kernel_line_script="sof-get-kernel-line.sh"
+else
+    cd $(dirname $0)
+    kernel_line_script=$PWD/sof-get-kernel-line.sh
+    cd $OLDPATH
+fi
 declare -a line_lst
 # here line lst to keep 2 value, [0] is target line, [1] is end line
 # if target is last one, so will cut content form [0] -> file end
 # if target is second last, so will cut content from [0] -> [1]
-line_lst=($(sof-get-kernel-line.sh $log_file|tail -n $last_order|awk '{print $1;}'))
+line_lst=($($kernel_line_script $log_file|tail -n $last_order|awk '{print $1;}'))
 # sof-get-kernel-line.sh dump nothing
 [[ ! "${line_lst[0]}" ]] && echo "$0 without catch system boot keyword" && builtin exit 1
 # check target is last one


### PR DESCRIPTION
Root cause is reset PATH in lib.sh, direct load sof-kernel-dump
skip reset PATH step, so miss sof-get-kernel-line in the PATH

Signed-off-by: Wu, BinX <binx.wu@intel.com>