### PR TITLE
tools: clean up ignore_str for sof-kernel-log-check.sh

### DIFF
--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -3,7 +3,7 @@
 begin_line=${1:-1}
 declare err_str ignore_str project_key
 err_str="error|failed|timed out|panic|oops"
-ignore_str="hda_sdw_acpi_scan failed|ACPI scan error|error: debugfs write failed to idle -16|error: status |error: cl_dsp_init|iteration [01]"
+ignore_str="hda_sdw_acpi_scan failed|ACPI scan error|error: debugfs write failed to idle -16|error: status|iteration [01]"
 project_key="sof-audio"
 
 [[ ! "$err_str" ]] && echo "Missing error keyword list" && exit 0

--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -3,7 +3,7 @@
 begin_line=${1:-1}
 declare err_str ignore_str project_key
 err_str="error|failed|timed out|panic|oops"
-ignore_str="ACPI scan error|error: debugfs write failed to idle -16|error: status |error: cl_dsp_init|iteration [01]"
+ignore_str="hda_sdw_acpi_scan failed|ACPI scan error|error: debugfs write failed to idle -16|error: status |error: cl_dsp_init|iteration [01]"
 project_key="sof-audio"
 
 [[ ! "$err_str" ]] && echo "Missing error keyword list" && exit 0

--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -28,8 +28,10 @@ else
 fi
 
 if [ "$err" ]; then
-    echo "Caught error: $err"
-    echo "kernel log has error(s)"
+    echo `date -u '+%Y-%m-%d %T %Z'` "[ERROR]" "Caught dmesg error"
+    echo "===========================>>"
+    echo "$err"
+    echo "<<==========================="
     builtin exit 1
 fi
 

--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -3,7 +3,7 @@
 begin_line=${1:-1}
 declare err_str ignore_str project_key
 err_str="error|failed|timed out|panic|oops"
-ignore_str="no reply expected,|error: debugfs write failed to idle -16|error: status |error: cl_dsp_init|iteration [01]"
+ignore_str="error: debugfs write failed to idle -16|error: status |error: cl_dsp_init|iteration [01]"
 project_key="sof-audio"
 
 [[ ! "$err_str" ]] && echo "Missing error keyword list" && exit 0

--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -3,7 +3,7 @@
 begin_line=${1:-1}
 declare err_str ignore_str project_key
 err_str="error|failed|timed out|panic|oops"
-ignore_str="error: debugfs write failed to idle -16|error: status |error: cl_dsp_init|iteration [01]"
+ignore_str="ACPI scan error|error: debugfs write failed to idle -16|error: status |error: cl_dsp_init|iteration [01]"
 project_key="sof-audio"
 
 [[ ! "$err_str" ]] && echo "Missing error keyword list" && exit 0


### PR DESCRIPTION
Some of the items in ignore_str is deprecated, and some new are needed. This patch do a clean up on ignore_str according to current kernel and sof status.