### PR TITLE
[DO NOT MERGE]test-case: smart amplifier case workaround to run on master FW

### DIFF
--- a/test-case/check-smart-amplifier.sh
+++ b/test-case/check-smart-amplifier.sh
@@ -98,14 +98,16 @@ do
         file="$tmp_dir/tmp_wave_${fmt%_*}.wav"
         recorded_file="$tmp_dir/recorded_tmp_wave_${fmt%_*}.wav"
         wavetool.py -gsine -A0.8 -B"${fmt%_*}" -o"$file"
-        dlogc "aplay -D$pb_dev -r $pb_rate -c $pb_chan -f $fmt -d $duration -q $file &"
-        aplay -D"$pb_dev" -r "$pb_rate" -c "$pb_chan" -f "$fmt" -d "$duration" -v -q "$file" &
-        dlogc "arecord -D$cp_dev -r $cp_rate -c $cp_chan -f $fmt -d $duration -q $recorded_file"
-        arecord -D"$cp_dev" -r "$cp_rate" -c "$cp_chan" -f "$fmt" -d "$duration" -v -q "$recorded_file"
+        dlogc "arecord -D$cp_dev -r $cp_rate -c $cp_chan -f $fmt -d $duration -v -q $recorded_file &"
+        arecord -D"$cp_dev" -r "$cp_rate" -c "$cp_chan" -f "$fmt" -d "$duration" -v -q "$recorded_file" &
+        sleep 0.5
+        dlogc "aplay -D$pb_dev -r $pb_rate -c $pb_chan -f $fmt -d $duration -v -q $file"
+        aplay -D"$pb_dev" -r "$pb_rate" -c "$pb_chan" -f "$fmt" -d "$duration" -v -q "$file"
         dlogi "Comparing recorded wave and reference wave"
         wavetool.py -a"smart_amp" -R"$recorded_file" -r"$file" || die "wavetool.py exit with $?"
         # clean up generated wave files
         rm -rf "$file" "$recorded_file"
+        sleep 2
     done
 done
 


### PR DESCRIPTION
The smart amplifier case can only run under some
special sequence of aplay/arecord with delay.

This workaround is used to cope with the latest
release, after the release, this workaround should
be reverted or the delay between aplay and arecord
should be removed.

Signed-off-by: Amery Song <chao.song@intel.com>