### PR TITLE
test-case: check-alsabat: remove set -e

### DIFF
--- a/test-case/check-alsabat.sh
+++ b/test-case/check-alsabat.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e
-
 ##
 ## Case Name: check alsabat
 ## Preconditions:


### PR DESCRIPTION
There is error hanlder to upload the failure wav files in this test case.
set -e will skip them

And our lib could not handle the return value 23 from alsabat failure.

Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>

Fix https://github.com/thesofproject/sof-test/issues/441