### PR TITLE
tools: sof-kernel-log-check: use journalctl command to query kernel log

### DIFF
--- a/case-lib/config.sh
+++ b/case-lib/config.sh
@@ -15,10 +15,11 @@ TPLG_ROOT=${TPLG_ROOT:-/lib/firmware/intel/sof-tplg}
 # example: ignore 'pcms that are HDA Digital & HDA Analog'
 # TPLG_IGNORE_LST['pcm']='HDA Digital,HDA Analog'
 declare -A TPLG_IGNORE_LST
+# shellcheck disable=SC2034 # use by pipeline.sh/func_pipeline_export
 TPLG_IGNORE_LST['pcm']='HDA Digital,Media Playback,DMIC16k'
 
 # Will be set by the lib function, don't need to set
-# Catches the last line of /var/log/kern.log, which will be used by
+# Catches the kernel last line of time stamp by journalctl, which will be used by
 #   sof-kernel-log-check.
 # KERNEL_LAST_LINE
 

--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -41,7 +41,9 @@ fi
 func_lib_setup_kernel_last_line()
 {
     # shellcheck disable=SC2034 # external script will use it
-    KERNEL_LAST_LINE=$(wc -l /var/log/kern.log|awk '{print $1;}')
+    KERNEL_LAST_LINE=$(journalctl --dmesg --no-pager -n 1 -o short-iso-precise|awk '/kernel/ {print $1;}')
+    KERNEL_LAST_LINE=${KERNEL_LAST_LINE:0:-5}
+    KERNEL_LAST_LINE=${KERNEL_LAST_LINE/T/ }
 }
 
 SOF_LOG_COLLECT=0

--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -1,38 +1,39 @@
 #!/bin/bash
 
-begin_line=${1:-1}
+begin_time="${@:-0}"
 declare err_str ignore_str project_key
 err_str="error|failed|timed out|panic|oops"
 ignore_str="error: debugfs write failed to idle -16|error: status|iteration [01]"
 project_key="sof-audio"
 
-[[ ! "$err_str" ]] && echo "Missing error keyword list" && exit 0
-# dmesg KB size buffer size
-#dmesg_config_define=$(awk -F '=' '/CONFIG_LOG_BUF_SHIFT/ {print $2;}' /boot/config-$(uname -r))
-#dmesg_buffer_size=$( echo $(( (1<<$dmesg_config_define) / 1024 )) )
-# kernel file log buffer size
-#kernel_buffer_size=$(du -k /var/log/kern.log |awk '{print $1;}')
-# now decide using which to catch the kernel log
-#[[ $kernel_buffer_size -lt $dmesg ]] && cmd="dmesg" || cmd="sed -n '$begin_line,\$p' /var/log/kern.log"
+[[ ! "$err_str" ]] && {
+    echo "Missing error keyword list"
+    exit 0
+}
 
-# confirm begin_line is number, if it is not the number, direct using dmesg
-[[ "${begin_line//[0-9]/}" ]] && begin_line=0
-[[ "$begin_line" -eq 0 ]] && cmd="dmesg" || cmd="sed -n '$begin_line,\$p' /var/log/kern.log"
-
-#echo "run $0 with parameter '$*' for check kernel message error"
+if [ "X$begin_time" == "X0" ]; then
+    cmd="dmesg"
+else
+    date -d "$begin_time" +'%F %T' > /dev/null || {
+        echo "Error parameter for date: $begin_time"
+        echo "Support date format: date +'%F %T'"
+        exit 0
+    }
+    cmd="journalctl --dmesg --no-pager --no-hostname -o short-precise --since='$begin_time'"
+fi
 
 if [ "$ignore_str" ]; then
-    err=$(eval $cmd|grep 'Call Trace' -A5 -B3)$(eval $cmd | grep $project_key | grep -E "$err_str"|grep -vE "$ignore_str")
+    err=$("$cmd" |grep 'Call Trace' -A5 -B3)$("$cmd" | grep $project_key | grep -E "$err_str"|grep -vE "$ignore_str")
 else
-    err=$(eval $cmd|grep 'Call Trace' -A5 -B3)$(eval $cmd | grep $project_key | grep -E "$err_str")
+    err=$("$cmd" |grep 'Call Trace' -A5 -B3)$("$cmd" | grep $project_key | grep -E "$err_str")
 fi
 
 if [ "$err" ]; then
-    echo `date -u '+%Y-%m-%d %T %Z'` "[ERROR]" "Caught dmesg error"
+    echo "$(date -u '+%F %T %Z') [ERROR] Caught dmesg error"
     echo "===========================>>"
     echo "$err"
     echo "<<==========================="
-    builtin exit 1
+    exit 1
 fi
 
-builtin exit 0
+exit 0


### PR DESCRIPTION
use journalctl command instead of query the begin line from /var/log/kern.log file

Signed-off-by: Wu, BinX <binx.wu@intel.com>