### PR TITLE
hijack.sh: fix sudo test for cached credentials or NOPASSWD

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -123,16 +123,9 @@ func_hijack_setup_sudo_level()
     [[ "$SUDO_LEVEL" ]] && return 0
     # root permission, don't need to check
     [[ $UID -eq 0 ]] && SUDO_LEVEL=0 && return 0
-    # now check whether we need sudo passwd using expect
-    if expect >/dev/null <<END
-spawn $SUDO_CMD ls
-expect {
-    "password" {
-        exit 1
-    }
-exit 0
-}
-END
+
+    # Test for either cached credentials or NOPASSWD
+    if $SUDO_CMD --non-interactive true
     then
         SUDO_LEVEL=1 && return 0
     fi


### PR DESCRIPTION
On my system sudo fails to use cached credentials when invoked from
"expect" for some unknown reason. Rather than debugging this, let's
replace the 9 lines long `expect` test with a much simpler one-line "sudo
--non-interactive" test which works perfectly.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>