### PR TITLE
Tools: Fix for printing extra blank after value

### DIFF
--- a/tools/sof-tplgreader.py
+++ b/tools/sof-tplgreader.py
@@ -250,7 +250,7 @@ if __name__ == "__main__":
                 output += str(value) + " "
             else:
                 output += key + "=" + str(value) + ";"
-        return output
+        return output.strip()
 
     def func_export_pipeline(pipeline_lst):
         length = len(pipeline_lst)


### PR DESCRIPTION
The just display value option "-v or --value" for sof-tplgreader.py
outputs after the actual value a space character. It can cause
unexpected issues when utilizing the values in test scripts. The added
strip fixes the issue.

Fixes #408

Signed-off-by: Marc Herbert <marc.herbert@intel.com>
Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>