### PR TITLE
kmod: sof_remove.sh: add snd_sof_ipc_test, snd_sof_probes support

### DIFF
--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -52,6 +52,8 @@ remove_module snd_soc_sdw_rt700
 remove_module snd_soc_sdw_rt711_rt1308_rt715
 remove_module snd_soc_sof_sdw
 remove_module snd_soc_ehl_rt5660
+remove_module snd_sof_ipc_test
+remove_module snd_sof_probes
 
 remove_module snd_sof
 remove_module snd_sof_nocodec


### PR DESCRIPTION
When multiclient changes are merged, snd_sof_ipc_test is first client
module to test ipc flood test. 2nd client is snf_sof_probes whilch support
Probe feature. The client modules need to be removed before snd_sof.

Signed-off-by: Fred Oh <fred.oh@linux.intel.com>