### PR TITLE
New aplay_opts() and arecord_opts() to change flags across all tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To run a test, call the scripts directly
 
 Example:
 ```
-~/sof-test/test-case$ ./check-playback.sh -h
+~/sof-test/test-case$ SOF_ALSA_OPTS='-q --fatal-errors' ./check-playback.sh -h
 Usage: ./check-playback.sh [OPTION]
 
     -F |  --fmts
@@ -49,8 +49,25 @@ Usage: ./check-playback.sh [OPTION]
 2020-03-19 22:13:32 UTC [INFO] Catch block option from TPLG_BLOCK_LST will block 'pcm=HDA Digital,Media Playback,DMIC16k' for /lib/firmware/intel/sof-tplg/sof-apl-pcm512x.tplg
 2020-03-19 22:13:32 UTC [INFO] Run command: 'sof-tplgreader.py /lib/firmware/intel/sof-tplg/sof-apl-pcm512x.tplg -f type:playback,both -b pcm:'HDA Digital,Media Playback,DMIC16k' -s 0 -e' to get BASH Array
 2020-03-19 22:13:32 UTC [INFO] Testing: (Round: 1/1) (PCM: Port5 [hw:0,0]<both>) (Loop: 1/3)
+2020-03-19 22:13:32 UTC [COMMAND] aplay -q --fatal-errors  -Dhw:0,0 -r 48000 -c 2 -f S16_LE -d 4 /dev/zero -v -q
     ...
 ```
+
+Some tests support SOF_ALSA_OPTS, SOF_APLAY_OPTS and SOF_ARECORD_OPTS,
+work in progress. Where supported, optional parameters in SOF_APLAY_OPTS
+and SOF_ARECORD_OPTS are passed to all aplay and arecord
+invocations. SOF_ALSA_OPTS parameters are passed to both aplay and
+arecord. Warning these environments variables do NOT support parameters
+with whitespace or globbing characters, in other words this does NOT
+work:
+
+   SOF_ALSA_OPTS='--foo --bar="spaces do not work"'
+
+For the up-to-date list of tests supporting these environment variables
+run:
+
+    git grep -l 'a[[:alnum:]]*_opts'
+
 ### tools
 To use tool script, call the scripts directly
  * `-h` will show the usage for the tool

--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -253,6 +253,47 @@ func_lib_get_tplg_path()
     return 0
 }
 
+# We must not quote SOF_ALSA_OPTS and disable SC2086 below for two reasons:
+#
+# 1. We want to support multiple parameters in a single variable, in
+#    other words we want to support this:
+#
+#      SOF_ALSA_OPTS="--foo --bar"
+#      aplay $SOF_ALSA_OPTS ...
+#
+# 2. aplay does not ignore empty arguments anyway, in other words this
+#    does not work anyway:
+#
+#      SOF_ALSA_OPTS=""
+#      aplay "$SOF_ALSA_OPTS" ...
+#
+# This is technically incorrect because it means our SOF_ALSA_OPTS
+# cannot support whitespace, for instance this would be split in two
+# options: --bar="aaaa and bbbb"
+#
+#      SOF_ALSA_OPTS='--foo --bar="aaaa bbbb"'
+#
+# To do this "correctly" SOF_ALSA_OPTS etc. should be arrays.
+# From https://mywiki.wooledge.org/BashGuide/Arrays "The only safe way
+# to represent multiple string elements in Bash is through the use of
+# arrays."
+#
+# However, 1. arrays would complicate the user interface 2. ALSA does not
+# seem to need arguments with whitespace or globbing characters.
+
+aplay_opts()
+{
+    dlogc "aplay $SOF_ALSA_OPTS $SOF_APLAY_OPTS $*"
+    # shellcheck disable=SC2086
+    aplay $SOF_ALSA_OPTS $SOF_APLAY_OPTS "$@"
+}
+arecord_opts()
+{
+    dlogc "arecord $SOF_ALSA_OPTS $SOF_ARECORD_OPTS $*"
+    # shellcheck disable=SC2086
+    arecord $SOF_ALSA_OPTS $SOF_ARECORD_OPTS "$@"
+}
+
 die()
 {
     dloge "$@"

--- a/test-case/check-capture.sh
+++ b/test-case/check-capture.sh
@@ -95,8 +95,7 @@ do
                     dlogi "using $file as capture output"
                 fi
 
-                dlogc "arecord -D$dev -r $rate -c $channel -f $fmt_elem -d $duration $file -v -q"
-                arecord -D$dev -r $rate -c $channel -f $fmt_elem -d $duration $file -v -q
+                arecord_opts -D$dev -r $rate -c $channel -f $fmt_elem -d $duration $file -v -q
                 if [[ $? -ne 0 ]]; then
                     func_lib_lsof_error_dump $snd
                     die "arecord on PCM $dev failed at $i/$loop_cnt."

--- a/test-case/check-playback.sh
+++ b/test-case/check-playback.sh
@@ -93,8 +93,7 @@ do
             for i in $(seq 1 $loop_cnt)
             do
                 dlogi "===== Testing: (Round: $round/$round_cnt) (PCM: $pcm [$dev]<$type>) (Loop: $i/$loop_cnt) ====="
-                dlogc "aplay -D$dev -r $rate -c $channel -f $fmt_elem -d $duration $file -v -q"
-                aplay -D"$dev" -r "$rate" -c "$channel" -f "$fmt_elem" \
+                aplay_opts -D"$dev" -r "$rate" -c "$channel" -f "$fmt_elem" \
                       -d "$duration" "$file" -v -q || {
                     func_lib_lsof_error_dump "$snd"
                     die "aplay on PCM $dev failed at $i/$loop_cnt."

--- a/test-case/multiple-pipeline-capture.sh
+++ b/test-case/multiple-pipeline-capture.sh
@@ -55,9 +55,9 @@ func_lib_setup_kernel_last_line
 
 # now small function define
 declare -A APP_LST DEV_LST
-APP_LST['playback']='aplay'
+APP_LST['playback']='aplay_opts'
 DEV_LST['playback']='/dev/zero'
-APP_LST['capture']='arecord'
+APP_LST['capture']='arecord_opts'
 DEV_LST['capture']='/dev/null'
 
 tmp_count=$max_count
@@ -84,7 +84,6 @@ func_run_pipeline_with_type()
 
         dlogi "Testing: $pcm [$dev]"
 
-        dlogc "${APP_LST[$1]} -D $dev -c $channel -r $rate -f $fmt ${DEV_LST[$1]} -q"
         "${APP_LST[$1]}" -D $dev -c $channel -r $rate -f $fmt "${DEV_LST[$1]}" -q &
 
         tmp_count=$(expr $tmp_count - 1 )


### PR DESCRIPTION
"All problems in computer science can be solved by another level of
indirection"

First step towards #489

Default `SOF_ALSA_OPTS` to `--fatal-errors`, can be overriden with:
```
 SOF_ALSA_OPTS="" ./scripts/run-all-tests.sh
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>