### PR TITLE
case-lib/lib.sh: add new fake_kern_error()

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -125,6 +125,8 @@ func_lib_restore_pulseaudio()
     local line
     for line in "${PULSECMD_LST[@]}"
     do
+        # Both the user and the command are the same $line var :-(
+        # shellcheck disable=SC2086
         nohup sudo -u $line >/dev/null &
     done
     # now wait for the pulseaudio restore in the ps process


### PR DESCRIPTION
Needed to (manually and locally) test our overly complex error handling framework, see for instance PR #354
    
Signed-off-by: Marc Herbert <marc.herbert@intel.com>