### PR TITLE
verify-sof-firmware-load: stop using dmesg; ring buffers can expire

### DIFF
--- a/test-case/verify-sof-firmware-load.sh
+++ b/test-case/verify-sof-firmware-load.sh
@@ -3,9 +3,9 @@
 ##
 ## Case Name: verify-sof-firmware-load
 ## Description:
-##    Check if the SOF fw loaded successfully in dmesg
+##    Check if the SOF fw loaded successfully in the kernel logs
 ## Case step:
-##    Check dmesg to search fw load info
+##    Check kernel logs to search fw load info
 ## Expect result:
 ##    Get fw version info in dmesg
 ##    sof-audio-pci 0000:00:0e.0: Firmware info: version 1:1:0-e5fe2
@@ -22,15 +22,15 @@ if [ ! "$(alias |grep 'Sub-Test')" ];then
     DMESG_LOG_START_LINE=$(sof-get-kernel-line.sh|tail -n 1 |awk '{print $1;}')
     cmd="sof-kernel-dump.sh"
 else
-    cmd="dmesg"
+    cmd="journalctl --dmesg"
 fi
 
 dlogi "Checking SOF Firmware load info in kernel log"
-if [[ $(eval $cmd | grep "] sof-audio.*version") ]]; then
+if $cmd | grep -q " sof-audio.*version"; then
     # dump the version info and ABI info
-    eval $cmd | grep "Firmware info" -A1
+    $cmd | grep "Firmware info" -A1 | head -n 12
     # dump the debug info
-    eval $cmd | grep "Firmware debug build" -A3
+    $cmd | grep "Firmware debug build" -A3 | head -n 12
     exit 0
 else
     die "Cannot find the sof audio version"


### PR DESCRIPTION
Switch to journalctl --dmesg which is slower because it gets the log
from boot which means it works.

Also remove the useless and confusing eval and the useless [ ]
test. Switch one grep to grep -q to avoid generating a massive string
and cap the other two to just 12 lines (enough to see some repetition if
any)

This was tricky to reproduce because it required some indirection script
like run-all-tests.sh.

Good reminder to gradually get rid of dmesg everywhere.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>