### PR TITLE
case-lib: hijack.sh use trap to hijack exit command

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -2,8 +2,9 @@
 
 SUDO_CMD=$(command -v sudo)
 
+trap 'func_exit_handler' EXIT
 # Overwrite other functions' exit to perform environment cleanup
-function exit()
+function func_exit_handler()
 {
     local exit_status=${1:-0}
 


### PR DESCRIPTION
use 'trap' command hijack exit command instead of function
'exit' which perpare for 'set -e'

Signed-off-by: Wu, BinX <binx.wu@intel.com>