### PR TITLE
tools: revert 7752b6b5 and 813566fc for ignore _str

### DIFF
--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -3,7 +3,7 @@
 begin_line=${1:-1}
 declare err_str ignore_str project_key
 err_str="error|failed|timed out|panic|oops"
-ignore_str="hda_sdw_acpi_scan failed|ACPI scan error|error: debugfs write failed to idle -16|error: status|iteration [01]"
+ignore_str="error: debugfs write failed to idle -16|error: status|iteration [01]"
 project_key="sof-audio"
 
 [[ ! "$err_str" ]] && echo "Missing error keyword list" && exit 0


### PR DESCRIPTION
As 'ACPI scan error' and 'hda_sdw_acpi_scan failed'
error messages are fixed in the kernel, these two
errors are not seen on platform without soundwire.

Revert with git introduces conflict, use this commit
to do the revert.

Signed-off-by: Amery Song <chao.song@intel.com>