### PR TITLE
test-case: verify-sof-firmware-load: update filter of firmware keyword

### DIFF
--- a/test-case/verify-sof-firmware-load.sh
+++ b/test-case/verify-sof-firmware-load.sh
@@ -13,25 +13,26 @@
 ##
 
 # source from the relative path of current folder
-source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
+# shellcheck source=case-lib/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../case-lib/lib.sh"
 
 func_opt_parse_option "$@"
 
-if [ ! "$(alias |grep 'Sub-Test')" ];then
+if alias |grep -q 'Sub-Test' ;then
+    cmd="dmesg"
+else
     # hijack DMESG_LOG_START_LINE which refer dump kernel log in exit function
     DMESG_LOG_START_LINE=$(sof-get-kernel-line.sh|tail -n 1 |awk '{print $1;}')
     cmd="sof-kernel-dump.sh"
-else
-    cmd="dmesg"
 fi
 
 dlogi "Checking SOF Firmware load info in kernel log"
-if [[ $(eval $cmd | grep "] sof-audio.*version") ]]; then
+$cmd | grep -q "sof-audio.*Firmware.*version" && {
     # dump the version info and ABI info
-    eval $cmd | grep "Firmware info" -A1
+    $cmd | grep "Firmware info" -A1
     # dump the debug info
-    eval $cmd | grep "Firmware debug build" -A3
+    $cmd | grep "Firmware debug build" -A3
     exit 0
-else
-    die "Cannot find the sof audio version"
-fi
+}
+
+die "Cannot find the sof audio version"


### PR DESCRIPTION
with replace kern.log file the keyword filter already changed from
'] sof-audio' to 'sof-audio' so need refine the case filter

Signed-off-by: Wu, BinX <binx.wu@intel.com>