### PR TITLE
lib.sh: revise card number acquisition code

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -35,7 +35,7 @@ fi
 
 # setup SOFCARD id
 if [ ! "$SOFCARD" ]; then
-    SOFCARD=$(grep 'sof-[a-z]' /proc/asound/cards|awk '{print $1;}')
+    SOFCARD=$(grep -v 'sof-probes' /proc/asound/cards | grep 'sof-[a-z]' | awk '{print $1;}')
 fi
 
 func_lib_setup_kernel_last_line()


### PR DESCRIPTION
Auxiliary devices in SOF feature is introduced in
thesofproject/linux#2501, which adds a new sof-probes
card in /proc/asound/cards. Old SOF card number
acquisition cannot work any more due to this change.
    
This patch excludes the sof-probes card with a grep.