### PR TITLE
lib: opts: fix format in help

### DIFF
--- a/case-lib/opt.sh
+++ b/case-lib/opt.sh
@@ -93,11 +93,11 @@ func_opt_parse_option()
                 printf '\n\t%s\n' "${OPT_DESC_lst[$i]}"
                 if [ "${OPT_VALUE_lst[$i]}" ]; then
                     if [ "${OPT_PARM_lst[$i]}" -eq 1 ]; then
-                        printf '\tDefault Value: %s' "${OPT_VALUE_lst[$i]}"
+                        printf '\tDefault Value: %s\n' "${OPT_VALUE_lst[$i]}"
                     elif [ "${OPT_VALUE_lst[$i]}" -eq 0 ]; then
-                        printf '\tDefault Value: Off'
+                        printf '\tDefault Value: Off\n'
                     else
-                        printf '\tDefault Value: On'
+                        printf '\tDefault Value: On\n'
                     fi
                 fi
             done


### PR DESCRIPTION
Add missed newline for the default value in help usage
output.

fix: #461

Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>

