### PR TITLE
config.sh: enable media playback pipeline test

### DIFF
--- a/case-lib/config.sh
+++ b/case-lib/config.sh
@@ -15,7 +15,7 @@ TPLG_ROOT=${TPLG_ROOT:-/lib/firmware/intel/sof-tplg}
 # example: ignore 'pcms that are HDA Digital & HDA Analog'
 # TPLG_IGNORE_LST['pcm']='HDA Digital,HDA Analog'
 declare -A TPLG_IGNORE_LST
-TPLG_IGNORE_LST['pcm']='HDA Digital,Media Playback'
+TPLG_IGNORE_LST['pcm']='HDA Digital'
 
 # Will be set by the lib function, don't need to set
 # Catches the last line of /var/log/kern.log, which will be used by


### PR DESCRIPTION
Media playback pipeline test is blocked in the
early stage of SOF development, maybe because it
caused a lot of trouble.

But as the SOF evolves, we don't have a reason to
continue blocking the test on media playback pipeline
any more.

Signed-off-by: Amery Song <chao.song@intel.com>