### PR TITLE
[RFC] use journalctl for kernel log

### DIFF
--- a/case-lib/config.sh
+++ b/case-lib/config.sh
@@ -20,9 +20,9 @@ declare -A TPLG_IGNORE_LST
 TPLG_IGNORE_LST['pcm']='HDA Digital'
 
 # Will be set by the lib function, don't need to set
-# Catches the last line of /var/log/kern.log, which will be used by
-#   sof-kernel-log-check.
-# KERNEL_LAST_LINE
+# Catches the timestamp for a test case start used by
+# sof-kernel-log-check with journalctl
+# KERNEL_LAST_TIMESTAMP
 
 # If not set will be automatically set by logging_ctl function
 # Test case log root

--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -38,10 +38,10 @@ if [ ! "$SOFCARD" ]; then
     SOFCARD=$(grep 'sof-[a-z]' /proc/asound/cards|awk '{print $1;}')
 fi
 
-func_lib_setup_kernel_last_line()
+func_lib_setup_kernel_last_timestamp()
 {
     # shellcheck disable=SC2034 # external script will use it
-    KERNEL_LAST_LINE=$(wc -l /var/log/kern.log|awk '{print $1;}')
+    KERNEL_LAST_TIMESTAMP=$(date +%s)
 }
 
 # This function adds a fake error to dmesg (which is always saved by

--- a/test-case/check-capture.sh
+++ b/test-case/check-capture.sh
@@ -59,7 +59,7 @@ file_prefix=${OPT_VALUE_lst['f']}
 
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
 
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_last_timestamp
 func_lib_check_sudo
 func_pipeline_export $tplg "type:capture & ${OPT_VALUE_lst['S']}"
 
@@ -106,5 +106,5 @@ do
     done
 done
 
-sof-kernel-log-check.sh $KERNEL_LAST_LINE
+sof-kernel-log-check.sh $KERNEL_LAST_TIMESTAMP
 exit $?

--- a/test-case/check-fw-echo-reference.sh
+++ b/test-case/check-fw-echo-reference.sh
@@ -44,7 +44,7 @@ frequency=${OPT_VALUE_lst['f']}
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
 
 func_pipeline_export $tplg "echo:any"
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_last_timestamp
 
 if [ "$PIPELINE_COUNT" != "2" ]; then
     die "Only detect $PIPELINE_COUNT pipeline(s) from topology, but two are needed"
@@ -93,4 +93,4 @@ do
     done
 done
 
-sof-kernel-log-check.sh "$KERNEL_LAST_LINE"
+sof-kernel-log-check.sh "$KERNEL_LAST_TIMESTAMP"

--- a/test-case/check-ipc-flood.sh
+++ b/test-case/check-ipc-flood.sh
@@ -39,20 +39,20 @@ dlogi "Check sof debug fs environment"
 [[ "$(sudo file $ipc_flood_dfs|grep 'No such file')" ]] && dlogw "${BASH_SOURCE[0]} need $ipc_flood_dfs to run the test case" && exit 2
 dlogi "Checking ipc flood test!"
 
-# cleanup dmesg buffer before test
-sudo dmesg -c > /dev/null
-
 for i in $(seq 1 $loop_cnt)
 do
+    # cleanup dmesg buffer for each iteration
+    sudo dmesg -c > /dev/null
+    # set up timestamp for each iteration
+    func_lib_setup_kernel_last_timestamp
     dlogi "===== [$i/$loop_cnt] loop Begin ====="
     dlogc "sudo bash -c 'echo $lpc_loop_cnt > $ipc_flood_dfs'"
     sudo bash -c "'echo $lpc_loop_cnt > $ipc_flood_dfs'"
 
-    sof-kernel-log-check.sh 0 || die "Catched error in dmesg"
+    # check kernel log for each iteration to catch issues
+    sof-kernel-log-check.sh $KERNEL_LAST_TIMESTAMP || die "Catch error in kernel log"
 
     dlogi "Dumping test logs!"
     dmesg | grep "IPC Flood count" -A 2
-done
 
-sof-kernel-log-check.sh $KERNEL_LAST_TIMESTAMP
-exit 0
+done

--- a/test-case/check-ipc-flood.sh
+++ b/test-case/check-ipc-flood.sh
@@ -32,7 +32,7 @@ loop_cnt=${OPT_VALUE_lst['l']}
 
 [[ ! "$(sof-kernel-dump.sh|grep 'sof-audio'|grep 'Firmware debug build')" ]] && dlogw "${BASH_SOURCE[0]} need debug version firmware" && exit 2
 
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_last_timestamp
 func_lib_check_sudo
 
 dlogi "Check sof debug fs environment"
