### PR TITLE
case-lib: misc fix on topology path

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -8,19 +8,14 @@ function exit()
     local exit_status=${1:-0}
 
     # To generate topology graph, test case should export $tplg for us
-    if [[ -n "$tplg" ]]; then
-        if [[ -f "$tplg" ]]; then
-            tplg_path="$tplg"
-        elif [[ -f "$TPLG_ROOT/$(basename $tplg)" ]]; then
-            tplg_path="$TPLG_ROOT/$(basename $tplg)"
-        else
-            tplg_path=""
-        fi
-        # don't check fw_path here, if fw_path is empty, print debug error.
+    tplg_path=`func_lib_get_tplg_path "$tplg"`
+    if [[ "$?" != "0" ]]; then
+        dlogw "No available topology for graph generation"
+    else
         tplgtool.py -d graph -D $LOG_ROOT $tplg_path &> /dev/null
         [[ "$?" != "0" ]] && dloge "Failed to generate topology graph"
-        unset tplg
     fi
+    unset tplg
 
     # when sof logger collect is open
     if [ "X$SOF_LOG_COLLECT" == "X1" ]; then

--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -9,7 +9,15 @@ function exit()
 
     # To generate topology graph, test case should export $tplg for us
     if [[ -n "$tplg" ]]; then
-        tplgtool.py -d graph -D $LOG_ROOT $tplg &> /dev/null
+        if [[ -f "$tplg" ]]; then
+            tplg_path="$tplg"
+        elif [[ -f "$TPLG_ROOT/$(basename $tplg)" ]]; then
+            tplg_path="$TPLG_ROOT/$(basename $tplg)"
+        else
+            tplg_path=""
+        fi
+        # don't check fw_path here, if fw_path is empty, print debug error.
+        tplgtool.py -d graph -D $LOG_ROOT $tplg_path &> /dev/null
         [[ "$?" != "0" ]] && dloge "Failed to generate topology graph"
         unset tplg
     fi

--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -155,3 +155,22 @@ func_lib_lsof_error_dump()
         echo "$ret"
     fi
 }
+
+func_lib_get_tplg_path()
+{
+    local tplg=$1
+    # tplg given is empty
+    if [[ -z "$tplg" ]]; then
+        return 1
+    fi
+
+    if [[ -f "$TPLG_ROOT/$(basename "$tplg")" ]]; then
+        echo "$TPLG_ROOT/$(basename "$tplg")"
+    elif [[ -f "$tplg" ]]; then
+        echo $(realpath "$tplg")
+    else
+        return 1
+    fi
+
+    return 0
+}

--- a/test-case/check-signal-stop-start.sh
+++ b/test-case/check-signal-stop-start.sh
@@ -94,7 +94,7 @@ do
     snd=$(func_pipeline_parse_value $idx snd)
 
     dlogi "Testing: run stop/start test on PCM:$pcm,$pipeline_type. Interval time: $interval"
-    dlogc $cmd -D$dev -r $rate -c $channel -f $fmt $dummy_file -q &
+    dlogc "$cmd -D$dev -r $rate -c $channel -f $fmt $dummy_file -q &"
     $cmd -D$dev -r $rate -c $channel -f $fmt $dummy_file -q &
     pid=$!
 

--- a/test-case/check-xrun-injection.sh
+++ b/test-case/check-xrun-injection.sh
@@ -100,7 +100,7 @@ do
     # check xrun injection file
     [[ ! -e $xrun_injection ]] && dloge "XRUN DEBUG is not enabled in kernel, skip the test." && exit 2
     dlogi "Testing: test xrun injection on PCM:$pcm,$pipeline_type. Interval time: $interval"
-    dlogc $cmd -D$dev -r $rate -c $channel -f $fmt $dummy_file -q
+    dlogc "$cmd -D$dev -r $rate -c $channel -f $fmt $dummy_file -q"
     $cmd -D$dev -r $rate -c $channel -f $fmt $dummy_file -q &
     pid=$!
 

--- a/test-case/simultaneous-playback-capture.sh
+++ b/test-case/simultaneous-playback-capture.sh
@@ -40,8 +40,9 @@ loop_cnt=${OPT_VALUE_lst['l']}
 # get 'both' pcm, it means pcm have same id with different type
 declare -A tmp_id_lst
 id_lst_str=""
-[[ -f $TPLG_ROOT/$tplg ]] && tmp_tplg=$TPLG_ROOT/$tplg || tmp_tplg=$tplg
-for i in $(sof-tplgreader.py $tmp_tplg -d id -v)
+tplg_path=`func_lib_get_tplg_path "$tplg"`
+[[ "$?" -ne "0" ]] && dloge "No available topology for this test case" && exit 1
+for i in $(sof-tplgreader.py $tplg_path -d id -v)
 do
     if [ ! "${tmp_id_lst["$i"]}" ]; then  # this id is never used
         tmp_id_lst["$i"]=0
