### PR TITLE
tools: remove spurious space from # !/usr/bin/python3 shebang

### DIFF
--- a/tools/tplgtool.py
+++ b/tools/tplgtool.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3
+#!/usr/bin/python3
 
 import os
 import sys

--- a/tools/wavetool.py
+++ b/tools/wavetool.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python3
+#!/usr/bin/python3
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright(c) 2020 Intel Corporation. All rights reserved.
 


### PR DESCRIPTION
This breaks the "file" command on Ubuntu 2018 which stops Travis from
looking at these files.

Should probably be #!/usr/bin/env python3 but that's for another day.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>