### PR TITLE
sof-kernel-log-check: ignore i2c error for DELL CML HDA laptop + i915 Type-C error

### DIFF
--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -61,6 +61,11 @@ ignore_str="$ignore_str"'|thermal thermal_zone.*: failed to read out thermal zon
 ignore_str="$ignore_str"'|iwlwifi 0000:00:14\.3: Microcode SW error detected\. Restarting 0x0\.'
 ignore_str="$ignore_str"'|: authentication with ..:..:..:..:..:.. timed out'
 
+# I915, issues reported by sof-test
+# BugLink: https://github.com/thesofproject/sof-test/issues/374
+ignore_str="$ignore_str"'|i915 0000:00:02\.0: \[drm\] ERROR TC cold unblock failed'
+ignore_str="$ignore_str"'|i915 0000:00:02\.0: \[drm\] ERROR TC cold block failed'
+
 # Test cases on some platforms fail because the boot retry message:
 #
 #    sof-audio-pci 0000:00:1f.3: status = 0x00000000 panic = 0x00000000

--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -29,6 +29,10 @@ ignore_str="$ignore_str"'|i2c_designware i2c_designware\.0: controller timed out
 ignore_str="$ignore_str"'|i2c_hid i2c-DELL0955:00: failed to change power setting'
 ignore_str="$ignore_str"'|PM: Device i2c-DELL0955:00 failed to resume async: error -110'
 
+# Dell CML HDA laptop, issues reported by sof-test
+# https://github.com/thesofproject/sof-test/issues/396
+ignore_str="$ignore_str"'|i2c_hid i2c-DELL0955:00: failed to set a report to device\.'
+
 # GLK i2c SRM failed to lock, found while running check-playback-all-formats.sh
 # https://github.com/thesofproject/sof-test/issues/348
 ignore_str="$ignore_str"'|da7219 i2c-DLGS7219:00: SRM failed to lock'


### PR DESCRIPTION
Fixes: #396

Signed-off-by: RuiqingX <ruiqingx.zhang@intel.com>