### PR TITLE
tools: sof-get-kernel-line remove 0x0 in grep result

### DIFF
--- a/tools/sof-get-kernel-line.sh
+++ b/tools/sof-get-kernel-line.sh
@@ -7,6 +7,6 @@
 # 2156 4.15.0-74-generic
 # 3246 4.15.0-74-generic
 log_file=${1:-"/var/log/kern.log"}
-[[ ! -f $log_file ]] && builtin exit 1
+[[ ! -f "$log_file" ]] && builtin exit 1
 bootup_keyword='\[    0.000000\] Linux version '
-grep -na "$bootup_keyword" $log_file|awk -F ':' '{print $1 $(NF-2);}'|sed "s/$bootup_keyword//g"|awk '{print $1, $2;}'
+grep -na "$bootup_keyword" "$log_file"|sed 's/\x0//g'|awk -F ':' '{print $1 $(NF-2);}'|sed "s/$bootup_keyword//g"|awk '{print $1, $2;}'


### PR DESCRIPTION
system will store '0x0' into /var/log/kern.log file,
it normally when system hang/something
For Ubuntu 18.04: it happend at line end
For Ubuntu 19.10: it happend at line begin

So for Ubuntu 19.10 with 'grep' command,
it will been catched after line number
This issue will cause the command of pipeline
couldn't format the string

This patch to fix the '0x0' after line number

Signed-off-by: Wu, BinX <binx.wu@intel.com>