### PR TITLE
[test]verify-sof-firmware-load: add debug logs for fail case

### DIFF
--- a/test-case/verify-sof-firmware-load.sh
+++ b/test-case/verify-sof-firmware-load.sh
@@ -33,5 +33,8 @@ if $cmd | grep -q " sof-audio.*version"; then
     $cmd | grep "Firmware debug build" -A3 | head -n 12
     exit 0
 else
+    journalctl --dmesg --lines 50
+    journalctl --dmesg | grep -C 1 -i version
+    printf '$cmd was %s\n' "$cmd"
     die "Cannot find the sof audio version"
 fi


### PR DESCRIPTION
Dump last 50 lines from journalctl to check why the test fail.

Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>

Add debug logs to check why the case failed