### PR TITLE
kmod: add support for snd_soc_sof_da7219_max98373

### DIFF
--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -31,6 +31,7 @@ remove_module snd_sof_xtensa_dsp
 remove_module snd_soc_acpi_intel_match
 
 remove_module snd_soc_sof_rt5682
+remove_module snd_soc_sof_da7219_max98373
 remove_module snd_soc_sst_bdw_rt5677_mach
 remove_module snd_soc_sst_broadwell
 remove_module snd_soc_sst_bxt_da7219_max98357a


### PR DESCRIPTION
add snd_soc_sof_da7219_max98373 support for JSL with da7219
and max98373 codecs.

Signed-off-by: Zhang Keqiao <keqiao.zhang@linux.intel.com>