### PR TITLE
hijack.sh: don't start a second logger in the exit handler

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -25,11 +25,6 @@ function func_exit_handler()
 
     # when sof logger collect is open
     if [ "X$SOF_LOG_COLLECT" == "X1" ]; then
-        # when error occurs, exit and catch etrace log
-        [[ $exit_status -eq 1 ]] && {
-            func_lib_start_log_collect 1
-            sleep 1s
-        }
 
         local loggerBin wcLog; loggerBin=$(basename "$SOFLOGGER")
         # INT doesn't print any "Killed" message in non-interactive mode


### PR DESCRIPTION
... because it makes no sense.

When a test using the logger fails it produces a confusing error
message like this:
```
2020-09-18 10:17:25 UTC [REMOTE_INFO] Starting /usr/bin/sof-logger
   -l /etc/sof/sof-byt.ldc -o
    /home/ubuntu/sof-test/logs/check-alsabat/<date>/etrace.txt
error: in logger_read(), fread(..., /sys/kernel/debug/sof/etrace)
    failed:  Inappropriate ioctl for device(25)
```
Reported by Pierre in #384

This mistake seems to have been there since the dawn of time however no
one noticed because most things logger-related (and others) have been
silenced so far - which is changing now with #297.

The problem this fixes can be reproduced trivially with this one-line
patch:
```diff
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -125,6 +125,7 @@ func_lib_start_log_collect()
     dlogi "Starting $loggerCmd"
     # Cleaned up by func_exit_handler() in hijack.sh
     sudo "$loggerCmd" &
+    exit 1
 }
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>