### PR TITLE
tools: sof-dump-status add 'know' for pci hw_name

### DIFF
--- a/tools/sof-dump-status.py
+++ b/tools/sof-dump-status.py
@@ -69,7 +69,7 @@ class clsSYSCardInfo():
 
     def loadPCI(self):
         self.pci_lst.clear()
-        exit_code, output=subprocess.getstatusoutput("lspci |grep audio -i")
+        exit_code, output=subprocess.getstatusoutput("lspci |grep audio -i|grep intel -i")
         # grep exit 1 means nothing matched
         if exit_code != 0:
             return


### PR DESCRIPTION
when target DUT have multiple PCI device
query from intel id list couldn't find target pci id
this patch to fix out of intel PCI device

Signed-off-by: Wu, BinX <binx.wu@intel.com>