### PR TITLE
case-lib: fix case exit early caused by sof-logger

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -16,7 +16,10 @@ function func_exit_handler()
             sleep 1s
         }
         local loggerBin; loggerBin=$(basename "$SOFLOGGER")
-        sudo pkill -9 "$loggerBin" 2>/dev/null
+        sudo pkill -9 "$loggerBin" 2>/dev/null || {
+            dloge "sof-logger was already dead"
+            exit_status=1
+        }
         sleep 1s
     fi
     # when case ends, store kernel log


### PR DESCRIPTION
Once DSP hangs, sof-logger will exit early before
we explicitly kill it. Test case will exit due to
the failure of killing sof-logger if we have 'set -e'
in the case.

This patch makes the kill of sof-logger always return
true.

Signed-off-by: Amery Song <chao.song@intel.com>