### PR TITLE
[IN DISCUSSION, NOT MERGE]case-lib: redirect nohup stdout and stderr to /dev/null

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -95,7 +95,7 @@ func_lib_restore_pulseaudio()
     do
         user=${line%% *}
         cmd=${line#* }
-        nohup sudo -u $user $cmd >/dev/null &
+        nohup sudo -u $user $cmd &>/dev/null &
     done
     # now wait for the pulseaudio restore in the ps process
     timeout=10


### PR DESCRIPTION
If only redirect nohup stdout to /dev/null, we will see
'nohup: redirecting stderr to stdout' message from nohup
when manually run './check-kmod-load-unload.sh -l1'.

Which will make the test log looks ugly.

Signed-off-by: Amery Song <chao.song@intel.com>