### PR TITLE
env-check: add sof-dyndbg.conf file check

### DIFF
--- a/env-check.sh
+++ b/env-check.sh
@@ -35,7 +35,7 @@ func_check_python_pkg graphviz
 
 # check for the tools folder
 old_path=$PWD
-cd $(dirname $0)/tools/
+cd "$(dirname "$0")/tools/"
 out_str="" check_res=0
 echo -ne "Check for tools folder:\t\t"
 
@@ -49,8 +49,8 @@ echo -ne "Check for tools folder:\t\t"
     echo -e "\e[31mWarning\e[0m\nSolution:"$out_str
 
 out_str="" check_res=0
-cd $old_path
-cd $(dirname $0)/test-case/
+cd "$old_path"
+cd "$(dirname "$0")/test-case/"
 echo -ne "Checking for case folder:\t\t"
 [[ "$(stat -c "%A" * |grep -v 'x')" ]] && check_res=1 && out_str="\n
 \tMissing execution permission of script/binary in test-case folder\n
@@ -60,7 +60,7 @@ echo -ne "Checking for case folder:\t\t"
 \tchmod a+x test-case/*\e[0m"
 [[ $check_res -eq 0 ]] && echo "pass" || \
     echo -e "\e[31mWarning\e[0m\nSolution:"$out_str
-cd $old_path
+cd "$old_path"
 
 out_str="" check_res=0
 echo -ne "Checking the permission:\t\t"
@@ -99,7 +99,7 @@ check_res=1 && out_str=$out_str"\n
 
 out_str="" check_res=0
 echo -ne "Checking the config setup:\t\t"
-source  $(dirname $0)/case-lib/config.sh
+source  "$(dirname "$0")/case-lib/config.sh"
 # effect check
 case "$SUDO_LEVEL" in
     '0'|'1'|'2')

--- a/env-check.sh
+++ b/env-check.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# enable dynamic debug logs for SOF modules
+DYNDBG="/etc/modprobe.d/sof-dyndbg.conf"
+
 # check for the system package
 out_str=""
 func_check_pkg(){
@@ -24,12 +27,21 @@ func_check_python_pkg(){
     fi
 }
 
+func_check_file(){
+    if [ -e "$1" ]; then
+        return
+    fi
+    out_str=$out_str"\nOptional: Enable dynamic debug logs on \e[31m $1 \e[0m file\n\tFor example,\n\toptions snd_sof dyndbg=+p\n\toptions snd_sof_pci dyndbg=+p"
+    check_res=1
+}
+
 check_res=0
 echo -ne "Check for the package:\t\t"
 func_check_pkg expect
 func_check_pkg aplay
 func_check_pkg python3
 func_check_python_pkg graphviz
+func_check_file "$DYNDBG"
 [[ $check_res -eq 0 ]] && echo "pass" || \
     echo -e "\e[31mWarning\e[0m\nSolution:"$out_str
 


### PR DESCRIPTION
Check sof-dyndbg.conf available in the system, give optional warning and
print short usage of dyndbg for SOF modules.