@@ -51,7 +52,7 @@ do
     fi
 done
 # now all duplicate ids have already been caught
-unset tmp_id_lst tmp_tplg
+unset tmp_id_lst tplg_path
 id_lst_str=${id_lst_str/,/} # remove 1st, which is not used
 [[ ${#id_lst_str} -eq 0 ]] && dlogw "no pipeline with both playback and capture capabilities found in $tplg" && exit 2
 func_pipeline_export $tplg "id:$id_lst_str"

--- a/test-case/verify-pcm-list.sh
+++ b/test-case/verify-pcm-list.sh
@@ -23,50 +23,31 @@ OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 func_opt_parse_option $*
 tplg=${OPT_VALUE_lst['t']}
 
-[[ ! "$tplg" ]] && dlogw "Missing tplg file for this case" && exit 1
+tplg_path=`func_lib_get_tplg_path "$tplg"`
+[[ "$?" != "0" ]] && dloge "No available topology for this test case" && exit 1
 
 # hijack DMESG_LOG_START_LINE which refer dump kernel log in exit function
 DMESG_LOG_START_LINE=$(sof-get-kernel-line.sh|tail -n 1 |awk '{print $1;}')
 
-# check TPLG by the loop
-# TODO: current miss multiple tplg behaivor
-# so this case logic just for 1 tplg process
-while [ ${#tplg} -gt 0 ]
-do
-    # go through each TPLG file and check the PCM list
-    # left ',' 1st field
-    tplg_file=${tplg%%,*}
-    # expect left ',' 1st field
-    tplg=${tplg#*,}
-    [ "$tplg_file" == "$tplg" ] && tplg=""
-    if [ -f "$TPLG_ROOT/$(basename $tplg_file)" ]; then
-        tplg_file="$TPLG_ROOT/$(basename $tplg_file)"   # catch from TPLG_ROOT
-    elif [ -f "$tplg_file" ];then
-        tplg_file=$(realpath $tplg_file)    # relative path -> absolute path
-    else
-        dloge "Couldn't find target TPLG file $tplg_file needed to run ${BASH_SOURCE[0]}" && exit 1
-    fi
+tplg_str="$(sof-tplgreader.py $tplg_path -d id pcm type -o)"
+pcm_str="$(sof-dump-status.py -i ${SOFCARD:-0})"
 
-    tplg_str="$(sof-tplgreader.py $tplg_file -d id pcm type -o)"
-    pcm_str="$(sof-dump-status.py -i ${SOFCARD:-0})"
+dlogc "sof-tplgreader.py $tplg_file -d id pcm type -o"
+dlogi "Pipeline(s) from topology file:"
+echo "$tplg_str"
+dlogc "sof-dump-status.py -i ${SOFCARD:-0}"
+dlogi "Pipeline(s) from system:"
+echo "$pcm_str"
 
-    dlogi "CMD: 'sof-tplgreader.py $tplg_file -d id pcm type -o' to get tplg list string:"
-    echo "$tplg_str"
-    dlogi "CMD: 'sof-dump-status.py -i ${SOFCARD:-0}' to get pcm list string:"
-    echo "$pcm_str"
-
-    if [[ "$tplg_str" != "$pcm_str" ]]; then
-        dloge "TPLG mismatch with PCM"
-        dlogi "Dump aplay -l"
-        aplay -l
-        dlogi "Dump arecord -l"
-        arecord -l
-        sof-kernel-dump.sh > $LOOG_ROOT/kernel.txt
-        exit 1
-    fi
-
-    # TODO: Miss multiple TPLG mapping pcm logic
-    break
-done
-
+if [[ "$tplg_str" != "$pcm_str" ]]; then
+    dloge "Pipeline(s) from topology don't match pipeline(s) from system"
+    dlogi "Dump aplay -l"
+    aplay -l
+    dlogi "Dump arecord -l"
+    arecord -l
+    sof-kernel-dump.sh > $LOOG_ROOT/kernel.txt
+    exit 1
+else
+    dlogi "Pipeline(s) from topology match pipeline(s) from system"
+fi
 exit 0

--- a/test-case/volume-basic-test.sh
+++ b/test-case/volume-basic-test.sh
@@ -68,7 +68,7 @@ do
     for i in "${pgalist[@]}"
     do
         volctrl=$(echo $i | sed 's/_/ /g;')
-        dlogi $volctrl
+        dlogi "$volctrl"
 
         for vol in ${volume_array[@]}; do
             dlogc "amixer -c$sofcard cset name='$volctrl' $vol"


### PR DESCRIPTION
PR test specify topology like this: TPLG=sof-cml-rt1011-rt5682.tplg, under this condition, the tplgtool.py can not find the topology we specified, thus, we will get "Failed to generate topology graph" error.
This patch add a function to get topology path, and use it everywhere it can be used to replace old ugly code.