### PR TITLE
kmod: update rt5682_i2c codec driver name

### DIFF
--- a/tools/kmod/sof_insert.sh
+++ b/tools/kmod/sof_insert.sh
@@ -27,7 +27,7 @@ insert_module snd_soc_rt5660
 insert_module snd_soc_rt5670
 insert_module snd_soc_rt5677
 insert_module snd_soc_rt5677_spi
-insert_module snd_soc_rt5682
+insert_module snd_soc_rt5682_i2c
 insert_module snd_soc_rt5682_sdw
 
 insert_module snd_soc_pcm512x_i2c

--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -80,6 +80,7 @@ remove_module snd_soc_rt5670
 remove_module snd_soc_rt5677
 remove_module snd_soc_rt5677_spi
 remove_module snd_soc_rt5682_sdw
+remove_module snd_soc_rt5682_i2c
 remove_module snd_soc_rt5682
 remove_module snd_soc_rl6231
 remove_module snd_soc_rl6347a


### PR DESCRIPTION
rt5682 i2c driver is spilt from rt5682 codec driver.

Signed-off-by: Bard Liao <yung-chuan.liao@linux.intel.com>

The kernel change is https://github.com/bardliao/linux/commit/a50067d4f3c1d60d3fa07584aa6a0f897c1ac5b6
