### PR TITLE
kmod: add support for SoundWire SDCA 0.6 codecs

### DIFF
--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -72,6 +72,9 @@ remove_module snd_soc_rt711
 remove_module snd_soc_rt1308
 remove_module snd_soc_rt1308_sdw
 remove_module snd_soc_rt715
+remove_module snd_soc_rt711_sdca
+remove_module snd_soc_rt1316_sdw
+remove_module snd_soc_rt715_sdca
 remove_module snd_soc_rt1011
 remove_module snd_soc_rt5640
 remove_module snd_soc_rt5645
@@ -113,6 +116,7 @@ remove_module soundwire_intel
 remove_module soundwire_cadence
 remove_module soundwire_generic_allocation
 remove_module regmap_sdw
+remove_module regmap_sdw_mbq
 remove_module soundwire_bus
 
 remove_module snd_soc_core


### PR DESCRIPTION
Modules need to be removed for kmod remove/insert tests to pass

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>