@@ -54,5 +54,5 @@ do
     dmesg | grep "IPC Flood count" -A 2
 done
 
-sof-kernel-log-check.sh $KERNEL_LAST_LINE
+sof-kernel-log-check.sh $KERNEL_LAST_TIMESTAMP
 exit 0

--- a/test-case/check-keyword-detection.sh
+++ b/test-case/check-keyword-detection.sh
@@ -55,7 +55,7 @@ duration=${OPT_VALUE_lst['d']}
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
 
 func_pipeline_export $tplg "kpbm:any"
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_last_timestamp
 
 if test "$PIPELINE_COUNT" != "1"; then
     die "detected $PIPELINE_COUNT wov pipeline(s) from topology, but 1 is needed"
@@ -154,4 +154,4 @@ do
     done
 done
 
-sof-kernel-log-check.sh "$KERNEL_LAST_LINE"
+sof-kernel-log-check.sh "$KERNEL_LAST_TIMESTAMP"

--- a/test-case/check-kmod-load-unload.sh
+++ b/test-case/check-kmod-load-unload.sh
@@ -33,7 +33,7 @@ OPT_OPT_lst['p']='pulseaudio'   OPT_DESC_lst['p']='disable pulseaudio on the tes
 OPT_PARM_lst['p']=0             OPT_VALUE_lst['p']=1
 
 func_opt_parse_option "$@"
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_last_timestamp
 
 loop_cnt=${OPT_VALUE_lst['l']}
 
@@ -48,7 +48,7 @@ for idx in $(seq 1 $loop_cnt)
 do
     dlogi "===== Starting iteration $idx of $loop_cnt ====="
     ## - 1: remove module section
-    func_lib_setup_kernel_last_line
+    func_lib_setup_kernel_last_timestamp
 
     # After module removal, it takes about 10s for "aplay -l" to show
     # device list, within this 10s, it shows "no soundcard found". Here
@@ -75,10 +75,10 @@ do
 
     ## - 1a: check for errors after removal
     dlogi "checking for general errors after kmod unload with sof-kernel-log-check tool"
-    sof-kernel-log-check.sh "$KERNEL_LAST_LINE" ||
+    sof-kernel-log-check.sh "$KERNEL_LAST_TIMESTAMP" ||
         die "error found after kmod unload is real error, failing"
 
