### PR TITLE
opt.sh: don't print a backtrace after the usage message

### DIFF
--- a/case-lib/opt.sh
+++ b/case-lib/opt.sh
@@ -90,6 +90,7 @@ func_opt_parse_option()
             printf '    -h |  --help\n'
             printf '\tthis message\n'
             _func_case_dump_descption
+            trap - EXIT
             exit 2
         }
 


### PR DESCRIPTION
Fixes #402

Signed-off-by: Marc Herbert <marc.herbert@intel.com>