### PR TITLE
test-case: don't save dmesg per pipeline

### DIFF
--- a/test-case/check-capture.sh
+++ b/test-case/check-capture.sh
@@ -93,11 +93,9 @@ do
                 arecord -D$dev -r $rate -c $channel -f $fmt_elem -d $duration $file -v -q
                 if [[ $? -ne 0 ]]; then
                     func_lib_lsof_error_dump $snd
-                    dmesg > $LOG_ROOT/arecord_error_${dev}_$i.txt
                     dloge "arecord on PCM $dev failed at $i/$loop_cnt."
                     exit 1
                 fi
-                dmesg > $LOG_ROOT/arecord_${dev}_$i.txt
             done
         done
     done

--- a/test-case/check-playback.sh
+++ b/test-case/check-playback.sh
@@ -91,11 +91,9 @@ do
                 aplay -D$dev -r $rate -c $channel -f $fmt_elem -d $duration $file -v -q
                 if [[ $? -ne 0 ]]; then
                     func_lib_lsof_error_dump $snd
-                    dmesg > $LOG_ROOT/aplay_error_${dev}_$i.txt
                     dloge "aplay on PCM $dev failed at $i/$loop_cnt."
                     exit 1
                 fi
-                dmesg > $LOG_ROOT/aplay_${dev}_$i.txt
             done
         done
     done


### PR DESCRIPTION
Previously, We will save dmesg per pipeline,
this not necessary, an overall log collection
at the end of test case is good enough.

more log files will add a lot of complexity to show in the web.
Here, the Per pipeline log are all empty. 
https://sof-ci.01.org/linuxpr/PR1971/build3638/devicetest/CFL_RVP_HDA/check-playback-3times/