### PR TITLE
test-case: add support for testing on specified pipeline

### DIFF
--- a/test-case/check-capture.sh
+++ b/test-case/check-capture.sh
@@ -42,6 +42,9 @@ OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 OPT_OPT_lst['F']='fmts'   OPT_DESC_lst['F']='Iterate all supported formats'
 OPT_PARM_lst['F']=0         OPT_VALUE_lst['F']=0
 
+OPT_OPT_lst['S']='filter_string'   OPT_DESC_lst['S']="run this case on specified pipelines"
+OPT_PARM_lst['S']=1             OPT_VALUE_lst['S']="id:any"
+
 func_opt_parse_option $*
 
 tplg=${OPT_VALUE_lst['t']}
@@ -55,7 +58,7 @@ file_prefix=${OPT_VALUE_lst['f']}
 
 func_lib_setup_kernel_last_line
 func_lib_check_sudo
-func_pipeline_export $tplg "type:capture"
+func_pipeline_export $tplg "type:capture & ${OPT_VALUE_lst['S']}"
 
 for round in $(seq 1 $round_cnt)
 do

--- a/test-case/check-pause-resume.sh
+++ b/test-case/check-pause-resume.sh
@@ -38,6 +38,9 @@ OPT_PARM_lst['a']=1         OPT_VALUE_lst['a']='200'
 OPT_OPT_lst['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
+OPT_OPT_lst['S']='filter_string'   OPT_DESC_lst['S']="run this case on specified pipelines"
+OPT_PARM_lst['S']=1             OPT_VALUE_lst['S']="id:any"
+
 func_opt_parse_option $*
 
 tplg=${OPT_VALUE_lst['t']}
@@ -70,7 +73,7 @@ esac
 
 [[ -z $file_name ]] && file_name=$dummy_file
 
-func_pipeline_export $tplg "type:$test_mode"
+func_pipeline_export $tplg "type:$test_mode & ${OPT_VALUE_lst['S']}"
 func_lib_setup_kernel_last_line
 for idx in $(seq 0 $(expr $PIPELINE_COUNT - 1))
 do

--- a/test-case/check-playback.sh
+++ b/test-case/check-playback.sh
@@ -39,6 +39,9 @@ OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 OPT_OPT_lst['F']='fmts'   OPT_DESC_lst['F']='Iterate all supported formats'
 OPT_PARM_lst['F']=0         OPT_VALUE_lst['F']=0
 
+OPT_OPT_lst['S']='filter_string'   OPT_DESC_lst['S']="run this case on specified pipelines"
+OPT_PARM_lst['S']=1             OPT_VALUE_lst['S']="id:any"
+
 func_opt_parse_option $*
 
 tplg=${OPT_VALUE_lst['t']}
@@ -63,7 +66,7 @@ fi
 
 func_lib_setup_kernel_last_line
 func_lib_check_sudo
-func_pipeline_export $tplg "type:playback"
+func_pipeline_export $tplg "type:playback & ${OPT_VALUE_lst['S']}"
 
 for round in $(seq 1 $round_cnt)
 do


### PR DESCRIPTION
with this patch, QA can run test case on specified single pipeline rather than iterate all pipelines