### PR TITLE
multiple-pipeline-playback.sh: show aplay/arecord processes left on fail

### DIFF
--- a/test-case/multiple-pipeline-playback.sh
+++ b/test-case/multiple-pipeline-playback.sh
@@ -95,6 +95,8 @@ func_run_pipeline_with_type()
 func_error_exit()
 {
     dloge "$*"
+    pgrep -a aplay
+    pgrep -a arecord
     pkill -9 aplay
     pkill -9 arecord
     exit 1


### PR DESCRIPTION
Display PID of aplay/arecord on failure.

Signed-off-by: Fred Oh <fred.oh@linux.intel.com>

I was so thrilled to see https://github.com/thesofproject/sof-test/pull/507. Missed playback test need same fix.