### PR TITLE
kmod: fix snd_soc_rt1308 not loaded error

### DIFF
--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -6,7 +6,7 @@ remove_module() {
 
     local MODULE="$1"
 
-    if lsmod | grep "$MODULE" &> /dev/null ; then
+    if lsmod | grep -w "$MODULE" &> /dev/null ; then
         echo "Removing $MODULE"
         sudo rmmod $MODULE
     else


### PR DESCRIPTION
For platforms with only snd_soc_rt1308_sdw,
the snd_soc_rt1308 module will escape the check
of 'if lsmod | grep "$MODULE" &> /dev/null'.
Removing not existed snd_soc_rt1308 causes error.

This patch does a full match with grep, and thus
avoids the error condition.