### PR TITLE
test-case: check-runtime-pm-* miss verify kernel check result

### DIFF
--- a/test-case/check-runtime-pm-double-active.sh
+++ b/test-case/check-runtime-pm-double-active.sh
@@ -141,7 +141,9 @@ do
         fi
     done
 
-    sof-kernel-log-check.sh 0
+    sof-kernel-log-check.sh 0 || {
+        dloge "Catch error in dmesg" && exit 1
+    }
 done
 
 sof-kernel-log-check.sh $KERNEL_LAST_LINE

--- a/test-case/check-runtime-pm-status.sh
+++ b/test-case/check-runtime-pm-status.sh
@@ -127,7 +127,9 @@ do
         fi
     done
 
-    sof-kernel-log-check.sh 0
+    sof-kernel-log-check.sh 0 || {
+        dloge "Catch error in dmesg" && exit 1
+    }
 done
 
 sof-kernel-log-check.sh $KERNEL_LAST_LINE


### PR DESCRIPTION
when load sof-kernel-log-check it should check the return value
fix case:
check-runtime-pm-status.sh
check-runtime-pm-double-active.sh

Signed-off-by: Wu, BinX <binx.wu@intel.com>