### PR TITLE
tools: pipeline filtering enhancement

### DIFF
--- a/tools/sof-tplgreader.py
+++ b/tools/sof-tplgreader.py
@@ -45,6 +45,7 @@ class clsTPLGReader:
                 pgas = formatter.find_comp_for_pcm(pcm, 'PGA')
                 eqs = formatter.find_comp_for_pcm(pcm, 'EQ')
                 kwds = formatter.find_comp_for_pcm(pcm, 'KPBM')
+                asrcs = formatter.find_comp_for_pcm(pcm, 'ASRC')
                 pipeline_dict = {}
                 pipeline_dict['pcm'] = pcm["pcm_name"]
                 pipeline_dict['id'] = str(pcm["pcm_id"])
@@ -54,6 +55,7 @@ class clsTPLGReader:
                 clsTPLGReader.attach_comp_to_pipeline(pgas, pcm['capture'], "PGA", pipeline_dict)
                 clsTPLGReader.attach_comp_to_pipeline(eqs, pcm['capture'], "EQ", pipeline_dict)
                 clsTPLGReader.attach_comp_to_pipeline(kwds, pcm['capture'], "KPBM", pipeline_dict)
+                clsTPLGReader.attach_comp_to_pipeline(asrcs, pcm['capture'], "ASRC", pipeline_dict)
                 # supported formats of playback pipeline in formats[0]
                 # supported formats of capture pipeline in formats[1]
                 formats = TplgFormatter.get_pcm_fmt(pcm)
@@ -70,6 +72,7 @@ class clsTPLGReader:
                     cap = pcm["caps"][pcm['playback']]
                     clsTPLGReader.attach_comp_to_pipeline(pgas, 0, "PGA", pb_pipeline_dict)
                     clsTPLGReader.attach_comp_to_pipeline(eqs, 0, "EQ", pb_pipeline_dict)
+                    clsTPLGReader.attach_comp_to_pipeline(asrcs, 0, "ASRC", pb_pipeline_dict)
                     pb_pipeline_dict["fmts"] = " ".join(formats[pcm['playback']])
                     pb_pipeline_dict['fmt'] = pb_pipeline_dict['fmts'].split(' ')[0]
                     pb_pipeline_dict['rate_min'], pb_pipeline_dict['rate_max'] = self._key2str(cap, 'rate')

--- a/tools/sof-tplgreader.py
+++ b/tools/sof-tplgreader.py
@@ -19,6 +19,13 @@ class clsTPLGReader:
     def _key2str(self, cap, key):
         return cap["%s_min" % (key)], cap["%s_max" % (key)]
 
+    @staticmethod
+    def attach_comp_to_pipeline(comps, comp_index, comp_name, pipeline_dict):
+        comp = comps[comp_index]
+        if comp != []:
+            comp_names = [i['name'] for i in comp]
+            pipeline_dict[comp_name.lower()] = " ".join(comp_names)
+
     # fork & split from TplgFormatter
     def loadFile(self, filename, sofcard=0):
         tplg_parser = TplgParser()
@@ -43,18 +50,10 @@ class clsTPLGReader:
                 pipeline_dict['id'] = str(pcm["pcm_id"])
                 pipeline_dict['type'] = TplgFormatter.get_pcm_type(pcm)
                 cap = pcm["caps"][pcm['capture']]
-                pga = pgas[pcm['capture']]
-                if pga != []:
-                    pga_names = [i['name'] for i in pga]
-                    pipeline_dict['pga'] = " ".join(pga_names)
-                eq = eqs[pcm['capture']]
-                if eq != []:
-                    eq_names = [i['name'] for i in eq]
-                    pipeline_dict['eq'] = " ".join(eq_names)
-                kwd = kwds[pcm['capture']]
-                if kwd != []:
-                    kwd_comp_names = [i['name'] for i in kwd]
-                    pipeline_dict['kwd'] = " ".join(kwd_comp_names)
+                # acquire component from pipeline graph, and add to pipeline dict
+                clsTPLGReader.attach_comp_to_pipeline(pgas, pcm['capture'], "PGA", pipeline_dict)
+                clsTPLGReader.attach_comp_to_pipeline(eqs, pcm['capture'], "EQ", pipeline_dict)
+                clsTPLGReader.attach_comp_to_pipeline(kwds, pcm['capture'], "KPBM", pipeline_dict)
                 # supported formats of playback pipeline in formats[0]
                 # supported formats of capture pipeline in formats[1]
                 formats = TplgFormatter.get_pcm_fmt(pcm)
