### PR TITLE
test: adjust the vloume for KWD capture

### DIFF
--- a/test-case/check-keyword-detection.sh
+++ b/test-case/check-keyword-detection.sh
@@ -77,7 +77,7 @@ wov_kctl_id=$(amixer controls |grep "Detector" |awk -F= '{print $2}' |cut -d"," 
 wov_kctl_pga=$(amixer controls |grep "KWD Capture Volume" |awk -F= '{print $4}')
 
 # adjust wov PGA volume
-amixer cset name="$wov_kctl_pga" 45
+amixer cset name="$wov_kctl_pga" 40
 
 # store the default config blob
 _store_default_wov_config_bolb()


### PR DESCRIPTION
During the test, we found that KWD capture volume is a little
bit high. The volume will affect the THDN value and leads WOV
test fails occasionally. Lower the volume to make the WOV test
more stable.

Signed-off-by: Zhang Keqiao <keqiao.zhang@linux.intel.com>