### PR TITLE
test-case: fix a bash grammer error

### DIFF
--- a/test-case/multiple-pause-resume.sh
+++ b/test-case/multiple-pause-resume.sh
@@ -41,7 +41,7 @@ OPT_PARM_lst['a']=1         OPT_VALUE_lst['a']='200'
 OPT_OPT_lst['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
-func_opt_parse_option"$@"
+func_opt_parse_option "$@"
 
 repeat_count=${OPT_VALUE_lst['r']}
 loop_count=${OPT_VALUE_lst['l']}


### PR DESCRIPTION
There should be a 'space' between function
and its arguments
