### PR TITLE
sof-kernel-log-check: ignore ACPI error for Dell TGL SDW laptop

### DIFF
--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -57,6 +57,11 @@ ignore_str="$ignore_str"'|thermal thermal_zone.*: failed to read out thermal zon
 ignore_str="$ignore_str"'|iwlwifi 0000:00:14\.3: Microcode SW error detected\. Restarting 0x0\.'
 ignore_str="$ignore_str"'|: authentication with ..:..:..:..:..:.. timed out'
 
+# Dell TGL laptop with SoundWire, issues reported by sof-test
+ignore_str="$ignore_str"'|ACPI BIOS Error (bug):'
+ignore_str="$ignore_str"'|ACPI Error:'
+ignore_str="$ignore_str"'|acpi device:00: Failed to change power state to D3hot'
+
 # I915, issues reported by sof-test
 # BugLink: https://github.com/thesofproject/sof-test/issues/374
 ignore_str="$ignore_str"'|i915 0000:00:02\.0: \[drm\] ERROR TC cold unblock failed'


### PR DESCRIPTION
This error is reported in suspend/resume test.

Signed-off-by: Bard Liao <yung-chuan.liao@linux.intel.com>