### PR TITLE
verify-ucm-config: assign cardname in option when open card

### DIFF
--- a/test-case/verify-ucm-config.sh
+++ b/test-case/verify-ucm-config.sh
@@ -144,15 +144,13 @@ func_verify_verb_device()
     return 0
 }
 
-ucm_folder=/usr/share/alsa/ucm
-
 sofcard=${SOFCARD:-0}
 cardname=$(sof-dump-status.py -s $sofcard)
 [[ $? -ne 0 ]] && exit 1
 
 # 1. use alsaucm to open the card
-dlogc "alsaucm open '$cardname'"
-alsaucm open "$cardname" 2>/dev/null
+dlogc "alsaucm -c ${cardname} open ${cardname}"
+alsaucm -c "${cardname}" open "${cardname}" 2>/dev/null
 [[ $? -ne 0 ]] && dloge "open card '$cardname' failed!" && exit 1
 
 # 2. try to reload the card to the initial settings.


### PR DESCRIPTION
After updating in alsa-lib to support UCMv2, uc_mgr_scan_master_configs()
in alsa-lib/src/ucm/parser.c will check ALSA_CONFIG_UCM2_VAR. If system
doesn't support ucm2, it won't setup this environment variable. Then it will
setup:
snprintf(filename, sizeof(filename), "%s/ucm2", snd_config_topdir());
as the config file folder. And the folder definitely doesn't exist.
A solution to skip the folder checking is use option -C to assign the
cardname manually by:
alsaucm -c $cardname open $cardname

Signed-off-by: Libin Yang <libin.yang@intel.com>