### PR TITLE
@marc-hb sof-kernel-log-check: narrower ignore_str for ICL reboot issue

### DIFF
--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -2,6 +2,9 @@
 
 begin_line=${1:-1}
 declare err_str ignore_str project_key
+
+platform=$(sof-dump-status.py -p)
+
 err_str="error|failed|timed out|panic|oops"
 
 # TODO explain


### PR DESCRIPTION
2 commits. The main one:

Fixes ac415de ("tools: ignore a false error message with 'panic'")
which was ignoring way too many errors. See previous PR and long source
code comment.

Generally speaking, ignoring errors ("green failures") is extremely
dangerous and should be as narrow as possible.

More specifically here, not even knowing which platforms experience the
issue and what code they print is is really not going to help fix it.