### PR TITLE
Add set -e to 5 basic tests

### DIFF
--- a/test-case/check-capture.sh
+++ b/test-case/check-capture.sh
@@ -16,6 +16,8 @@
 ##    The return value of arecord is 0
 ##
 
+set -e
+
 # shellcheck source=case-lib/lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 

--- a/test-case/check-capture.sh
+++ b/test-case/check-capture.sh
@@ -16,9 +16,10 @@
 ##    The return value of arecord is 0
 ##
 
-source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
+# shellcheck source=case-lib/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
+OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $''TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
 OPT_OPT_lst['r']='round'     OPT_DESC_lst['r']='round count'

--- a/test-case/check-playback.sh
+++ b/test-case/check-playback.sh
@@ -16,6 +16,8 @@
 ##    The return value of aplay is 0
 ##
 
+set -e
+
 # shellcheck source=case-lib/lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 

--- a/test-case/check-playback.sh
+++ b/test-case/check-playback.sh
@@ -16,9 +16,10 @@
 ##    The return value of aplay is 0
 ##
 
-source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
+# shellcheck source=case-lib/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
+OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $''TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
 OPT_OPT_lst['r']='round'     OPT_DESC_lst['r']='round count'

--- a/test-case/verify-firmware-presence.sh
+++ b/test-case/verify-firmware-presence.sh
@@ -13,6 +13,8 @@
 ##    list target firmware md5sum
 ##
 
+set -e
+
 # source from the relative path of current folder
 # shellcheck source=case-lib/lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh

--- a/test-case/verify-pcm-list.sh
+++ b/test-case/verify-pcm-list.sh
@@ -14,6 +14,8 @@
 ##    pipeline list is same as pcm list
 ##
 
+set -e
+
 # source from the relative path of current folder
 # shellcheck source=case-lib/lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")/../case-lib/lib.sh"

--- a/test-case/verify-pcm-list.sh
+++ b/test-case/verify-pcm-list.sh
@@ -15,9 +15,10 @@
 ##
 
 # source from the relative path of current folder
-source "$(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh"
+# shellcheck source=case-lib/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")/../case-lib/lib.sh"
 
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
+OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $''TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="${TPLG:-}"
 
 func_opt_parse_option "$@"

--- a/test-case/verify-tplg-binary.sh
+++ b/test-case/verify-tplg-binary.sh
@@ -13,6 +13,8 @@
 ##    list topology files md5sum
 ##
 
+set -e
+
 # source from the relative path of current folder
 # shellcheck source=case-lib/lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh

--- a/test-case/verify-tplg-binary.sh
+++ b/test-case/verify-tplg-binary.sh
@@ -14,9 +14,10 @@
 ##
 
 # source from the relative path of current folder
-source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
+# shellcheck source=case-lib/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
+OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $''TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
 func_opt_parse_option "$@"


### PR DESCRIPTION
Now that we have commit 1aef6b9a18e7 ("print a call trace on every
failure") any premature exit is easy to locate even if doesn't print any
error.

Incremental progress towards issue #312 "add set -e to all
tests". Provides some decent coverage of case-lib/*.sh routines while
carefully avoiding any big disruption.

Will also help detect failures to start the logger when combined with
some other, incoming work.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>