### PR TITLE
case-lib: rename pulseaudio before disabling it

### DIFF
--- a/case-lib/config.sh
+++ b/case-lib/config.sh
@@ -8,7 +8,6 @@ SUDO_PASSWD=${SUDO_PASSWD:-}
 
 # global define
 TPLG_ROOT=${TPLG_ROOT:-/lib/firmware/intel/sof-tplg}
-PULSEAUDIO_CONFIG=${PULSEAUDIO_CONFIG:-/etc/pulse/client.conf}
 
 # ignore the target keyword for tplg
 # example: ignore 'pipeline ids equal to 2'

--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -58,7 +58,7 @@ function exit()
     # if failed to restore pulseaudio, even test caes passed, set exit status to ret
     # to make test case failed. this helps to dectect pulseaudio failures.
     if [ $exit_status -eq 0 -a $ret -ne 0 ]; then
-        exit_status=ret
+        exit_status=$ret
     fi
 
     case $exit_status in


### PR DESCRIPTION
Pulseaudio may be started by many other applications,
which will cause some of the test cases failed.

This patch renames pulseaudio in func_lib_disable_pulseaudio
and rename it back in func_lib_restore_pulseaudio

Signed-off-by: Amery Song <chao.song@intel.com>