### PR TITLE
test-case: add quotes to function arguments for func_export_pipeline

### DIFF
--- a/test-case/check-audio-equalizer.sh
+++ b/test-case/check-audio-equalizer.sh
@@ -38,7 +38,7 @@ duration=${OPT_VALUE_lst['d']}
 loop_cnt=${OPT_VALUE_lst['l']}
 
 # import only EQ pipeline from topology
-func_pipeline_export $tplg "eq:any"
+func_pipeline_export "$tplg" "eq:any"
 sofcard=${SOFCARD:-0}
 
 # Test equalizer

--- a/test-case/check-capture.sh
+++ b/test-case/check-capture.sh
@@ -61,7 +61,7 @@ file_prefix=${OPT_VALUE_lst['f']}
 
 func_lib_setup_kernel_last_line
 func_lib_check_sudo
-func_pipeline_export $tplg "type:capture & ${OPT_VALUE_lst['S']}"
+func_pipeline_export "$tplg" "type:capture & ${OPT_VALUE_lst['S']}"
 
 for round in $(seq 1 $round_cnt)
 do

--- a/test-case/check-fw-echo-reference.sh
+++ b/test-case/check-fw-echo-reference.sh
@@ -43,7 +43,7 @@ frequency=${OPT_VALUE_lst['f']}
 
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
 
-func_pipeline_export $tplg "echo:any"
+func_pipeline_export "$tplg" "echo:any"
 func_lib_setup_kernel_last_line
 
 if [ "$PIPELINE_COUNT" != "2" ]; then

--- a/test-case/check-keyword-detection.sh
+++ b/test-case/check-keyword-detection.sh
@@ -54,7 +54,7 @@ duration=${OPT_VALUE_lst['d']}
 
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
 
-func_pipeline_export $tplg "kpbm:any"
+func_pipeline_export "$tplg" "kpbm:any"
 func_lib_setup_kernel_last_line
 
 if test "$PIPELINE_COUNT" != "1"; then

--- a/test-case/check-kmod-load-unload-after-playback.sh
+++ b/test-case/check-kmod-load-unload-after-playback.sh
@@ -52,7 +52,7 @@ tplg=${OPT_VALUE_lst['t']}
 loop_cnt=${OPT_VALUE_lst['l']}
 pb_duration=${OPT_VALUE_lst['d']}
 
-func_pipeline_export $tplg "type:playback"
+func_pipeline_export "$tplg" "type:playback"
 
 func_lib_check_sudo
 # overwrite the subscript: test-case LOG_ROOT environment

--- a/test-case/check-pause-resume.sh
+++ b/test-case/check-pause-resume.sh
@@ -74,7 +74,7 @@ esac
 
 [[ -z $file_name ]] && file_name=$dummy_file
 
-func_pipeline_export $tplg "type:$test_mode & ${OPT_VALUE_lst['S']}"
+func_pipeline_export "$tplg" "type:$test_mode & ${OPT_VALUE_lst['S']}"
 func_lib_setup_kernel_last_line
 for idx in $(seq 0 $(expr $PIPELINE_COUNT - 1))
 do

--- a/test-case/check-playback.sh
+++ b/test-case/check-playback.sh
@@ -69,7 +69,7 @@ fi
 
 func_lib_setup_kernel_last_line
 func_lib_check_sudo
-func_pipeline_export $tplg "type:playback & ${OPT_VALUE_lst['S']}"
+func_pipeline_export "$tplg" "type:playback & ${OPT_VALUE_lst['S']}"
 
 for round in $(seq 1 $round_cnt)
 do

--- a/test-case/check-runtime-pm-double-active.sh
+++ b/test-case/check-runtime-pm-double-active.sh
@@ -70,7 +70,7 @@ APP_LST['capture']='arecord'
 DEV_LST['capture']='/dev/null'
 
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
-func_pipeline_export $tplg "type:any"
+func_pipeline_export "$tplg" "type:any"
 func_lib_setup_kernel_last_line
 
 for idx in $(seq 0 $(expr $PIPELINE_COUNT - 1))

--- a/test-case/check-runtime-pm-status.sh
+++ b/test-case/check-runtime-pm-status.sh
@@ -64,7 +64,7 @@ APP_LST['capture']='arecord'
 DEV_LST['capture']='/dev/null'
 
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
-func_pipeline_export $tplg "type:any"
+func_pipeline_export "$tplg" "type:any"
 func_lib_setup_kernel_last_line
 
 for idx in $(seq 0 $(expr $PIPELINE_COUNT - 1))

--- a/test-case/check-signal-stop-start.sh
+++ b/test-case/check-signal-stop-start.sh
@@ -81,7 +81,7 @@ func_stop_start_pipeline()
     done
 }
 
-func_pipeline_export $tplg "type:$test_mode"
+func_pipeline_export "$tplg" "type:$test_mode"
 for idx in $(seq 0 $(expr $PIPELINE_COUNT - 1))
 do
     channel=$(func_pipeline_parse_value $idx channel)

--- a/test-case/check-smart-amplifier.sh
+++ b/test-case/check-smart-amplifier.sh
@@ -58,7 +58,7 @@ tplg=${OPT_VALUE_lst['t']}
 
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
 
-func_pipeline_export $tplg "smart_amp:any"
+func_pipeline_export "$tplg" "smart_amp:any"
 func_lib_setup_kernel_last_line
 
 [ "$PIPELINE_COUNT" == "2" ] || die "Only detect $PIPELINE_COUNT pipeline(s) from topology, but two are needed"

--- a/test-case/check-suspend-resume-with-audio.sh
+++ b/test-case/check-suspend-resume-with-audio.sh
@@ -73,7 +73,7 @@ else
 fi
 [[ -z $file_name ]] && file_name=$dummy_file
 