-    func_lib_setup_kernel_last_line
+    func_lib_setup_kernel_last_timestamp
     dlogi "run kmod/sof_insert.sh"
     sudo sof_insert.sh || {
         # FIXME: don't exit the status of dloge(). Use die()
@@ -87,7 +87,7 @@ do
 
     ## - 2a: check for errors after insertion
     dlogi "checking for general errors after kmod insert with sof-kernel-log-check tool"
-    sof-kernel-log-check.sh "$KERNEL_LAST_LINE" ||
+    sof-kernel-log-check.sh "$KERNEL_LAST_TIMESTAMP" ||
         die "Found error(s) in kernel log after module insertion"
 
     dlogi "checking if firmware is loaded successfully"

--- a/test-case/check-pause-release-suspend-resume.sh
+++ b/test-case/check-pause-release-suspend-resume.sh
@@ -110,7 +110,7 @@ esac
 
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
 
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_last_timestamp
 
 dlogi "Entering audio stream expect script with: $cmd -D $pcm -r $rate -c $channel -f $fmt -vv -i $dummy_file -q"
 dlogi "Will enter suspend-resume cycle during paused period of audio stream process"
@@ -180,5 +180,5 @@ if [ $ret -ne 0 ]; then
     [[ $? -ne 0 ]] && dlogw "Kill process catch error"
     exit $ret
 fi
-sof-kernel-log-check.sh $KERNEL_LAST_LINE
+sof-kernel-log-check.sh $KERNEL_LAST_TIMESTAMP
 exit $?

--- a/test-case/check-pause-resume.sh
+++ b/test-case/check-pause-resume.sh
@@ -75,9 +75,10 @@ esac
 [[ -z $file_name ]] && file_name=$dummy_file
 
 func_pipeline_export $tplg "type:$test_mode & ${OPT_VALUE_lst['S']}"
-func_lib_setup_kernel_last_timestamp
 for idx in $(seq 0 $(expr $PIPELINE_COUNT - 1))
 do
+    # set up timestamp for each iteration
+    func_lib_setup_kernel_last_timestamp
     channel=$(func_pipeline_parse_value $idx channel)
     rate=$(func_pipeline_parse_value $idx rate)
     fmt=$(func_pipeline_parse_value $idx fmt)
@@ -122,9 +123,6 @@ END
         [[ $? -ne 0 ]] && dlogw "Kill process catch error"
         exit $ret
     fi
-    # sof-kernel-log-check script parameter number is 0/Non-Number will force check from dmesg
-    sof-kernel-log-check.sh 0 || die "Catch error in dmesg"
+    # check kernel log for each iteration to catch issues
+    sof-kernel-log-check.sh $KERNEL_LAST_TIMESTAMP || die "Catch error in kernel log"
 done
-
-sof-kernel-log-check.sh $KERNEL_LAST_TIMESTAMP
-exit $?

--- a/test-case/check-pause-resume.sh
+++ b/test-case/check-pause-resume.sh
@@ -75,7 +75,7 @@ esac
 [[ -z $file_name ]] && file_name=$dummy_file
 
 func_pipeline_export $tplg "type:$test_mode & ${OPT_VALUE_lst['S']}"
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_last_timestamp
 for idx in $(seq 0 $(expr $PIPELINE_COUNT - 1))
 do
     channel=$(func_pipeline_parse_value $idx channel)
@@ -126,5 +126,5 @@ END
     sof-kernel-log-check.sh 0 || die "Catch error in dmesg"
 done
 
-sof-kernel-log-check.sh $KERNEL_LAST_LINE
+sof-kernel-log-check.sh $KERNEL_LAST_TIMESTAMP
 exit $?

--- a/test-case/check-playback.sh
+++ b/test-case/check-playback.sh
@@ -67,7 +67,7 @@ else
     dlogi "using $file as playback source"
 fi
 
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_last_timestamp
 func_lib_check_sudo
 func_pipeline_export $tplg "type:playback & ${OPT_VALUE_lst['S']}"
 
@@ -104,4 +104,4 @@ do
     done
 done
 
-sof-kernel-log-check.sh "$KERNEL_LAST_LINE"
+sof-kernel-log-check.sh "$KERNEL_LAST_TIMESTAMP"

--- a/test-case/check-runtime-pm-double-active.sh
+++ b/test-case/check-runtime-pm-double-active.sh
@@ -71,7 +71,7 @@ DEV_LST['capture']='/dev/null'
 
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
 func_pipeline_export $tplg "type:any"
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_last_timestamp
 
 for idx in $(seq 0 $(expr $PIPELINE_COUNT - 1))
 do
@@ -141,5 +141,5 @@ do
     sof-kernel-log-check.sh 0 || die "Catch error in dmesg"
 done
 
-sof-kernel-log-check.sh $KERNEL_LAST_LINE
+sof-kernel-log-check.sh $KERNEL_LAST_TIMESTAMP
 exit $?

--- a/test-case/check-runtime-pm-status.sh
+++ b/test-case/check-runtime-pm-status.sh
@@ -65,7 +65,6 @@ DEV_LST['capture']='/dev/null'
 
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
 func_pipeline_export $tplg "type:any"
-func_lib_setup_kernel_last_timestamp
 
 for idx in $(seq 0 $(expr $PIPELINE_COUNT - 1))
 do
@@ -83,6 +82,8 @@ do
 
     for i in $(seq 1 $loop_count)
     do
+        # set up timestamp for each iteration
+        func_lib_setup_kernel_last_timestamp
         dlogi "===== Iteration $i of $loop_count for $pcm ====="
         # playback or capture device - check status
         dlogc "$cmd -D $dev -r $rate -c $channel -f $fmt $dummy_file -q"
@@ -122,10 +123,8 @@ do
             func_lib_lsof_error_dump $snd
             exit 1
         fi
+        # check kernel log for each iteration to catch issues
+        sof-kernel-log-check.sh $KERNEL_LAST_TIMESTAMP || die "Catch error in kernel log"
     done
-
-    sof-kernel-log-check.sh 0 || die "Catch error in dmesg"
 done
 
-sof-kernel-log-check.sh $KERNEL_LAST_TIMESTAMP
-exit $?

--- a/test-case/check-runtime-pm-status.sh
+++ b/test-case/check-runtime-pm-status.sh
@@ -65,7 +65,7 @@ DEV_LST['capture']='/dev/null'
 
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
 func_pipeline_export $tplg "type:any"
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_last_timestamp
 
 for idx in $(seq 0 $(expr $PIPELINE_COUNT - 1))
 do
@@ -127,5 +127,5 @@ do
     sof-kernel-log-check.sh 0 || die "Catch error in dmesg"
 done
 
-sof-kernel-log-check.sh $KERNEL_LAST_LINE
+sof-kernel-log-check.sh $KERNEL_LAST_TIMESTAMP
 exit $?

--- a/test-case/check-signal-stop-start.sh
+++ b/test-case/check-signal-stop-start.sh
@@ -56,7 +56,7 @@ case $test_mode in
     ;;
 esac
 
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_last_timestamp
 
 func_stop_start_pipeline()
 {
@@ -116,5 +116,5 @@ do
     kill -9 $pid && wait $pid 2>/dev/null
 done
 
-sof-kernel-log-check.sh $KERNEL_LAST_LINE
+sof-kernel-log-check.sh $KERNEL_LAST_TIMESTAMP
 exit $?

--- a/test-case/check-smart-amplifier.sh
+++ b/test-case/check-smart-amplifier.sh
@@ -59,7 +59,7 @@ tplg=${OPT_VALUE_lst['t']}
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
 
 func_pipeline_export $tplg "smart_amp:any"
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_last_timestamp
 
 [ "$PIPELINE_COUNT" == "2" ] || die "Only detect $PIPELINE_COUNT pipeline(s) from topology, but two are needed"
 
@@ -114,4 +114,4 @@ do
     done
 done
 
-sof-kernel-log-check.sh "$KERNEL_LAST_LINE"
+sof-kernel-log-check.sh "$KERNEL_LAST_TIMESTAMP"

--- a/test-case/check-suspend-resume-with-audio.sh
+++ b/test-case/check-suspend-resume-with-audio.sh
@@ -53,7 +53,7 @@ OPT_PARM_lst['f']=1         OPT_VALUE_lst['f']=''
 
 func_opt_parse_option "$@"
 func_lib_check_sudo
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_last_timestamp
 
 tplg=${OPT_VALUE_lst['t']}
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
@@ -131,4 +131,4 @@ do
 done
 
 # check full log
-sof-kernel-log-check.sh $KERNEL_LAST_LINE
+sof-kernel-log-check.sh $KERNEL_LAST_TIMESTAMP

--- a/test-case/check-suspend-resume.sh
+++ b/test-case/check-suspend-resume.sh
@@ -41,7 +41,7 @@ OPT_PARM_lst['r']=0         OPT_VALUE_lst['r']=0
 
 func_opt_parse_option "$@"
 func_lib_check_sudo
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_last_timestamp
 
 type=${OPT_VALUE_lst['T']}
 # switch type
@@ -91,5 +91,5 @@ do
 done
 
 # check full log
-sof-kernel-log-check.sh $KERNEL_LAST_LINE
+sof-kernel-log-check.sh $KERNEL_LAST_TIMESTAMP
 exit $?

--- a/test-case/check-suspend-resume.sh
+++ b/test-case/check-suspend-resume.sh
@@ -74,8 +74,8 @@ fi
 for i in $(seq 1 $loop_count)
 do
     dlogi "===== Round($i/$loop_count) ====="
-    # cleanup dmesg befor run case
-    sudo dmesg --clear
+    # set up timestamp for each iteration
+    func_lib_setup_kernel_last_timestamp
     sleep_count=$(cat /sys/power/wakeup_count)
     dlogc "Run the command: rtcwake -m mem -s ${sleep_lst[$i]}"
     sudo rtcwake -m mem -s ${sleep_lst[$i]}
@@ -83,13 +83,11 @@ do
     dlogc "sleep for ${wait_lst[$i]}"
     sleep ${wait_lst[$i]}
     dlogi "Check for the kernel log status"
-    wake_count=$(cat /sys/power/wakeup_count)
-    # sof-kernel-log-check script parameter number is 0/Non-Number will force check from dmesg
-    sof-kernel-log-check.sh 0 || die "Catch error in dmesg"
+    # check kernel log for each iteration to catch issues
+    sof-kernel-log-check.sh "$KERNEL_LAST_TIMESTAMP" || die "Catch error in kernel log"
     # check wakeup count correct
-    [[ $wake_count -le $sleep_count ]] && die "suspend/resume didn't happen, because /sys/power/wakeup_count does not increase"
+    wake_count=$(cat /sys/power/wakeup_count)
+    dlogi "Check for the wakeup_count"
+    [[ $wake_count -gt $sleep_count ]] || die "suspend/resume didn't happen, because /sys/power/wakeup_count does not increase"
 done
 
-# check full log
-sof-kernel-log-check.sh $KERNEL_LAST_TIMESTAMP
-exit $?

--- a/test-case/check-xrun-injection.sh
+++ b/test-case/check-xrun-injection.sh
@@ -43,7 +43,7 @@ interval=${OPT_VALUE_lst['i']}
 
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
 
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_last_timestamp
 func_lib_check_sudo
 
 case $test_mode in
@@ -122,5 +122,5 @@ do
     kill -9 $pid && wait $pid 2>/dev/null
 done
 
-sof-kernel-log-check.sh $KERNEL_LAST_LINE
+sof-kernel-log-check.sh $KERNEL_LAST_TIMESTAMP
 exit $?

--- a/test-case/multiple-pause-resume.sh
+++ b/test-case/multiple-pause-resume.sh
@@ -58,7 +58,7 @@ func_pipeline_export $tplg "type:any"
 
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
 
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_last_timestamp
 
 declare -a pipeline_idx_lst
 declare -a cmd_idx_lst
@@ -190,5 +190,5 @@ do
     sof-kernel-log-check.sh 0 || die "Catch error in dmesg"
 done
 
-sof-kernel-log-check.sh $KERNEL_LAST_LINE
+sof-kernel-log-check.sh $KERNEL_LAST_TIMESTAMP
 exit $?

--- a/test-case/multiple-pause-resume.sh
+++ b/test-case/multiple-pause-resume.sh
@@ -12,7 +12,7 @@ set -e
 ##    expect sleep for sleep time then mocks spacebar keypresses ' ' to
 ##    cause resume action
 ## Case step:
-##    1. run 1st pipeline 
+##    1. run 1st pipeline
 ##    2. pickup any other pipeline
 ##    3. use expect to fake pause/resume in each pipeline
 ##    4. go through with tplg file
@@ -91,7 +91,7 @@ done
 [[ ${#pipeline_idx_lst[*]} -gt ${OPT_VALUE_lst['c']} ]] && max_count=${OPT_VALUE_lst['c']} || max_count=${#pipeline_idx_lst[*]}
 [[ $max_count -eq 1 ]] && dlogw "pipeline count is 1, don't need to run this case" && exit 2
 
-# create combination list 
+# create combination list
 declare -a pipeline_combine_lst
 for i in $(sof-combinatoric.py -n ${#pipeline_idx_lst[*]} -p $max_count)
 do
@@ -145,7 +145,8 @@ max_wait_time=$[ 10 * $repeat_count ]
 for i in $(seq 1 $loop_count)
 do
     dlogi "===== Loop count( $i / $loop_count ) ====="
-    sudo dmesg -c >/dev/null
+    # set up timestamp for each iteration
+    func_lib_setup_kernel_last_timestamp
     for pipeline_combine_str in "${pipeline_combine_lst[@]}"
     do
         unset pid_lst
@@ -165,7 +166,7 @@ do
             [[ ! "$(pidof expect)" ]] && break
         done
         # fix aplay/arecord last output
-        echo 
+        echo
         if [ "$(pidof expect)" ]; then
             dloge "Still have expect process not finished after wait for $max_wait_time"
             # now dump process
@@ -187,8 +188,7 @@ do
             [[ $? -ne 0 ]] && die "pause resume is exit status error"
         done
     done
-    sof-kernel-log-check.sh 0 || die "Catch error in dmesg"
+    # check kernel log for each iteration to catch issues
+    sof-kernel-log-check.sh $KERNEL_LAST_TIMESTAMP || die "Catch error in kernel log"
 done
 
-sof-kernel-log-check.sh $KERNEL_LAST_TIMESTAMP
-exit $?

--- a/test-case/multiple-pipeline-capture.sh
+++ b/test-case/multiple-pipeline-capture.sh
@@ -102,9 +102,9 @@ func_error_exit()
 
 for i in $(seq 1 $loop_cnt)
 do
+    # set up timestamp for each iteration
+    func_lib_setup_kernel_last_timestamp
     dlogi "===== Testing: (Loop: $i/$loop_cnt) ====="
-    # clean up dmesg
-    sudo dmesg -C
 
     # start capture:
     func_run_pipeline_with_type "capture"
@@ -146,13 +146,11 @@ do
     sof-process-state.sh aplay >/dev/null
     [[ $? -eq 1 ]] && func_error_exit "Catch the abnormal process status of aplay"
 
-
     # kill all arecord
     pkill -9 arecord
     pkill -9 aplay
 
-    sof-kernel-log-check.sh 0 || die "Catch error in dmesg"
+    # check kernel log for each iteration to catch issues
+    sof-kernel-log-check.sh $KERNEL_LAST_TIMESTAMP || die "Catch error in kernel log"
 done
 
-sof-kernel-log-check.sh $KERNEL_LAST_TIMESTAMP >/dev/null
-exit $?

--- a/test-case/multiple-pipeline-capture.sh
+++ b/test-case/multiple-pipeline-capture.sh
@@ -51,7 +51,7 @@ max_count=0
 func_pipeline_export $tplg "type:any" # this line will help to get $PIPELINE_COUNT
 # get the min value of TPLG:'pipeline count' with Case:'pipeline count'
 [[ $PIPELINE_COUNT -gt ${OPT_VALUE_lst['c']} ]] && max_count=${OPT_VALUE_lst['c']} || max_count=$PIPELINE_COUNT
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_last_timestamp
 
 # now small function define
 declare -A APP_LST DEV_LST
@@ -154,5 +154,5 @@ do
     sof-kernel-log-check.sh 0 || die "Catch error in dmesg"
 done
 
-sof-kernel-log-check.sh $KERNEL_LAST_LINE >/dev/null
+sof-kernel-log-check.sh $KERNEL_LAST_TIMESTAMP >/dev/null
 exit $?

--- a/test-case/multiple-pipeline-playback.sh
+++ b/test-case/multiple-pipeline-playback.sh
@@ -51,7 +51,7 @@ max_count=0
 func_pipeline_export $tplg "type:any" # this line will help to get $PIPELINE_COUNT
 # get the min value of TPLG:'pipeline count' with Case:'pipeline count'
 [[ $PIPELINE_COUNT -gt ${OPT_VALUE_lst['c']} ]] && max_count=${OPT_VALUE_lst['c']} || max_count=$PIPELINE_COUNT
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_last_timestamp
 
 # now small function define
 declare -A APP_LST DEV_LST
@@ -154,5 +154,5 @@ do
     sof-kernel-log-check.sh 0 || die "Catch error in dmesg"
 done
 
-sof-kernel-log-check.sh $KERNEL_LAST_LINE >/dev/null
+sof-kernel-log-check.sh $KERNEL_LAST_TIMESTAMP >/dev/null
 exit $?

--- a/test-case/simultaneous-playback-capture.sh
+++ b/test-case/simultaneous-playback-capture.sh
@@ -57,7 +57,7 @@ id_lst_str=${id_lst_str/,/} # remove 1st, which is not used
 [[ ${#id_lst_str} -eq 0 ]] && dlogw "no pipeline with both playback and capture capabilities found in $tplg" && exit 2
 func_pipeline_export $tplg "id:$id_lst_str"
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_last_timestamp
 
 func_error_exit()
 {
@@ -115,5 +115,5 @@ do
     sof-kernel-log-check.sh 0 || die "Catch error in dmesg"
 done
 
-sof-kernel-log-check.sh $KERNEL_LAST_LINE > /dev/null
+sof-kernel-log-check.sh $KERNEL_LAST_TIMESTAMP > /dev/null
 exit $?

--- a/test-case/simultaneous-playback-capture.sh
+++ b/test-case/simultaneous-playback-capture.sh
@@ -57,7 +57,6 @@ id_lst_str=${id_lst_str/,/} # remove 1st, which is not used
 [[ ${#id_lst_str} -eq 0 ]] && dlogw "no pipeline with both playback and capture capabilities found in $tplg" && exit 2
 func_pipeline_export $tplg "id:$id_lst_str"
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
-func_lib_setup_kernel_last_timestamp
 
 func_error_exit()
 {
@@ -69,6 +68,8 @@ func_error_exit()
 
 for i in $(seq 1 $loop_cnt)
 do
+    # set up timestamp for each iteration
+    func_lib_setup_kernel_last_timestamp
     dlogi "===== Testing: (Loop: $i/$loop_cnt) ====="
     # clean up dmesg
     sudo dmesg -C
@@ -112,8 +113,7 @@ do
         kill -9 $arecord_pid && wait $arecord_pid 2>/dev/null
 
     done
-    sof-kernel-log-check.sh 0 || die "Catch error in dmesg"
+    # check kernel log for each iteration to catch issues
+    sof-kernel-log-check.sh $KERNEL_LAST_TIMESTAMP || die "Catch error in kernel log"
 done
 
-sof-kernel-log-check.sh $KERNEL_LAST_TIMESTAMP > /dev/null
-exit $?

--- a/test-case/test-speaker.sh
+++ b/test-case/test-speaker.sh
@@ -32,7 +32,7 @@ tplg=${OPT_VALUE_lst['t']}
 
 func_pipeline_export $tplg "type:playback"
 tcnt=${OPT_VALUE_lst['l']}
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_last_timestamp
 for idx in $(seq 0 $(expr $PIPELINE_COUNT - 1))
 do
     channel=$(func_pipeline_parse_value $idx channel)
@@ -54,5 +54,5 @@ do
     fi
 done
 
-sof-kernel-log-check.sh $KERNEL_LAST_LINE
+sof-kernel-log-check.sh $KERNEL_LAST_TIMESTAMP
 exit $?

--- a/test-case/verify-sof-firmware-load.sh
+++ b/test-case/verify-sof-firmware-load.sh
@@ -24,6 +24,9 @@ func_opt_parse_option "$@"
 # TODO: clean up Sub-Test feature
 alias | grep -q 'Sub-Test' || DMESG_LOG_START_LINE=$(sof-get-kernel-line.sh | tail -n 1 | awk '{print $1;}' )
 
+# flush and sync journalctl logs
+sudo journalctl --sync --flush || true
+
 cmd="journalctl -k -q --no-pager --utc --output=short-monotonic --no-hostname"
 
 dlogi "Checking SOF Firmware load info in kernel log"

--- a/test-case/volume-basic-test.sh
+++ b/test-case/volume-basic-test.sh
@@ -62,7 +62,7 @@ dlogi "pgalist number = ${#pgalist[@]}"
 
 for i in $(seq 1 $maxloop)
 do
-    func_lib_setup_kernel_last_line
+    func_lib_setup_kernel_last_timestamp
     dlogi "===== Round($i/$maxloop) ====="
     # TODO: need to check command effect
     for i in "${pgalist[@]}"
@@ -80,7 +80,7 @@ do
     sleep 1
 
     dlogi "check dmesg for error"
-    sof-kernel-log-check.sh $KERNEL_LAST_LINE
+    sof-kernel-log-check.sh $KERNEL_LAST_TIMESTAMP
     [[ $? -ne 0 ]] && func_error_exit "dmesg has errors!"
 done
 

--- a/tools/sof-get-default-tplg.sh
+++ b/tools/sof-get-default-tplg.sh
@@ -1,14 +1,12 @@
 #!/bin/bash
+#
+# read kernel log to get topology file loaded by SOF driver
+# Example from an apl up2 pcm512x device:
+#
+# sof-audio-pci 0000:00:0e.0: loading topology:intel/sof-tplg/sof-apl-pcm512x.tplg
+#
+# sof-apl-pcm512x.tplg will be returned
+#
 
-# Current: load TPLG file order:
-# dmesg
-# journalctl
-# /var/log/syslog (sof-kernel-dump.sh)
-# Future: possibly be loaded from elsewhere
-# Notice: Only verified on Ubuntu 18.04
-tplg_file=$(dmesg |grep -i topology|awk -F ':' '/tplg/ {print $NF;}'|tail -n 1)
-[[ ! "$tplg_file" ]] && \
-    tplg_file=$(journalctl -k |grep -i topology |awk -F ':' '/tplg/ {print $NF;}'|tail -n 1)
-[[ ! "$tplg_file" ]] && \
-    tplg_file=$(sof-kernel-dump.sh |grep -i topology|awk -F ':' '/tplg/ {print $NF;}'|tail -n 1)
+tplg_file=$(journalctl -k |grep -i topology |awk -F ':' '/tplg/ {print $NF;}'|tail -n 1)
 [[ "$tplg_file" ]] && basename $tplg_file || echo ""

--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -238,8 +238,68 @@ case "$platform" in
         ;;
 esac
 
+# below are new error level kernel logs from journalctl --priority=err
+# that did not influcen system and can be ignored
+
+# systemd issues can be ignored
+# seen on mutiple platforms
+# systemd[1]: Failed to mount Mount unit for core.
+# systemd[1]: Failed to mount Mount unit for gnome-calculator.
+# systemd[1]: Failed to mount Mount unit for [UNIT].
+ignore_str="$ignore_str"'|systemd\[.\]: Failed to mount Mount unit for'
+
+# initramfs issues can be ignored
+ignore_str="$ignore_str"'|Initramfs unpacking failed'
+
+# keyboard issues can be ignored
+ignore_str="$ignore_str"'|atkbd serio0: Failed to deactivate keyboard on isa0060/serio0'
+ignore_str="$ignore_str"'|atkbd serio0: Failed to enable keyboard on isa0060/serio0'
+
+# smbus issues can be ignored
+ignore_str="$ignore_str"'|i801_smbus 0000:00:..\..: Transaction timeout'
+ignore_str="$ignore_str"'|i801_smbus 0000:00:..\..: Failed terminating the transaction'
+ignore_str="$ignore_str""|i801_smbus 0000:00:..\..: SMBus is busy, can't use it!"
+ignore_str="$ignore_str"'|i801_smbus 0000:00:..\..: Failed to allocate irq .: -16'
+
+# SATA related issue can be ignored is it did not break device
+ignore_str="$ignore_str"'|ata3: COMRESET failed \(errno=-16\)'
+
+# genirq issues can be ignored
+# origin logs seen on GLK platforms
+# genirq: Flags mismatch irq 0. 00000080 (i801_smbus) vs. 00015a00 (timer)
+ignore_str="$ignore_str"'|genirq: Flags mismatch irq .'
+
+# DMAR warnings can be ignored
+# origin logs seen on BDW platforms
+# DMAR: [Firmware Bug]: No firmware reserved region can cover this RMRR [0x00000000ad000000-0x00000000af7fffff], contact BIOS vendor for fixes
+ignore_str="$ignore_str"'|DMAR: \[Firmware Bug\]: No firmware reserved region can cover this RMRR .'
+
+# dw_dmac logs can be ignored
+# origin logs seen on BDW/BYT/CHT platforms
+# dw_dmac INTL9C60:00: Missing DT data
+# dw_dmac INTL9C60:01: Missing DT data
+ignore_str="$ignore_str"'|dw_dmac INTL9C60:..: Missing DT data'
+
+# proc_thermal logs can be ignored
+# origin logs seen on CHT platforms
+# proc_thermal 0000:00:0b.0: No auxiliary DTSs enabled
+ignore_str="$ignore_str"'|proc_thermal 0000:00:..\..: No auxiliary DTSs enabled'
+
+# touch pad logs can be ignored
+# origin logs seen on GLK platforms
+# elan_i2c i2c-ELAN0000:00: invalid report id data (ff)
+ignore_str="$ignore_str"'|elan_i2c i2c-ELAN0000:.*: invalid report id data'
+
+#
+# SDW related logs
+#
+
+# origin logs seen on CML with RT700 platforms
+# rt700 sdw:1:25d:700:0: Bus clash detected
+ignore_str="$ignore_str"'|rt700 sdw:.:.*:700:.: Bus clash detected'
+
 # confirm begin_timestamp is in UNIX timestamp format, otherwise search full log
-journalctlflag="-k -q --no-pager --utc --output=short-iso --no-hostname"
+journalctlflag="-k -q --no-pager --utc --output=short-monotonic --no-hostname"
 [[ $begin_timestamp =~ ^[0-9]{10} ]] && cmd="journalctl $journalctlflag --since=@$begin_timestamp" || cmd="journalctl $journalctlflag"
 
 declare -p cmd

--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -130,7 +130,7 @@
 begin_line=${1:-1}
 declare err_str ignore_str
 
-platform=$(sof-dump-status.py -p)
+platform=$($(dirname "$0")/sof-dump-status.py -p)
 
 err_str="error|failed|timed out|panic|oops"
 


### PR DESCRIPTION
Try to use journalctl to read kernel log from system.
Use UNIX style timestamp to split kernel logs from test case to test case.
Print same format like dmesg in journalctl kernel log.
Update all test case used to relay on demsg logs