### PR TITLE
tools/shellcheck-gitrange.bash to add '-x' option

### DIFF
--- a/tools/shellcheck-gitrange.bash
+++ b/tools/shellcheck-gitrange.bash
@@ -31,7 +31,7 @@ main()
         ftype=$(file --brief --mime-type "$fname")
         if  [ x'text/x-shellscript' = x"$ftype" ]; then
             printf '\n\n  ----- shellcheck %s ----\n\n' "$fname"
-            shellcheck "$@" "$fname"  || : $((failed_files++))
+            shellcheck -x "$@" "$fname"  || : $((failed_files++))
         fi
 
     done < <(git diff --name-only --diff-filter=d "$diffrange" -- )


### PR DESCRIPTION
Add '-x' option for shellcheck to fix SC1090 error

Signed-off-by: Wu, BinX <binx.wu@intel.com>