### PR TITLE
tools: kmod: remove snd_soc_skl

### DIFF
--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -33,6 +33,7 @@ remove_module snd_soc_catpt
 remove_module snd_intel_sst_acpi
 remove_module snd_intel_sst_core
 remove_module snd_soc_sst_atom_hifi2_platform
+remove_module snd_soc_skl
 
 #-------------------------------------------
 # Machine drivers


### PR DESCRIPTION
Now SST driver is enabled alongside with SOF drvier. Need to
remove the SST drivers as well.

Fix: #458

Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>