@@ -69,14 +68,8 @@ class clsTPLGReader:
                     pb_pipeline_dict = pipeline_dict.copy()
                     pb_pipeline_dict["type"] = "playback"
                     cap = pcm["caps"][pcm['playback']]
-                    pga = pgas[0] # idx 0 is playback PGA
-                    if pga != []:
-                        pga_names = [i['name'] for i in pga]
-                        pb_pipeline_dict['pga'] = " ".join(pga_names)
-                    eq = eqs[0]
-                    if eq != []:
-                        eq_names = [i['name'] for i in eq]
-                        pb_pipeline_dict['eq'] = " ".join(eq_names)
+                    clsTPLGReader.attach_comp_to_pipeline(pgas, 0, "PGA", pb_pipeline_dict)
+                    clsTPLGReader.attach_comp_to_pipeline(eqs, 0, "EQ", pb_pipeline_dict)
                     pb_pipeline_dict["fmts"] = " ".join(formats[pcm['playback']])
                     pb_pipeline_dict['fmt'] = pb_pipeline_dict['fmts'].split(' ')[0]
                     pb_pipeline_dict['rate_min'], pb_pipeline_dict['rate_max'] = self._key2str(cap, 'rate')

--- a/tools/tplgtool.py
+++ b/tools/tplgtool.py
@@ -701,14 +701,12 @@ class TplgFormatter:
                 TplgFormatter.recursive_search_comp(elem, comp_type, comp_list, direction)
 
         if type(node) != list and direction == "forward":
-            if node["widget"]["name"].startswith(comp_type) or \
-                node["widget"]["sname"].startswith(comp_type):
+            if node["widget"]["name"].startswith(comp_type):
                 if not comp_in_list(node, comp_list): comp_list.append(node["widget"])
             TplgFormatter.recursive_search_comp(node["sink"], comp_type, comp_list, direction)
 
         if type(node) != list and direction == "backward":
-            if node["widget"]["name"].startswith(comp_type) or \
-                node["widget"]["sname"].startswith(comp_type):
+            if node["widget"]["name"].startswith(comp_type):
                 if not comp_in_list(node, comp_list): comp_list.append(node["widget"])
             TplgFormatter.recursive_search_comp(node["source"], comp_type, comp_list, direction)
 

--- a/tools/tplgtool.py
+++ b/tools/tplgtool.py
@@ -814,11 +814,11 @@ if __name__ == "__main__":
         # this function is used to deal with multiple connections.
         def inner_init(graph, head):
             if head["sink"] != None and type(head) != list:
-                graph.node(name=head["name"],)
+                graph.node(name=head["name"])
                 init_node(graph, head["sink"])
             elif head["sink"] != None:
                 for node in head["sink"]:
-                    init_node(graph, node,)
+                    init_node(graph, node)
             else :
                 graph.node(name=head["name"])
 


### PR DESCRIPTION
- enhance pipeline searching logic to support complex graph search
- add support for filterg KWD pipeline
- add support for filtering pipeline with ASRC

Usage: 
- get KWD pipeline: `sof-tplgreader.py -f "kpbm" tplg-name`
- get all pipelines: `sof-tplgreader.py tplg-name` or `sof-tplgreader.py -f "type:any" tplg-name`
- get pipelines with eq: `sof-tplgreader.py -f "eq" tplg-name` or `sof-tplgreader.py -f "eq:any" tplg-name`
- get playback pipelines: `sof-tplgreader.py -f "type:playback" tplg-name`
- get capture pipelines exclude KWD pipeline: `sof-tplgreader.py -f "type:capture" tplg-name`  KWD pipeline is hidden, current test case cannot handle it.
- get pipelines without eq: `sof-tplgreader.py -f "~eq" tplg-name`
- get pipelines with PGA but without eq: `sof-tplgreader.py -f "pga & ~eq" tplg-name`
- get pipelines with PGA or with eq: `sof-tplgreader.py -f "pga | eq" tplg-name`