### PR TITLE
fix pulseaudio re-start command line

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -122,12 +122,10 @@ func_lib_restore_pulseaudio()
         fi
     done
     # start pulseaudio
-    local cmd="" user="" line=""
+    local line
     for line in "${PULSECMD_LST[@]}"
     do
-        user=${line%% *}
-        cmd=${line#* }
-        nohup sudo -u "$user" "$cmd" >/dev/null &
+        nohup sudo -u $line >/dev/null &
     done
     # now wait for the pulseaudio restore in the ps process
     timeout=10


### PR DESCRIPTION
When running a kmod-load-unload test locally on a Ubuntu 20.04 machine, it couldn't re-start pulseaudio, the reason was, that the script was trying to start the command in the form '   pulseaudio -D' i.e. with several spaces in front of the executable name and that didn't work. Whereas just using the line as obtained from "ps" output works.

I'm not sure how reliable this solution is. But it also boils down to whether we should use `ps` output to re-start pulseaudio or just use `pulseaudio --start`. Maybe the latter would be more reliable.