### PR TITLE
lib.sh: make func_lib_lsof_error_dump() compatible with set -e

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -228,10 +228,11 @@ func_lib_get_random()
 func_lib_lsof_error_dump()
 {
     local file="$1" ret
+    # lsof exits the same '1' whether the file is missing or not open :-(
     [[ ! -c "$file" ]] && return
-    ret=$(lsof "$file")
+    ret=$(lsof "$file") || true
     if [ "$ret" ];then
-        dloge "Sound device file is in use:"
+        dloge "Sound device $file is in use:"
         echo "$ret"
     fi
 }


### PR DESCRIPTION
See #312 for more details.

This bug was neither painting failures green nor successes red but it
was at least interrupting the tests before manual error messages could
get printed.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>