### PR TITLE
case-lib: hijack.sh fix trap exit command

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -2,7 +2,7 @@
 
 SUDO_CMD=$(command -v sudo)
 
-trap 'func_exit_handler' EXIT
+trap 'func_exit_handler $?' EXIT
 # Overwrite other functions' exit to perform environment cleanup
 function func_exit_handler()
 {


### PR DESCRIPTION
direct to `trap 'func' exit` command
will load the exit code of exit command
use `trap 'func $?' exit` to passdown exit code
to the function

Signed-off-by: Wu, BinX <binx.wu@intel.com>