### PR TITLE
kmod: update wm8804 machine driver name

### DIFF
--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -36,7 +36,7 @@ remove_module snd_soc_sst_broadwell
 remove_module snd_soc_sst_bxt_da7219_max98357a
 remove_module snd_soc_sst_sof_pcm512x
 remove_module snd_soc_sst_bxt_rt298
-remove_module snd_soc_sst_bxt_wm8804
+remove_module snd_soc_sst_sof_wm8804
 remove_module snd_soc_sst_byt_cht_da7213
 remove_module snd_soc_sst_byt_cht_es8316
 remove_module snd_soc_sst_bytcr_rt5640


### PR DESCRIPTION
moved from bxt to sof

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>