### PR TITLE
sof-kernel-log-check: filter out DRM error

### DIFF
--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -188,6 +188,10 @@ ignore_str="$ignore_str"'|acpi device:00: Failed to change power state to D3hot'
 # BugLink: https://github.com/thesofproject/sof-test/issues/374
 ignore_str="$ignore_str"'|i915 0000:00:02\.0: \[drm\] ERROR TC cold unblock failed'
 ignore_str="$ignore_str"'|i915 0000:00:02\.0: \[drm\] ERROR TC cold block failed'
+
+# DRM issues with kernel v5.10-rc1 https://github.com/thesofproject/linux/pull/2538
+ignore_str="$ignore_str"'|\[drm:drm_dp_send_link_address \[drm_kms_helper\]\] \*ERROR\* Sending link address failed with -5'
+
 # CHT devices with USB hub, issues reported by sof-test
 # BugLink: https://github.com/thesofproject/sof-test/issues/431
 ignore_str="$ignore_str"'|hub 2-.: .'


### PR DESCRIPTION
This error appeared in V5.10-rc1, discard it for now.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>