### PR TITLE
tools/shellcheck: git log ${TRAVIS_COMMIT_RANGE/.../..}

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,5 @@ jobs:
   include:
 
     - name: "shellcheck"
+      # Triple-dotted 'origin/master...HEAD'
       script: ./tools/shellcheck-gitrange.bash "${TRAVIS_COMMIT_RANGE}"


### PR DESCRIPTION
$TRAVIS_COMMIT_RANGE contains triple dots,
e.g. "origin/master...HEAD". This is great for git diff but unsuitable
for git log. Convert any triple dots to double dots before passing to
git log (don't change the argument for git diff --name-only).

Also use a more verbose git log command and --no-pager instead of the
gross '|cat ': the sanity check was reporting issues but always
reporting success.

Fixes: faadb20a8548 ("CI: travis: new shellcheck-gitrange.bash")

Signed-off-by: Marc Herbert <marc.herbert@intel.com>