### PR TITLE
tools: exit successfully if call trace is not from alsa

### DIFF
--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -22,16 +22,19 @@ project_key="sof-audio"
 #echo "run $0 with parameter '$*' for check kernel message error"
 
 if [ "$ignore_str" ]; then
-    err=$(eval $cmd|grep 'Call Trace' -A5 -B3)$(eval $cmd | grep $project_key | grep -E "$err_str"|grep -vE "$ignore_str")
+    err=$(eval "$cmd"|grep 'Call Trace' -A5 -B3)$(eval "$cmd" | grep "$project_key" | grep -E "$err_str"|grep -vE "$ignore_str")
 else
-    err=$(eval $cmd|grep 'Call Trace' -A5 -B3)$(eval $cmd | grep $project_key | grep -E "$err_str")
+    err=$(eval "$cmd"|grep 'Call Trace' -A5 -B3)$(eval "$cmd" | grep "$project_key" | grep -E "$err_str")
 fi
 
 if [ "$err" ]; then
-    echo `date -u '+%Y-%m-%d %T %Z'` "[ERROR]" "Caught dmesg error"
+    echo "$(date -u '+%Y-%m-%d %T %Z') [ERROR] Caught dmesg error"
     echo "===========================>>"
     echo "$err"
     echo "<<==========================="
+    # exclude none alsa trace, but still print trace message
+    snd_trace=$(echo "$err" | grep "snd")
+    [ -z "$snd_trace" ] && builtin exit 0
     builtin exit 1
 fi
 


### PR DESCRIPTION
Previouly, every call trace will fail the test
case, that's not correct. Only ALSA related
call trace should fail the test case.

This patch checks call trace message, and
only failed test case with ALSA related
call trace.

fix https://github.com/thesofproject/sof-test/issues/184