### PR TITLE
Remove sof-audio before scanning dmesg for error and Ignore known issues

### DIFF
--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -22,6 +22,10 @@ ignore_str="$ignore_str"'|error: debugfs write failed to idle -16'
 # Possible fix - https://github.com/thesofproject/linux/pull/1984
 ignore_str="$ignore_str"'|Parity error detected'
 
+# CML Helios known issue related with xhci_hcd
+# https://bugzilla.kernel.org/show_bug.cgi?id=202541
+ignore_str="$ignore_str"'|xhci_hcd 0000:00:14.0: WARN Set TR Deq Ptr cmd failed due to incorrect slot or ep state'
+
 [[ ! "$err_str" ]] && echo "Missing error keyword list" && exit 0
 # dmesg KB size buffer size
 #dmesg_config_define=$(awk -F '=' '/CONFIG_LOG_BUF_SHIFT/ {print $2;}' /boot/config-$(uname -r))

--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -18,6 +18,10 @@ ignore_str="$ignore_str"'|error: status'
 # TODO explain
 ignore_str="$ignore_str"'|error: debugfs write failed to idle -16'
 
+# Realtek codecs thrown an error on startup, checking with Realtek
+# Possible fix - https://github.com/thesofproject/linux/pull/1984
+ignore_str="$ignore_str"'|Parity error detected'
+
 [[ ! "$err_str" ]] && echo "Missing error keyword list" && exit 0
 # dmesg KB size buffer size
 #dmesg_config_define=$(awk -F '=' '/CONFIG_LOG_BUF_SHIFT/ {print $2;}' /boot/config-$(uname -r))

--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -3,7 +3,6 @@
 begin_line=${1:-1}
 declare err_str ignore_str project_key
 err_str="error|failed|timed out|panic|oops"
-project_key="sof-audio"
 
 # There will be debug logs at each failed initializaiton of DSP:
 #   sof-audio-pci 0000:00:1f.3: error: status = 0x00000000 panic = 0x00000000
@@ -35,9 +34,9 @@ ignore_str="$ignore_str"'|error: debugfs write failed to idle -16'
 #echo "run $0 with parameter '$*' for check kernel message error"
 
 if [ "$ignore_str" ]; then
-    err=$(eval $cmd|grep 'Call Trace' -A5 -B3)$(eval $cmd | grep $project_key | grep -E "$err_str"|grep -vE "$ignore_str")
+    err=$(eval $cmd|grep 'Call Trace' -A5 -B3)$(eval $cmd | grep -E "$err_str"|grep -vE "$ignore_str")
 else
-    err=$(eval $cmd|grep 'Call Trace' -A5 -B3)$(eval $cmd | grep $project_key | grep -E "$err_str")
+    err=$(eval $cmd|grep 'Call Trace' -A5 -B3)$(eval $cmd | grep -E "$err_str")
 fi
 
 if [ "$err" ]; then


### PR DESCRIPTION
When scan errors in kernel log in sof-kernel-log-check.sh, current code filter "sof-audio" first then check for error. This will limit scanning logs and not scalable. Below $project_key is nothing but "sof-audio".

```
err_str="error|failed|timed out|panic|oops"
project_key="sof-audio"

if [ "$ignore_str" ]; then
    err=$(eval $cmd|grep 'Call Trace' -A5 -B3)$(eval $cmd | grep $project_key | grep -E "$err_str"|grep -vE "$ignore_str")
else
    err=$(eval $cmd|grep 'Call Trace' -A5 -B3)$(eval $cmd | grep $project_key | grep -E "$err_str")
fi
```

We should remove this limitation. If we see unrelated error, we can add it to ignoring error list. This is first step toward this approach. I ran first test on APL, CML Helios, ICL RVP. If no objection is raised, I will scan logs for all supported platforms and update ignore_str.