### PR TITLE
lib: rename last_line to checkpoint

### DIFF
--- a/case-lib/config.sh
+++ b/case-lib/config.sh
@@ -22,7 +22,7 @@ TPLG_IGNORE_LST['pcm']='HDA Digital'
 # Will be set by the lib function, don't need to set
 # Catches the last line of /var/log/kern.log, which will be used by
 #   sof-kernel-log-check.
-# KERNEL_LAST_LINE
+# KERNEL_CHECKPOINT
 
 # If not set will be automatically set by logging_ctl function
 # Test case log root

--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -38,10 +38,10 @@ if [ ! "$SOFCARD" ]; then
     SOFCARD=$(grep -v 'sof-probes' /proc/asound/cards | grep 'sof-[a-z]' | awk '{print $1;}')
 fi
 
-func_lib_setup_kernel_last_line()
+func_lib_setup_kernel_checkpoint()
 {
     # shellcheck disable=SC2034 # external script will use it
-    KERNEL_LAST_LINE=$(wc -l /var/log/kern.log|awk '{print $1;}')
+    KERNEL_CHECKPOINT=$(wc -l /var/log/kern.log|awk '{print $1;}')
 }
 
 # This function adds a fake error to dmesg (which is always saved by

--- a/test-case/check-capture.sh
+++ b/test-case/check-capture.sh
@@ -59,7 +59,7 @@ file_prefix=${OPT_VALUE_lst['f']}
 
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
 
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_checkpoint
 func_lib_check_sudo
 func_pipeline_export "$tplg" "type:capture & ${OPT_VALUE_lst['S']}"
 
@@ -106,5 +106,5 @@ do
     done
 done
 
-sof-kernel-log-check.sh $KERNEL_LAST_LINE
+sof-kernel-log-check.sh "$KERNEL_CHECKPOINT"
 exit $?

--- a/test-case/check-fw-echo-reference.sh
+++ b/test-case/check-fw-echo-reference.sh
@@ -44,7 +44,7 @@ frequency=${OPT_VALUE_lst['f']}
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
 
 func_pipeline_export "$tplg" "echo:any"
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_checkpoint
 
 if [ "$PIPELINE_COUNT" != "2" ]; then
     die "Only detect $PIPELINE_COUNT pipeline(s) from topology, but two are needed"
@@ -93,4 +93,4 @@ do
     done
 done
 
-sof-kernel-log-check.sh "$KERNEL_LAST_LINE"
+sof-kernel-log-check.sh "$KERNEL_CHECKPOINT"

--- a/test-case/check-ipc-flood.sh
+++ b/test-case/check-ipc-flood.sh
@@ -32,7 +32,7 @@ loop_cnt=${OPT_VALUE_lst['l']}
 
 [[ ! "$(sof-kernel-dump.sh|grep 'sof-audio'|grep 'Firmware debug build')" ]] && dlogw "${BASH_SOURCE[0]} need debug version firmware" && exit 2
 
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_checkpoint
 func_lib_check_sudo
 
 dlogi "Check sof debug fs environment"
@@ -54,5 +54,5 @@ do
     dmesg | grep "IPC Flood count" -A 2
 done
 
-sof-kernel-log-check.sh $KERNEL_LAST_LINE
+sof-kernel-log-check.sh "$KERNEL_CHECKPOINT"
 exit 0

--- a/test-case/check-keyword-detection.sh
+++ b/test-case/check-keyword-detection.sh
@@ -55,7 +55,7 @@ duration=${OPT_VALUE_lst['d']}
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
 
 func_pipeline_export "$tplg" "kpbm:any"
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_checkpoint
 
 if test "$PIPELINE_COUNT" != "1"; then
     die "detected $PIPELINE_COUNT wov pipeline(s) from topology, but 1 is needed"
@@ -154,4 +154,4 @@ do
     done
 done
 
-sof-kernel-log-check.sh "$KERNEL_LAST_LINE"
+sof-kernel-log-check.sh "$KERNEL_CHECKPOINT"

--- a/test-case/check-kmod-load-unload.sh
+++ b/test-case/check-kmod-load-unload.sh
@@ -33,7 +33,7 @@ OPT_OPT_lst['p']='pulseaudio'   OPT_DESC_lst['p']='disable pulseaudio on the tes
 OPT_PARM_lst['p']=0             OPT_VALUE_lst['p']=1
 
 func_opt_parse_option "$@"
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_checkpoint
 
 loop_cnt=${OPT_VALUE_lst['l']}
 
