### PR TITLE
tools: sort pipeline by numerical ID

### DIFF
--- a/tools/sof-tplgreader.py
+++ b/tools/sof-tplgreader.py
@@ -14,7 +14,7 @@ class clsTPLGReader:
         self._ignore_lst = []
 
     def __comp_pipeline(self, pipeline):
-        return pipeline['id']
+        return int(pipeline['id'])
 
     def _key2str(self, cap, key):
         return cap["%s_min" % (key)], cap["%s_max" % (key)]


### PR DESCRIPTION
Pipeline ID acquired from binary topology
is a string, we should sort pipeline by
numerical ID.

This patch converts string ID to numerical
ID when sorting pipeline.

Fixes: #284

Signed-off-by: Amery Song <chao.song@intel.com>