### PR TITLE
case-lib: make variable local to avoid impact on test cases

### DIFF
--- a/case-lib/pipeline.sh
+++ b/case-lib/pipeline.sh
@@ -28,8 +28,8 @@ func_pipeline_export()
         done
     fi
 
-    opt="-f \"$filter\" -b \"$ignore\""
-    cmd="sof-tplgreader.py $tplg_path $opt -s $sofcard -e"
+    local opt="-f \"$filter\" -b \"$ignore\""
+    local cmd="sof-tplgreader.py $tplg_path $opt -s $sofcard -e"
     dlogi "Run command to get pipeline parameters"
     dlogc "$cmd"
     OLD_IFS="$IFS" IFS=$'\n'


### PR DESCRIPTION
In pipeline.sh, we should make variable cmd local,
because this variable name is also used in some
test cases.
