### PR TITLE
kmod: add support for snd_sof_ipc_test

### DIFF
--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -53,6 +53,7 @@ remove_module snd_soc_sdw_rt711_rt1308_rt715
 remove_module snd_soc_sof_sdw
 remove_module snd_soc_ehl_rt5660
 
+remove_module snd_sof_ipc_test
 remove_module snd_sof
 remove_module snd_sof_nocodec
 


### PR DESCRIPTION
Kernel PR1841 introduces this kernel module,
we need to remove it before snd_sof to resolve
"Module snd_sof is in use by: snd_sof_ipc_test"
error when do module removal.

PR1841 test result here https://sof-ci.01.org/linuxpr/PR1841/build3591/devicetest/