@@ -48,7 +48,7 @@ for idx in $(seq 1 $loop_cnt)
 do
     dlogi "===== Starting iteration $idx of $loop_cnt ====="
     ## - 1: remove module section
-    func_lib_setup_kernel_last_line
+    func_lib_setup_kernel_checkpoint
 
     # After module removal, it takes about 10s for "aplay -l" to show
     # device list, within this 10s, it shows "no soundcard found". Here
@@ -75,10 +75,10 @@ do
 
     ## - 1a: check for errors after removal
     dlogi "checking for general errors after kmod unload with sof-kernel-log-check tool"
-    sof-kernel-log-check.sh "$KERNEL_LAST_LINE" ||
+    sof-kernel-log-check.sh "$KERNEL_CHECKPOINT" ||
         die "error found after kmod unload is real error, failing"
 
-    func_lib_setup_kernel_last_line
+    func_lib_setup_kernel_checkpoint
     dlogi "run kmod/sof_insert.sh"
     sudo sof_insert.sh || {
         # FIXME: don't exit the status of dloge(). Use die()
@@ -87,7 +87,7 @@ do
 
     ## - 2a: check for errors after insertion
     dlogi "checking for general errors after kmod insert with sof-kernel-log-check tool"
-    sof-kernel-log-check.sh "$KERNEL_LAST_LINE" ||
+    sof-kernel-log-check.sh "$KERNEL_CHECKPOINT" ||
         die "Found error(s) in kernel log after module insertion"
 
     dlogi "checking if firmware is loaded successfully"

--- a/test-case/check-pause-release-suspend-resume.sh
+++ b/test-case/check-pause-release-suspend-resume.sh
@@ -110,7 +110,7 @@ esac
 
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
 
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_checkpoint
 
 dlogi "Entering audio stream expect script with: $cmd -D $pcm -r $rate -c $channel -f $fmt -vv -i $dummy_file -q"
 dlogi "Will enter suspend-resume cycle during paused period of audio stream process"
@@ -180,5 +180,5 @@ if [ $ret -ne 0 ]; then
     [[ $? -ne 0 ]] && dlogw "Kill process catch error"
     exit $ret
 fi
-sof-kernel-log-check.sh $KERNEL_LAST_LINE
+sof-kernel-log-check.sh "$KERNEL_CHECKPOINT"
 exit $?

--- a/test-case/check-pause-resume.sh
+++ b/test-case/check-pause-resume.sh
@@ -75,7 +75,7 @@ esac
 [[ -z $file_name ]] && file_name=$dummy_file
 
 func_pipeline_export "$tplg" "type:$test_mode & ${OPT_VALUE_lst['S']}"
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_checkpoint
 for idx in $(seq 0 $(expr $PIPELINE_COUNT - 1))
 do
     channel=$(func_pipeline_parse_value $idx channel)
@@ -126,5 +126,5 @@ END
     sof-kernel-log-check.sh 0 || die "Catch error in dmesg"
 done
 
-sof-kernel-log-check.sh $KERNEL_LAST_LINE
+sof-kernel-log-check.sh "$KERNEL_CHECKPOINT"
 exit $?

--- a/test-case/check-playback.sh
+++ b/test-case/check-playback.sh
@@ -67,7 +67,7 @@ else
     dlogi "using $file as playback source"
 fi
 
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_checkpoint
 func_lib_check_sudo
 func_pipeline_export "$tplg" "type:playback & ${OPT_VALUE_lst['S']}"
 
@@ -104,4 +104,4 @@ do
     done
 done
 
-sof-kernel-log-check.sh "$KERNEL_LAST_LINE"
+sof-kernel-log-check.sh "$KERNEL_CHECKPOINT"

--- a/test-case/check-runtime-pm-double-active.sh
+++ b/test-case/check-runtime-pm-double-active.sh
@@ -71,7 +71,7 @@ DEV_LST['capture']='/dev/null'
 
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
 func_pipeline_export "$tplg" "type:any"
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_checkpoint
 
 for idx in $(seq 0 $(expr $PIPELINE_COUNT - 1))
 do
@@ -141,5 +141,5 @@ do
     sof-kernel-log-check.sh 0 || die "Catch error in dmesg"
 done
 
-sof-kernel-log-check.sh $KERNEL_LAST_LINE
+sof-kernel-log-check.sh "$KERNEL_CHECKPOINT"
 exit $?

--- a/test-case/check-runtime-pm-status.sh
+++ b/test-case/check-runtime-pm-status.sh
@@ -65,7 +65,7 @@ DEV_LST['capture']='/dev/null'
 
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
 func_pipeline_export "$tplg" "type:any"
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_checkpoint
 
 for idx in $(seq 0 $(expr $PIPELINE_COUNT - 1))
 do
@@ -127,5 +127,5 @@ do
     sof-kernel-log-check.sh 0 || die "Catch error in dmesg"
 done
 
-sof-kernel-log-check.sh $KERNEL_LAST_LINE
+sof-kernel-log-check.sh "$KERNEL_CHECKPOINT"
 exit $?

--- a/test-case/check-signal-stop-start.sh
+++ b/test-case/check-signal-stop-start.sh
@@ -56,7 +56,7 @@ case $test_mode in
     ;;
 esac
 
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_checkpoint
 
 func_stop_start_pipeline()
 {
@@ -116,5 +116,5 @@ do
     kill -9 $pid && wait $pid 2>/dev/null
 done
 
-sof-kernel-log-check.sh $KERNEL_LAST_LINE
+sof-kernel-log-check.sh "$KERNEL_CHECKPOINT"
 exit $?

--- a/test-case/check-smart-amplifier.sh
+++ b/test-case/check-smart-amplifier.sh
@@ -59,7 +59,7 @@ tplg=${OPT_VALUE_lst['t']}
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
 
 func_pipeline_export "$tplg" "smart_amp:any"
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_checkpoint
 
 [ "$PIPELINE_COUNT" == "2" ] || die "Only detect $PIPELINE_COUNT pipeline(s) from topology, but two are needed"
 
@@ -114,4 +114,4 @@ do
     done
 done
 
-sof-kernel-log-check.sh "$KERNEL_LAST_LINE"
+sof-kernel-log-check.sh "$KERNEL_CHECKPOINT"

--- a/test-case/check-suspend-resume-with-audio.sh
+++ b/test-case/check-suspend-resume-with-audio.sh
@@ -53,7 +53,7 @@ OPT_PARM_lst['f']=1         OPT_VALUE_lst['f']=''
 
 func_opt_parse_option "$@"
 func_lib_check_sudo
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_checkpoint
 
 tplg=${OPT_VALUE_lst['t']}
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
@@ -131,4 +131,4 @@ do
 done
 
 # check full log
-sof-kernel-log-check.sh $KERNEL_LAST_LINE
+sof-kernel-log-check.sh "$KERNEL_CHECKPOINT"

--- a/test-case/check-suspend-resume.sh
+++ b/test-case/check-suspend-resume.sh
@@ -41,7 +41,7 @@ OPT_PARM_lst['r']=0         OPT_VALUE_lst['r']=0
 
 func_opt_parse_option "$@"
 func_lib_check_sudo
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_checkpoint
 
 type=${OPT_VALUE_lst['T']}
 # switch type
@@ -91,5 +91,5 @@ do
 done
 
 # check full log
-sof-kernel-log-check.sh $KERNEL_LAST_LINE
+sof-kernel-log-check.sh "$KERNEL_CHECKPOINT"
 exit $?

--- a/test-case/check-xrun-injection.sh
+++ b/test-case/check-xrun-injection.sh
@@ -43,7 +43,7 @@ interval=${OPT_VALUE_lst['i']}
 
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
 
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_checkpoint
 func_lib_check_sudo
 
 case $test_mode in
@@ -122,5 +122,5 @@ do
     kill -9 $pid && wait $pid 2>/dev/null
 done
 
-sof-kernel-log-check.sh $KERNEL_LAST_LINE
+sof-kernel-log-check.sh "$KERNEL_CHECKPOINT"
 exit $?

--- a/test-case/multiple-pause-resume.sh
+++ b/test-case/multiple-pause-resume.sh
@@ -58,7 +58,7 @@ func_pipeline_export "$tplg" "type:any"
 
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
 
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_checkpoint
 
 declare -a pipeline_idx_lst
 declare -a cmd_idx_lst
@@ -190,5 +190,5 @@ do
     sof-kernel-log-check.sh 0 || die "Catch error in dmesg"
 done
 
-sof-kernel-log-check.sh $KERNEL_LAST_LINE
+sof-kernel-log-check.sh "$KERNEL_CHECKPOINT"
 exit $?

--- a/test-case/multiple-pipeline-capture.sh
+++ b/test-case/multiple-pipeline-capture.sh
@@ -51,7 +51,7 @@ max_count=0
 func_pipeline_export "$tplg" "type:any" # this line will help to get $PIPELINE_COUNT
 # get the min value of TPLG:'pipeline count' with Case:'pipeline count'
 [[ $PIPELINE_COUNT -gt ${OPT_VALUE_lst['c']} ]] && max_count=${OPT_VALUE_lst['c']} || max_count=$PIPELINE_COUNT
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_checkpoint
 
 # now small function define
 declare -A APP_LST DEV_LST
@@ -154,5 +154,5 @@ do
     sof-kernel-log-check.sh 0 || die "Catch error in dmesg"
 done
 
-sof-kernel-log-check.sh $KERNEL_LAST_LINE >/dev/null
+sof-kernel-log-check.sh "$KERNEL_CHECKPOINT" >/dev/null
 exit $?

--- a/test-case/multiple-pipeline-playback.sh
+++ b/test-case/multiple-pipeline-playback.sh
@@ -51,7 +51,7 @@ max_count=0
 func_pipeline_export "$tplg" "type:any" # this line will help to get $PIPELINE_COUNT
 # get the min value of TPLG:'pipeline count' with Case:'pipeline count'
 [[ $PIPELINE_COUNT -gt ${OPT_VALUE_lst['c']} ]] && max_count=${OPT_VALUE_lst['c']} || max_count=$PIPELINE_COUNT
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_checkpoint
 
 # now small function define
 declare -A APP_LST DEV_LST
@@ -154,5 +154,5 @@ do
     sof-kernel-log-check.sh 0 || die "Catch error in dmesg"
 done
 
-sof-kernel-log-check.sh $KERNEL_LAST_LINE >/dev/null
+sof-kernel-log-check.sh "$KERNEL_CHECKPOINT" >/dev/null
 exit $?

--- a/test-case/simultaneous-playback-capture.sh
+++ b/test-case/simultaneous-playback-capture.sh
@@ -57,7 +57,7 @@ id_lst_str=${id_lst_str/,/} # remove 1st, which is not used
 [[ ${#id_lst_str} -eq 0 ]] && dlogw "no pipeline with both playback and capture capabilities found in $tplg" && exit 2
 func_pipeline_export "$tplg" "id:$id_lst_str"
 [[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_checkpoint
 
 func_error_exit()
 {
@@ -115,5 +115,5 @@ do
     sof-kernel-log-check.sh 0 || die "Catch error in dmesg"
 done
 
-sof-kernel-log-check.sh $KERNEL_LAST_LINE > /dev/null
+sof-kernel-log-check.sh "$KERNEL_CHECKPOINT" > /dev/null
 exit $?

--- a/test-case/test-speaker.sh
+++ b/test-case/test-speaker.sh
@@ -32,7 +32,7 @@ tplg=${OPT_VALUE_lst['t']}
 
 func_pipeline_export "$tplg" "type:playback"
 tcnt=${OPT_VALUE_lst['l']}
-func_lib_setup_kernel_last_line
+func_lib_setup_kernel_checkpoint
 for idx in $(seq 0 $(expr $PIPELINE_COUNT - 1))
 do
     channel=$(func_pipeline_parse_value $idx channel)
@@ -54,5 +54,5 @@ do
     fi
 done
 
-sof-kernel-log-check.sh $KERNEL_LAST_LINE
+sof-kernel-log-check.sh "$KERNEL_CHECKPOINT"
 exit $?

--- a/test-case/volume-basic-test.sh
+++ b/test-case/volume-basic-test.sh
@@ -62,7 +62,7 @@ dlogi "pgalist number = ${#pgalist[@]}"
 
 for i in $(seq 1 $maxloop)
 do
-    func_lib_setup_kernel_last_line
+    func_lib_setup_kernel_checkpoint
     dlogi "===== Round($i/$maxloop) ====="
     # TODO: need to check command effect
     for i in "${pgalist[@]}"
@@ -80,7 +80,7 @@ do
     sleep 1
 
     dlogi "check dmesg for error"
-    sof-kernel-log-check.sh $KERNEL_LAST_LINE
+    sof-kernel-log-check.sh "$KERNEL_CHECKPOINT"
     [[ $? -ne 0 ]] && func_error_exit "dmesg has errors!"
 done
 


### PR DESCRIPTION
What we need is to set a checkpoint for kernel log to let
us start check kernel. Rename last_line to a more generic
name checkpoint.

Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>