### PR TITLE
sof-kernel-log-check: fix last_line / begin_line off-by-one error

### DIFF
--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-begin_line=${1:-1}
+last_line=${1:-0}
+begin_line=$((last_line+1))
+
 declare err_str ignore_str project_key
 err_str="error|failed|timed out|panic|oops"
 


### PR DESCRIPTION
If the last line of kern.log was an error then the _next_ test was failing.

Found thanks to the new fake_kern_error() function submitted separately.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>