### PR TITLE
hijack.sh: print a call trace on every failure

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -8,6 +8,21 @@ function func_exit_handler()
 {
     local exit_status=${1:-0}
 
+    # call trace
+    if [ "$exit_status" -ne 0 ] ; then
+        dloge "Starting ${FUNCNAME[0]}(), exit status=$exit_status, FUNCNAME stack:"
+        local i line_no
+
+        for i in $(seq 1 $((${#FUNCNAME[@]}-1))); do
+
+            line_no=${BASH_LINENO[$((i-1))]} || true
+            # BASH_LINENO doesn't always work
+            if [ $line_no -gt 1 ]; then line_no=":$line_no"; else line_no=""; fi
+
+            dloge " ${FUNCNAME[i]}()  @  ${BASH_SOURCE[i]}${line_no}"
+        done
+    fi
+
     # when sof logger collect is open
     if [ "X$SOF_LOG_COLLECT" == "X1" ]; then
         # when error occurs, exit and catch etrace log


### PR DESCRIPTION
Example:
```
06:03:34 UTC [WARNING] No sof-logger found
06:03:34 UTC [INFO] no source file, use /dev/zero as dummy playback source
06:03:34 UTC [ERROR] No available topology for pipeline export
06:03:34 UTC [ERROR] Starting func_exit_handler(), exit status=1, FUNCNAME stack:
06:03:34 UTC [ERROR]    die()  @  ./test-case/../case-lib/lib.sh
06:03:34 UTC [ERROR]    func_pipeline_export()  @  sof-test/case-lib/pipeline.sh:11
06:03:34 UTC [ERROR]    main()  @  ./test-case/check-playback.sh:71
06:03:34 UTC [WARNING] No sof-logger found
06:03:35 UTC [ERROR] sof-logger was already dead
06:03:36 UTC [INFO] Test Result: FAIL!
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>