### PR TITLE
hijack.sh: don't fail yet when sof-logger resists kill -INT

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -39,9 +39,10 @@ function func_exit_handler()
         }
         sleep 1s
         if pgrep "$loggerBin"; then
-            dloge "$loggerBin resisted pkill -INT, using -KILL"
+            # FIXME: https://github.com/thesofproject/sof/issues/3433
+            dlogw "$loggerBin resisted pkill -INT, using -KILL"
             sudo pkill -KILL "$loggerBin"
-            exit_status=2
+            # exit_status=1
         fi
         # logfile is set in a different file: lib.sh
         # shellcheck disable=SC2154


### PR DESCRIPTION
Mitigates #3433 for now.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>