### PR TITLE
test-case: add kern.log debug logs in verify-sof-firmware-load

### DIFF
--- a/test-case/verify-sof-firmware-load.sh
+++ b/test-case/verify-sof-firmware-load.sh
@@ -36,7 +36,9 @@ if $cmd | grep -q " sof-audio.*Firmware.*version"; then
     $cmd | grep "Firmware debug build" -A3 | head -n 12
     exit 0
 else
-    $cmd | tail -n 500
+    printf ' ------\n  debuging with /var/log/kern.log  \n ---- \n'
+    ls -alht /var/log/kern.log
+    grep -na "Linux version" /var/log/kern.log || true
     printf ' ------\n  cmd was %s, DMESG_LOG_START_LINE was %s  \n ---- \n' \
             "$cmd" "$DMESG_LOG_START_LINE"
     journalctl --dmesg --lines 50 --no-pager


### PR DESCRIPTION
With previous logs, we can norrow down the empty sof version info is related with
kern.log. Add debug logs to kern.log to help us root cause the issue.

Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>