### PR TITLE
test-case: add missing pipeline count acquisition logic

### DIFF
--- a/test-case/multiple-pipeline-capture.sh
+++ b/test-case/multiple-pipeline-capture.sh
@@ -48,6 +48,7 @@ tplg=${OPT_VALUE_lst['t']}
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
 
 max_count=0
+func_pipeline_export $tplg "type:any" # this line will help to get $PIPELINE_COUNT
 # get the min value of TPLG:'pipeline count' with Case:'pipeline count'
 [[ $PIPELINE_COUNT -gt ${OPT_VALUE_lst['c']} ]] && max_count=${OPT_VALUE_lst['c']} || max_count=$PIPELINE_COUNT
 func_lib_setup_kernel_last_line

--- a/test-case/multiple-pipeline-playback.sh
+++ b/test-case/multiple-pipeline-playback.sh
@@ -48,6 +48,7 @@ tplg=${OPT_VALUE_lst['t']}
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
 
 max_count=0
+func_pipeline_export $tplg "type:any" # this line will help to get $PIPELINE_COUNT
 # get the min value of TPLG:'pipeline count' with Case:'pipeline count'
 [[ $PIPELINE_COUNT -gt ${OPT_VALUE_lst['c']} ]] && max_count=${OPT_VALUE_lst['c']} || max_count=$PIPELINE_COUNT
 func_lib_setup_kernel_last_line


### PR DESCRIPTION
The commit 84f5895 wrongly remove the code logic to
acquire pipeline count from multi-pipeline-playback/
capture test cases. This leads to the 'max_count' used
in these scripts being empty, as no pipeline is actually
tested, the test cases will always pass.

This patch adds the pipeline count acquisition logic back.