### PR TITLE
check-keyword-detection.sh: fix 5 trivial shellcheck warnings

### DIFF
--- a/test-case/check-keyword-detection.sh
+++ b/test-case/check-keyword-detection.sh
@@ -19,9 +19,10 @@ set -e
 ##
 
 libdir=$(dirname "${BASH_SOURCE[0]}")
+# shellcheck source=case-lib/lib.sh
 source "$libdir"/../case-lib/lib.sh
 
-OPT_OPT_lst['t']='tplg'              OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
+OPT_OPT_lst['t']='tplg'              OPT_DESC_lst['t']='tplg file, default value is env TPLG: $''TPLG'
 OPT_PARM_lst['t']=1                  OPT_VALUE_lst['t']="$TPLG"
 
 OPT_OPT_lst['s']='sof-logger'        OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"


### PR DESCRIPTION
The only warning left 'frequency appears unused' seems legit.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>