### PR TITLE
kmod: remove legacy drivers if loaded

### DIFF
--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -27,6 +27,14 @@ remove_module snd_sof_pci
 remove_module snd_sof_acpi
 
 #-------------------------------------------
+# legacy drivers (not used but loaded)
+#-------------------------------------------
+remove_module snd_soc_catpt
+remove_module snd_intel_sst_acpi
+remove_module snd_intel_sst_core
+remove_module snd_soc_sst_atom_hifi2_platform
+
+#-------------------------------------------
 # Machine drivers
 #-------------------------------------------
 remove_module snd_sof_intel_byt


### PR DESCRIPTION
When legacy drivers are built and driver run-time selection, the
sof_remove.sh script fails since a number of modules are in use. These
drivers are actually not doing anything since their probe failed, but
the modules are still loaded.

Remove them explicitly so that the script correctly handles
dependencies.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>