### PR TITLE
sof-kernel-log-check.sh: change sed -n $begin,\$p to tail -n +$begin 

### DIFF
--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -111,18 +111,19 @@ esac
 # kernel file log buffer size
 #kernel_buffer_size=$(du -k /var/log/kern.log |awk '{print $1;}')
 # now decide using which to catch the kernel log
-#[[ $kernel_buffer_size -lt $dmesg ]] && cmd="dmesg" || cmd="sed -n '$begin_line,\$p' /var/log/kern.log"
+#[[ $kernel_buffer_size -lt $dmesg ]] && cmd="dmesg" || cmd="tail -n  +${begin_line}  /var/log/kern.log"
 
 # confirm begin_line is number, if it is not the number, direct using dmesg
 [[ "${begin_line//[0-9]/}" ]] && begin_line=0
-[[ "$begin_line" -eq 0 ]] && cmd="dmesg" || cmd="sed -n '$begin_line,\$p' /var/log/kern.log"
+[[ "$begin_line" -eq 0 ]] && cmd="dmesg" || cmd="tail -n  +${begin_line}  /var/log/kern.log"
 
 #echo "run $0 with parameter '$*' for check kernel message error"
 
+# declare -p cmd
 if [ "$ignore_str" ]; then
-    err=$(eval $cmd|grep 'Call Trace' -A5 -B3)$(eval $cmd | grep -E "$err_str"|grep -vE "$ignore_str")
+    err=$(   $cmd | grep 'Call Trace' -A5 -B3)$(     $cmd | grep -E "$err_str"|grep -vE "$ignore_str")
 else
-    err=$(eval $cmd|grep 'Call Trace' -A5 -B3)$(eval $cmd | grep -E "$err_str")
+    err=$(   $cmd | grep 'Call Trace' -A5 -B3)$(     $cmd | grep -E "$err_str")
 fi
 
 if [ "$err" ]; then

--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 begin_line=${1:-1}
-declare err_str ignore_str project_key
+declare err_str ignore_str
 
 platform=$(sof-dump-status.py -p)
 
@@ -127,11 +127,9 @@ else
 fi
 
 if [ "$err" ]; then
-    echo `date -u '+%Y-%m-%d %T %Z'` "[ERROR]" "Caught dmesg error"
+    echo "$(date -u '+%Y-%m-%d %T %Z')" "[ERROR]" "Caught dmesg error"
     echo "===========================>>"
     echo "$err"
     echo "<<==========================="
     builtin exit 1
 fi
-
-builtin exit 0


### PR DESCRIPTION
This allows removing "eval" and some quoting headaches.

Also fix the last shellcheck warnings