### PR TITLE
hijack.sh: switch first attempt to stop the logger from -INT to -TERM

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -32,17 +32,18 @@ function func_exit_handler()
         }
 
         local loggerBin wcLog; loggerBin=$(basename "$SOFLOGGER")
-        # INT doesn't print any "Killed" message in non-interactive mode
-        sudo pkill -INT "$loggerBin" || {
+        # We need this to avoid the confusion of a "Terminated" message
+        # without context.
+        dlogi "pkill -TERM $loggerBin"
+        sudo pkill -TERM "$loggerBin" || {
             dloge "sof-logger was already dead"
             exit_status=1
         }
         sleep 1s
         if pgrep "$loggerBin"; then
-            # FIXME: https://github.com/thesofproject/sof/issues/3433
-            dlogw "$loggerBin resisted pkill -INT, using -KILL"
+            dloge "$loggerBin resisted pkill -TERM, using -KILL"
             sudo pkill -KILL "$loggerBin"
-            # exit_status=1
+            exit_status=1
         fi
         # logfile is set in a different file: lib.sh
         # shellcheck disable=SC2154


### PR DESCRIPTION
Commit 61271a3a03aa ("logger: stop discarding all error messages and fix
the cleanup code") made two mistakes:

1. It used the -INT signal which doesn't always work. This broke most
   tests.
2. It then misused exit_failure=2 where 2 means Not Applicable. This
  turned most broken tests to green.

Rushed commit a2669ff6591a ("hijack.sh: don't fail yet when sof-logger
resists kill -INT") then downgraded all this to warning to get the tests
passing again. However it didn't deal with the real issue: stopping the
logger on the first try. Switching to TERM does it and will hopefully
close https://github.com/thesofproject/sof/issues/3433

Signed-off-by: Marc Herbert <marc.herbert@intel.com>