### PR TITLE
test-case: check-sof-logger use file content instead of size of file

### DIFF
--- a/test-case/check-sof-logger.sh
+++ b/test-case/check-sof-logger.sh
@@ -75,14 +75,13 @@ if [[ $logger_err ]]; then
     dloge "No available log to export due to sof-logger errors."
     func_logger_exit 1 'error'
 fi
-# get size of trace log$
-size=`du -k $data_file | awk '{print $1}'`
+
 # '\.c\:[1-9]' to filter like '.c:6' this type keyword like:
 # [3017136.770833]  (11.302083) c0 SA  src/lib/agent.c:65  ERROR validate(), ll drift detected, delta = 25549
 fw_log_err=`grep -i "error" $data_file | grep -v '\.c\:[1-9]'`
-# 4 here is log header size
-# only log header and no fw log
-if [[ $size -lt 4 ]]; then
+# '[[:blank:]]TIMESTAMP.*CONTENT$' to filter the log header:
+# TIMESTAMP  DELTA C# COMPONENT  LOCATION  CONTENT
+if [[ ! $(sed -n '/[[:blank:]]TIMESTAMP.*CONTENT$/p' $data_file) ]]; then
     dloge "No available log to export."
     func_logger_exit 1
 # we catch error from fw log


### PR DESCRIPTION
use file content keyword instead of file size detect to judgment data
file already dumped

Signed-off-by: Wu, BinX <binx.wu@intel.com>