### PR TITLE
run-all-tests.sh: print results at the end of the (long!) output

### DIFF
--- a/test-case/run-all-tests.sh
+++ b/test-case/run-all-tests.sh
@@ -34,7 +34,9 @@ suspend-resume-with-capture"
 
 main()
 {
-	local failures=0
+	local failures=()
+	local passed=()
+
 	local time_delay=3
 
 	while getopts "hT:" OPTION; do
@@ -53,13 +55,18 @@ main()
 		printf "\033[40;32m ---------- \033[0m\n"
 		printf "\033[40;32m ---------- \033[0m\n"
 		printf "\033[40;32m starting test_%s \033[0m\n" "$t"
-		"test_$t" || : $((failures++))
+		if "test_$t"; then passed+=( "$t" ); else failures+=( "$t" ); fi
 		
 		sleep "$time_delay"
 	done
 
-	printf "\033[40;32m test end with %d failed\033[0m\n" "$failures"
-	exit "$failures"
+	printf "\n\nPASS:"; printf ' %s;' "${passed[@]}"
+	if [ "${#failures[@]}" -gt 0 ]; then
+	    printf "\nFAIL:"; printf ' %s;' "${failures[@]}"
+	fi
+
+	printf "\n\n\033[40;32m test end with %d failed tests\033[0m\n\n" "${#failures[@]}"
+	exit "${#failures[@]}"
 }
 
 test_firmware-presence()


### PR DESCRIPTION
Sample output (with artificially modified testlist):
```
PASS: tplg-binary;
FAIL: firmware-presence; sof-logger; firmware-load;
 test end with 3 failed tests
```
Or:
```
PASS: firmware-presence; firmware-load; tplg-binary;
 test end with 0 failed tests
```
We should not keep investing in this script but rather find and re-use
some existing test runner instead. For instance git has an impressive
test runner for tests in shell script. On the other hand, 6 extra lines
of code is very little additional technical debt for a short summary of
which tests passed and failed. This saves grepping a very long test log
- even worse - scrolling up and down and missing failures.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>