### PR TITLE
case-lib: remove 'cd' from case-lib

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -8,9 +8,10 @@ source $(dirname ${BASH_SOURCE[0]})/pipeline.sh
 source $(dirname ${BASH_SOURCE[0]})/hijack.sh
 
 # Add tools to command PATH
-cd $(dirname ${BASH_SOURCE[1]})/../tools
-PATH=$PWD:$PATH
-cd $OLDPWD
+if [ ! "$(declare -p TOOL_PATH 2>/dev/null)" ]; then
+    declare -x TOOL_PATH=$(realpath $(dirname ${BASH_SOURCE[1]})/../tools)
+    PATH=$TOOL_PATH:$PATH
+fi
 
 # setup SOFCARD id
 if [ ! "$SOFCARD" ]; then

--- a/case-lib/logging_ctl.sh
+++ b/case-lib/logging_ctl.sh
@@ -61,21 +61,18 @@ _func_log_directory()
 
     local case_name=$(basename ${BASH_SOURCE[-1]})
     local log_dir=$(dirname ${BASH_SOURCE[0]})/../logs/
+    log_dir=$(realpath $log_dir)
     local timetag=$(date +%F"-"%T)"-"$RANDOM
     local cur_pwd=$PWD
     case_name=${case_name%.*}
-    mkdir -p $log_dir/$case_name/$timetag
-    cd $log_dir/$case_name
+    local case_folder=$log_dir/$case_name
+    mkdir -p $case_folder/$timetag
     # now using the last link for the time tag
-    [[ -L last ]] && rm last
-    if [[ ! -e last ]]; then
-        ln -s $timetag last
-        cd last
-    else     # if "last" is not the link skip it
-        cd $timetag
+    [[ -L $case_folder/last ]] && rm $case_folder/last
+    if [[ ! -e $case_folder/last ]]; then
+        ln -s $case_folder/$timetag $case_folder/last
     fi
-    export LOG_ROOT=$PWD
-    cd $cur_pwd
+    export LOG_ROOT=$case_folder/$timetag
 }
 
 for _func_ in $(declare -F|grep _func_log_|awk '{print $NF;}')

--- a/case-lib/opt.sh
+++ b/case-lib/opt.sh
@@ -133,10 +133,9 @@ func_opt_parse_option()
             fi
         done
         echo $cmd >> $LOG_ROOT/cmd.txt
-        cd $(dirname $0)
-        echo "Branch: "$(git branch|grep '^*') >> $LOG_ROOT/version.txt
-        echo "Commit: "$(git log --oneline -1) >> $LOG_ROOT/version.txt
-        cd $OLDPATH
+        local git_path=$(dirname $0)
+        echo "Branch: "$(git -C $git_path branch |grep '^*') >> $LOG_ROOT/version.txt
+        echo "Commit: "$(git -C $git_path log --oneline -1) >> $LOG_ROOT/version.txt
     fi
 
     unset _func_create_tmpbash _func_opt_dump_help _func_case_dump_descption

--- a/tools/sof-boot-once.sh
+++ b/tools/sof-boot-once.sh
@@ -30,7 +30,7 @@ if [ "$#" -ne 0 ]; then
     if [ "X${cmd_path/\/*/}" == "X." -o -d "$cmd_path" ]; then #relative path
         cd $cmd_path
         cmd=$PWD/$(basename $1)
-        cd $OLD_PATH
+        cd $OLDPWD
         shift
     elif [ "X${cmd_path:0:1}" == "X/" ]; then #absolute path
         cmd=$cmd_path/$(basename $1)

--- a/tools/sof-kernel-dump.sh
+++ b/tools/sof-kernel-dump.sh
@@ -15,7 +15,7 @@ if [ $? -eq 0 ]; then
 else
     cd $(dirname $0)
     kernel_line_script=$PWD/sof-get-kernel-line.sh
-    cd $OLDPATH
+    cd $OLDPWD
 fi
 declare -a line_lst
 # here line lst to keep 2 value, [0] is target line, [1] is end line


### PR DESCRIPTION
2 patch:

1. fix typo of tools
2. remove 'cd' change work directory to avoid some script miss problem

fix issue #163 