### PR TITLE
test-case: fix the missing separator in config blob and remove the unused parameter

### DIFF
--- a/test-case/check-keyword-detection.sh
+++ b/test-case/check-keyword-detection.sh
@@ -113,7 +113,8 @@ _update_blob(){
     [ $preamble_time -ge $history_depth ] || {
         die "Warning: invalid arguments, preamble_time must be greater than or equal to history_depth"
     }
-    awk -F "," '{if ( $4 == '"$def_pt"' && $7 == '"$def_hd"' ) $4='"$preamble_time"'; $7='"$history_depth"'}1' "$def_blob" > "$new_blob"
+    awk -F, -v OFS=, '{if ( $4 == '"$def_pt"' && $7 == '"$def_hd"' ) $4='"$preamble_time"'; $7='"$history_depth"'}1' \
+        "$def_blob" > "$new_blob"
     dlogi "kwd config blob is updated to:"
     cat "$new_blob"
     dlogi "write back the new kwd config blob"

--- a/test-case/check-keyword-detection.sh
+++ b/test-case/check-keyword-detection.sh
@@ -37,9 +37,6 @@ OPT_PARM_lst['s']=1                  OPT_VALUE_lst['s']=2100
 OPT_OPT_lst['b']='buffer'            OPT_DESC_lst['b']='buffer size'
 OPT_PARM_lst['b']=1                  OPT_VALUE_lst['b']=67200
 
-OPT_OPT_lst['f']='frequency'         OPT_DESC_lst['f']='target frequency of sine wav'
-OPT_PARM_lst['f']=1                  OPT_VALUE_lst['f']=997
-
 OPT_OPT_lst['l']='loop'              OPT_DESC_lst['l']='loop count'
 OPT_PARM_lst['l']=1                  OPT_VALUE_lst['l']=1
 
@@ -51,7 +48,6 @@ func_opt_parse_option "$@"
 tplg=${OPT_VALUE_lst['t']}
 loop_cnt=${OPT_VALUE_lst['l']}
 buffer_size=${OPT_VALUE_lst['b']}
-frequency=${OPT_VALUE_lst['f']}
 history_depth=${OPT_VALUE_lst['s']}
 preamble_time=${OPT_VALUE_lst['p']}
 duration=${OPT_VALUE_lst['d']}


### PR DESCRIPTION
The comma separator is missing when updating the config
blob, which will cause errors when writing it back.

Signed-off-by: Zhang Keqiao <keqiao.zhang@linux.intel.com>