### PR TITLE
kmod: sof_remove: remove snd_intel_dspcfg

### DIFF
--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -97,6 +97,8 @@ remove_module snd_hda_codec_generic
 remove_module snd_soc_acpi
 remove_module snd_hda_ext_core
 
+remove_module snd_intel_dspcfg
+
 remove_module soundwire_intel_init
 remove_module soundwire_intel
 remove_module soundwire_cadence


### PR DESCRIPTION
This needs to be removed before removing soundwire_intel

https://sof-ci.01.org/linuxpr/PR1940/build3399/devicetest/ICL_RVP_HDA/check-kmod-load-unload.sh/check-kmod-load-unload.sh.txt

Removing soundwire_intel
rmmod: ERROR: Module soundwire_intel is in use by: snd_intel_dspcfg


Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>