### PR TITLE
kmod: support snd_soc_rt5682_i2c

### DIFF
--- a/tools/kmod/sof_insert.sh
+++ b/tools/kmod/sof_insert.sh
@@ -29,6 +29,7 @@ insert_module snd_soc_rt5677
 insert_module snd_soc_rt5677_spi
 insert_module snd_soc_rt5682
 insert_module snd_soc_rt5682_sdw
+insert_module snd_soc_rt5682_i2c
 
 insert_module snd_soc_pcm512x_i2c
 insert_module snd_soc_wm8804_i2c

--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -79,6 +79,7 @@ remove_module snd_soc_rt5660
 remove_module snd_soc_rt5670
 remove_module snd_soc_rt5677
 remove_module snd_soc_rt5677_spi
+remove_module snd_soc_rt5682_i2c
 remove_module snd_soc_rt5682_sdw
 remove_module snd_soc_rt5682
 remove_module snd_soc_rl6231


### PR DESCRIPTION
new module introduced upstream, fix.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>