### PR TITLE
kmod: add snd_soc_rt5682_sdw support

### DIFF
--- a/tools/kmod/sof_insert.sh
+++ b/tools/kmod/sof_insert.sh
@@ -27,6 +27,7 @@ insert_module snd_soc_rt5670
 insert_module snd_soc_rt5677
 insert_module snd_soc_rt5677_spi
 insert_module snd_soc_rt5682
+insert_module snd_soc_rt5682_sdw
 
 insert_module snd_soc_pcm512x_i2c
 insert_module snd_soc_wm8804_i2c

--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -75,6 +75,7 @@ remove_module snd_soc_rt5651
 remove_module snd_soc_rt5670
 remove_module snd_soc_rt5677
 remove_module snd_soc_rt5677_spi
+remove_module snd_soc_rt5682_sdw
 remove_module snd_soc_rt5682
 remove_module snd_soc_rl6231
 remove_module snd_soc_rl6347a


### PR DESCRIPTION
add snd_soc_rt5682_sdw support in kmod test.

Signed-off-by: Zhang Keqiao <keqiao.zhang@linux.intel.com>