### PR TITLE
case-lib: remove I/O redirection for tplgtool.py

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -13,8 +13,8 @@ function exit()
         dlogw "No available topology for graph generation"
     else
         dlogi "Graph of $tplg_path will be generated to $LOG_ROOT"
-        tplgtool.py -d graph -D $LOG_ROOT $tplg_path > /dev/null
-        [[ "$?" != "0" ]] && dloge "Failed to generate topology graph"
+        tplgtool.py -d graph -D $LOG_ROOT $tplg_path
+        [[ "$?" != "0" ]] && dlogw "Failed to generate topology graph"
     fi
     unset tplg
 

--- a/tools/tplgtool.py
+++ b/tools/tplgtool.py
@@ -681,7 +681,7 @@ class TplgFormatter:
                     return node
         # if excution goes here, it means we didn't find the widget in the list,
         # obviously, there is error in topology
-        print("Widget {} not exist, error in topology", name)
+        print("Widget %s not exist, error in topology" %name)
         sys.exit(1)
         return None
 


### PR DESCRIPTION
We may lost debug message if we redirect stdout of tplgtool.py to /dev/null.
```
tplgtool.py -d graph -D $LOG_ROOT $tplg_path > /dev/null
```
As above call of tplgtool.py output nothing but error message, remove the redirection. without the error message, we may get confused in PR test result.

```
2020-04-10 02:37:53 UTC [REMOTE_INFO] Graph of /lib/firmware/intel/sof-tplg/sof-hda-generic-4ch.tplg will be generated to /home/ubuntu/sof-test/logs/check-playback/2020-04-10-10:37:15-29086
2020-04-10 02:37:53 UTC [REMOTE_ERROR] Failed to generate topology graph
2020-04-10 02:37:54 UTC [REMOTE_INFO] Test Result: PASS!
```
This patch helps to tell us why topology graph is failed to generate.