### PR TITLE
wavetool: lower default threshold for WoV test case

### DIFF
--- a/tools/wavetool.py
+++ b/tools/wavetool.py
@@ -246,7 +246,7 @@ def parse_cmdline():
     parser.add_argument('-R', '--recorded_wave', type=str, help='path of recorded wave')
     parser.add_argument('-Z', '--zero_threshold', type=float, default=-50.3, help='zero threshold in dBFS')
     parser.add_argument('-H', '--hb_time', type=float, default=2.1, help='history buffer size')
-    parser.add_argument('-T', '--threshold', type=float, default=-72.0, help='expected threshold')
+    parser.add_argument('-T', '--threshold', type=float, default=-65.0, help='expected threshold')
     return parser.parse_args()
 
 def main():


### PR DESCRIPTION
For current WoV setup, the THD+N of a captured wave
without any distortion may be lower than -75dB, lower
the default threshold to make WoV test pass.

Signed-off-by: Amery Song <chao.song@intel.com>