-func_pipeline_export $tplg "type:${OPT_VALUE_lst['m']}"
+func_pipeline_export "$tplg" "type:${OPT_VALUE_lst['m']}"
 
 if [ "${OPT_VALUE_lst['T']}" ]; then
     opt="-l ${OPT_VALUE_lst['l']} -T ${OPT_VALUE_lst['T']}"

--- a/test-case/check-xrun-injection.sh
+++ b/test-case/check-xrun-injection.sh
@@ -81,7 +81,7 @@ func_xrun_injection()
     done
 }
 
-func_pipeline_export $tplg "type:$test_mode"
+func_pipeline_export "$tplg" "type:$test_mode"
 for idx in $(seq 0 $(expr $PIPELINE_COUNT - 1))
 do
     channel=$(func_pipeline_parse_value $idx channel)

--- a/test-case/multiple-pause-resume.sh
+++ b/test-case/multiple-pause-resume.sh
@@ -54,7 +54,7 @@ rnd_range=$[ $rnd_max - $rnd_min ]
 [[ $rnd_range -le 0 ]] && dlogw "Error random range scope [ min:$rnd_min - max:$rnd_max ]" && exit 2
 
 tplg=${OPT_VALUE_lst['t']}
-func_pipeline_export $tplg "type:any"
+func_pipeline_export "$tplg" "type:any"
 
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
 

--- a/test-case/multiple-pipeline-capture.sh
+++ b/test-case/multiple-pipeline-capture.sh
@@ -48,7 +48,7 @@ tplg=${OPT_VALUE_lst['t']}
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
 
 max_count=0
-func_pipeline_export $tplg "type:any" # this line will help to get $PIPELINE_COUNT
+func_pipeline_export "$tplg" "type:any" # this line will help to get $PIPELINE_COUNT
 # get the min value of TPLG:'pipeline count' with Case:'pipeline count'
 [[ $PIPELINE_COUNT -gt ${OPT_VALUE_lst['c']} ]] && max_count=${OPT_VALUE_lst['c']} || max_count=$PIPELINE_COUNT
 func_lib_setup_kernel_last_line
@@ -66,7 +66,7 @@ tmp_count=$max_count
 func_run_pipeline_with_type()
 {
     [[ $tmp_count -le 0 ]] && return
-    func_pipeline_export $tplg "type:$1"
+    func_pipeline_export "$tplg" "type:$1"
     local -a idx_lst
     if [ ${OPT_VALUE_lst['r']} -eq 0 ]; then
         idx_lst=( $(seq 0 $(expr $PIPELINE_COUNT - 1)) )

--- a/test-case/multiple-pipeline-playback.sh
+++ b/test-case/multiple-pipeline-playback.sh
@@ -48,7 +48,7 @@ tplg=${OPT_VALUE_lst['t']}
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
 
 max_count=0
-func_pipeline_export $tplg "type:any" # this line will help to get $PIPELINE_COUNT
+func_pipeline_export "$tplg" "type:any" # this line will help to get $PIPELINE_COUNT
 # get the min value of TPLG:'pipeline count' with Case:'pipeline count'
 [[ $PIPELINE_COUNT -gt ${OPT_VALUE_lst['c']} ]] && max_count=${OPT_VALUE_lst['c']} || max_count=$PIPELINE_COUNT
 func_lib_setup_kernel_last_line
@@ -66,7 +66,7 @@ tmp_count=$max_count
 func_run_pipeline_with_type()
 {
     [[ $tmp_count -le 0 ]] && return
-    func_pipeline_export $tplg "type:$1"
+    func_pipeline_export "$tplg" "type:$1"
     local -a idx_lst
     if [ ${OPT_VALUE_lst['r']} -eq 0 ]; then
         idx_lst=( $(seq 0 $(expr $PIPELINE_COUNT - 1)) )

--- a/test-case/simultaneous-playback-capture.sh
+++ b/test-case/simultaneous-playback-capture.sh
@@ -55,7 +55,7 @@ done
 unset tmp_id_lst tplg_path
 id_lst_str=${id_lst_str/,/} # remove 1st, which is not used
 [[ ${#id_lst_str} -eq 0 ]] && dlogw "no pipeline with both playback and capture capabilities found in $tplg" && exit 2
-func_pipeline_export $tplg "id:$id_lst_str"
+func_pipeline_export "$tplg" "id:$id_lst_str"
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
 func_lib_setup_kernel_last_line
 

--- a/test-case/test-speaker.sh
+++ b/test-case/test-speaker.sh
@@ -30,7 +30,7 @@ func_opt_parse_option "$@"
 tplg=${OPT_VALUE_lst['t']}
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
 
-func_pipeline_export $tplg "type:playback"
+func_pipeline_export "$tplg" "type:playback"
 tcnt=${OPT_VALUE_lst['l']}
 func_lib_setup_kernel_last_line
 for idx in $(seq 0 $(expr $PIPELINE_COUNT - 1))

--- a/test-case/volume-basic-test.sh
+++ b/test-case/volume-basic-test.sh
@@ -39,7 +39,7 @@ func_error_exit()
 }
 
 [[ -z $tplg ]] && die "Missing tplg file needed to run"
-func_pipeline_export $tplg "type:playback"
+func_pipeline_export "$tplg" "type:playback"
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
 
 [[ $PIPELINE_COUNT -eq 0 ]] && die "Missing playback pipeline for aplay to run"


### PR DESCRIPTION
If a shell function takes a variable as its argument,
and the variable is empty, then the argument will
degrade to nothing in the function.

This patch adds quotes to function arguments to avoid
argument degrading.

Signed-off-by: Amery Song <chao.song@intel.com>