### PR TITLE
[DON't MERGE] check-ipc-flood.sh: check ipc flood test logs from dmesg

### DIFF
--- a/test-case/check-ipc-flood.sh
+++ b/test-case/check-ipc-flood.sh
@@ -53,7 +53,12 @@ do
     }
 
     dlogi "Dumping test logs!"
-    dmesg | grep "IPC Flood count" -A 2
+    if dmesg | grep -q -i "IPC Flood count"; then
+        dmesg | grep "IPC Flood count" -A 2
+    else
+        # dmesg is cleared already, safe to dump dmesg again before exit
+        dloge "No IPC Flood count log in dmesg" && dmesg && exit 1
+    fi
 done
 
 sof-kernel-log-check.sh $KERNEL_LAST_LINE


### PR DESCRIPTION
Make sure IPC flood test results are printed. If the test summary is not
available, it is failed case. This is a fix of false positive case.

[   96.248808] sof-audio-pci 0000:00:1f.3: error: debugfs write failed to idle -16

Signed-off-by: Fred Oh <fred.oh@linux.intel.com>


Related issue is https://github.com/thesofproject/linux/issues/2204
I will debug why ipc flood test is not performed and failed to transit to idle.