### PR TITLE
multiple-pipeline-capture: show aplay/record processes left on fail

### DIFF
--- a/test-case/multiple-pipeline-capture.sh
+++ b/test-case/multiple-pipeline-capture.sh
@@ -95,6 +95,8 @@ func_run_pipeline_with_type()
 func_error_exit()
 {
     dloge "$*"
+    pgrep -a aplay
+    pgrep -a arecord
     pkill -9 aplay
     pkill -9 arecord
     exit 1


### PR DESCRIPTION
Only on a test failure.

Sample output:
```
15248 aplay -D hw:0,0 -c 2 -r 48000 -f S16_LE /dev/zero -q
15209 arecord -D hw:0,1 -c 2 -r 48000 -f S16_LE /dev/null -q
15218 arecord -D hw:0,2 -c 2 -r 16000 -f S16_LE /dev/null -q
15228 arecord -D hw:0,0 -c 2 -r 48000 -f S16_LE /dev/null -q
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>