### PR TITLE
kmod: remove snd_soc_rt1308 before removing snd_soc_rt6231

### DIFF
--- a/tools/kmod/sof_insert.sh
+++ b/tools/kmod/sof_insert.sh
@@ -35,6 +35,7 @@ insert_module snd_soc_max98090
 
 insert_module snd_soc_rt700
 insert_module snd_soc_rt711
+insert_module snd_soc_rt1308
 insert_module snd_soc_rt1308_sdw
 insert_module snd_soc_rt715
 insert_module snd_soc_rt1011

--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -65,6 +65,7 @@ remove_module snd_soc_rt286
 remove_module snd_soc_rt298
 remove_module snd_soc_rt700
 remove_module snd_soc_rt711
+remove_module snd_soc_rt1308
 remove_module snd_soc_rt1308_sdw
 remove_module snd_soc_rt715
 remove_module snd_soc_rt1011


### PR DESCRIPTION
This patch fixed https://github.com/thesofproject/sof-test/issues/146