### PR TITLE
case-lib: fix pulseaudio restore couldn't work

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -90,9 +90,9 @@ sudo()
     case $SUDO_LEVEL in
         '0')    cmd="$*" # as root
         ;;
-        '1')    cmd="$SUDO_CMD env 'PATH=$PATH' $*" # sudo without passwd
+        '1')    cmd="$SUDO_CMD --preserve-env=PATH $*" # sudo without passwd
         ;;
-        '2')    cmd="echo '$SUDO_PASSWD' | $SUDO_CMD -S env 'PATH=$PATH' $*" # sudo need passwd
+        '2')    cmd="echo '$SUDO_PASSWD' | $SUDO_CMD -S --preserve-env=PATH $*" # sudo need passwd
         ;;
         *)      # without sudo permission
             dlogw "Need root privilege to run $*"


### PR DESCRIPTION
1. hijack.sh modify sudo function:
use `--preserve-env=PATH` instead of `env 'PATH=$PATH'`
which can be worked at 20.04 test environment

2. remove 'nohup' for `sudo` command to avoid reset `sudo`

3. kill extend 'sudo' process for pulseaudio after restore finish

Signed-off-by: Wu, BinX <binx.wu@intel.com>

PS: see also #289 