### PR TITLE
verify-sof-firmware-load: fix the last shellcheck warnings and more specific grep

### DIFF
--- a/test-case/verify-sof-firmware-load.sh
+++ b/test-case/verify-sof-firmware-load.sh
@@ -13,11 +13,12 @@
 ##
 
 # source from the relative path of current folder
-source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
+# shellcheck source=case-lib/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
 func_opt_parse_option "$@"
 
-if [ ! "$(alias |grep 'Sub-Test')" ];then
+if ! alias | grep -q 'Sub-Test'; then
     # hijack DMESG_LOG_START_LINE which refer dump kernel log in exit function
     DMESG_LOG_START_LINE=$(sof-get-kernel-line.sh|tail -n 1 |awk '{print $1;}')
     cmd="sof-kernel-dump.sh"

--- a/test-case/verify-sof-firmware-load.sh
+++ b/test-case/verify-sof-firmware-load.sh
@@ -27,7 +27,7 @@ else
 fi
 
 dlogi "Checking SOF Firmware load info in kernel log"
-if $cmd | grep -q " sof-audio.*version"; then
+if $cmd | grep -q " sof-audio.*Firmware.*version"; then
     # dump the version info and ABI info
     $cmd | grep "Firmware info" -A1 | head -n 12
     # dump the debug info


### PR DESCRIPTION
Supersedes #252 