### PR TITLE
lib.sh: fix SOF card ID acquisition logic

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -35,7 +35,7 @@ fi
 
 # setup SOFCARD id
 if [ ! "$SOFCARD" ]; then
-    SOFCARD=$(grep '\]: sof-[a-z]' /proc/asound/cards|awk '{print $1;}')
+    SOFCARD=$(grep 'sof-[a-z]' /proc/asound/cards|awk '{print $1;}')
 fi
 
 func_lib_setup_kernel_last_line()


### PR DESCRIPTION
The SOF card is renamed in linux kernel,
our regular expression for old nameing style
only works under SoundWire and HDAudio. But
SOF card information in /proc/asound/cards
still contains 'sof-[a-z]' pattern.

This patch updates the regular expression for
acquiring SOF card ID.

Fixes: #420

Signed-off-by: Amery Song <chao.song@intel.com>