### PR TITLE
env-check: add check for more required files and python packages

### DIFF
--- a/env-check.sh
+++ b/env-check.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 mydir=$(cd "$(dirname "$0")"; pwd)
 
 # enable dynamic debug logs for SOF modules
@@ -78,7 +80,7 @@ cd "$mydir"
 \t\e[31mcd ${mydir}\n
 \tchmod a+x tools/*\e[0m"
 [[ $check_res -eq 0 ]] && echo "pass" || \
-    echo -e "\e[31mWarning\e[0m\nSolution:"$out_str
+    echo -e "\e[31mWarning\e[0m\nSolution:$out_str"
 
 out_str="" check_res=0
 echo -ne "Checking for case folder:\t\t"
@@ -89,7 +91,7 @@ echo -ne "Checking for case folder:\t\t"
 \t\e[31mcd ${mydir}\n
 \tchmod a+x test-case/*\e[0m"
 [[ $check_res -eq 0 ]] && echo "pass" || \
-    echo -e "\e[31mWarning\e[0m\nSolution:"$out_str
+    echo -e "\e[31mWarning\e[0m\nSolution:$out_str"
 
 out_str="" check_res=0
 echo -ne "Checking the permission:\t\t"
@@ -125,7 +127,7 @@ check_res=1 && out_str=$out_str"\n
 \t\tPlease create the \e[31mlink\e[0m of your distribution kernel log file at \e[31m/var/log/kern.log\e[0m"
 
 [[ $check_res -eq 0 ]] && echo "pass" || \
-    echo -e "\e[31mWarning\e[0m\nSolution:"$out_str
+    echo -e "\e[31mWarning\e[0m\nSolution:$out_str"
 
 out_str="" check_res=0
 echo -ne "Checking the config setup:\t\t"
@@ -159,4 +161,4 @@ esac
 \t\tthe permissions are properly set up according to instructions."
 
 [[ $check_res -eq 0 ]] && echo "pass" || \
-    echo -e "\e[31mWarning\e[0m\nSolution:"$out_str
+    echo -e "\e[31mWarning\e[0m\nSolution:$out_str"

--- a/env-check.sh
+++ b/env-check.sh
@@ -43,6 +43,8 @@ func_check_pkg expect
 func_check_pkg aplay
 func_check_pkg python3
 func_check_python_pkg graphviz
+func_check_python_pkg numpy
+func_check_python_pkg scipy
 func_check_file "$DYNDBG"
 if [ $check_res -eq 0 ]; then
     printf "pass\n"

--- a/env-check.sh
+++ b/env-check.sh
@@ -37,6 +37,13 @@ func_check_file(){
     check_res=1
 }
 
+func_check_exec_binary() {
+    if ! type "$1" &> /dev/null; then
+        out_str="$out_str""\tExecutable \e[31m $1 \e[0m not found, please put $1 in PATH\n"
+        check_res=1
+    fi
+}
+
 check_res=0
 printf "Checking for some OS packages:\t\t"
 func_check_pkg expect
@@ -46,6 +53,8 @@ func_check_python_pkg graphviz
 func_check_python_pkg numpy
 func_check_python_pkg scipy
 func_check_file "$DYNDBG"
+func_check_exec_binary sof-logger
+func_check_exec_binary sof-ctl
 if [ $check_res -eq 0 ]; then
     printf "pass\n"
 else


### PR DESCRIPTION
This PR improve env-check.sh:
- add check for sof-logger, sof-ctl and sof-*.ldc
- add check for python3-numpy and python3-scipy
- fix some shellcheck warnings