### PR TITLE
use journalctl as default kernel log reader

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -41,7 +41,7 @@ fi
 func_lib_setup_kernel_checkpoint()
 {
     # shellcheck disable=SC2034 # external script will use it
-    KERNEL_CHECKPOINT=$(wc -l /var/log/kern.log|awk '{print $1;}')
+    KERNEL_CHECKPOINT=$(date +%s)
 }
 
 # This function adds a fake error to dmesg (which is always saved by

--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -311,3 +311,10 @@ is_sof_used()
 {
     grep -q "sof" /proc/asound/cards;
 }
+
+# a wrapper to journalctl with required style
+journalctl_cmd()
+{
+   journalctl -k -q --no-pager --utc --output=short-monotonic \
+     --no-hostname  "$@"
+}

--- a/test-case/verify-sof-firmware-load.sh
+++ b/test-case/verify-sof-firmware-load.sh
@@ -20,13 +20,11 @@ source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
 func_opt_parse_option "$@"
 
-if ! alias | grep -q 'Sub-Test'; then
-    # hijack DMESG_LOG_START_LINE which refer dump kernel log in exit function
-    DMESG_LOG_START_LINE=$(sof-get-kernel-line.sh|tail -n 1 |awk '{print $1;}')
-    cmd="sof-kernel-dump.sh"
-else
-    cmd="journalctl --dmesg --no-pager"
-fi
+# hijack DMESG_LOG_START_LINE to dump kernel from file start is not Sub-Test
+# TODO: clean up Sub-Test feature
+alias | grep -q 'Sub-Test' || DMESG_LOG_START_LINE=$(sof-get-kernel-line.sh | tail -n 1 | awk '{print $1;}' )
+
+cmd="journalctl_cmd"
 
 dlogi "Checking SOF Firmware load info in kernel log"
 if $cmd | grep -q " sof-audio.*Firmware.*version"; then
@@ -36,12 +34,8 @@ if $cmd | grep -q " sof-audio.*Firmware.*version"; then
     $cmd | grep "Firmware debug build" -A3 | head -n 12
     exit 0
 else
-    printf ' ------\n  debuging with /var/log/kern.log  \n ---- \n'
-    ls -alht /var/log/kern.log
-    grep -na "Linux version" /var/log/kern.log || true
-    printf ' ------\n  cmd was %s, DMESG_LOG_START_LINE was %s  \n ---- \n' \
-            "$cmd" "$DMESG_LOG_START_LINE"
-    journalctl --dmesg --lines 50 --no-pager
-    journalctl --dmesg | grep -C 1 " sof-audio.*Firmware.*version" || true
+    journalctl_cmd --lines 50 || true
+    printf ' ------\n  debugging with systemd journalctl  \n ---- \n'
+    systemctl status systemd-journald* || true
     die "Cannot find the sof audio version"
 fi

--- a/tools/sof-get-default-tplg.sh
+++ b/tools/sof-get-default-tplg.sh
@@ -1,14 +1,12 @@
 #!/bin/bash
+#
+# read kernel log to get topology file loaded by SOF driver
+# Example from an apl up2 pcm512x device:
+#
+# sof-audio-pci 0000:00:0e.0: loading topology:intel/sof-tplg/sof-apl-pcm512x.tplg
+#
+# sof-apl-pcm512x.tplg will be returned
+#
 
-# Current: load TPLG file order:
-# dmesg
-# journalctl
-# /var/log/syslog (sof-kernel-dump.sh)
-# Future: possibly be loaded from elsewhere
-# Notice: Only verified on Ubuntu 18.04
-tplg_file=$(dmesg |grep -i topology|awk -F ':' '/tplg/ {print $NF;}'|tail -n 1)
-[[ ! "$tplg_file" ]] && \
-    tplg_file=$(journalctl -k |grep -i topology |awk -F ':' '/tplg/ {print $NF;}'|tail -n 1)
-[[ ! "$tplg_file" ]] && \
-    tplg_file=$(sof-kernel-dump.sh |grep -i topology|awk -F ':' '/tplg/ {print $NF;}'|tail -n 1)
+tplg_file=$(journalctl -k |grep -i topology |awk -F ':' '/tplg/ {print $NF;}'|tail -n 1)
 [[ "$tplg_file" ]] && basename "$tplg_file" || echo ""

--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -126,11 +126,14 @@
 # Append some garbage to an ignore pattern to turn it off. Much easier
 # than deleting it.
 
-
-begin_line=${1:-1}
+# fallback to use dmseg when set to 0.
+# TODO: update the fallback option when drop dmesg
+begin_timestamp=${1:-0}
 declare err_str ignore_str
 
-platform=$($(dirname "$0")/sof-dump-status.py -p)
+# pwd resolves relative paths
+my_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+platform=$("$my_dir"/sof-dump-status.py -p)
 
 err_str="error|failed|timed out|panic|oops"
 
@@ -250,32 +253,22 @@ case "$platform" in
         ;;
 esac
 
-[[ ! "$err_str" ]] && echo "Missing error keyword list" && exit 0
-# dmesg KB size buffer size
-#dmesg_config_define=$(awk -F '=' '/CONFIG_LOG_BUF_SHIFT/ {print $2;}' /boot/config-$(uname -r))
-#dmesg_buffer_size=$( echo $(( (1<<$dmesg_config_define) / 1024 )) )
-# kernel file log buffer size
-#kernel_buffer_size=$(du -k /var/log/kern.log |awk '{print $1;}')
-# now decide using which to catch the kernel log
-#[[ $kernel_buffer_size -lt $dmesg ]] && cmd="dmesg" || cmd="tail -n  +${begin_line}  /var/log/kern.log"
+# confirm begin_timestamp is in UNIX timestamp format, otherwise use dmesg
+# TODO: drop dmesg usage as fallback and use no --since as fallback
+journalctlflag="-k -q --no-pager --utc --output=short-iso --no-hostname"
+[[ $begin_timestamp =~ ^[0-9]{10} ]] && cmd="journalctl $journalctlflag --since=@$begin_timestamp" || cmd="dmesg"
 
-# confirm begin_line is number, if it is not the number, direct using dmesg
-[[ "${begin_line//[0-9]/}" ]] && begin_line=0
-[[ "$begin_line" -eq 0 ]] && cmd="dmesg" || cmd="tail -n  +${begin_line}  /var/log/kern.log"
-
-#echo "run $0 with parameter '$*' for check kernel message error"
-
-# declare -p cmd
+declare -p cmd
 if [ "$ignore_str" ]; then
-    err=$(   $cmd | grep 'Call Trace' -A5 -B3)$(     $cmd | grep -E "$err_str"|grep -vE "$ignore_str")
+    err=$($cmd | grep 'Call Trace' -A5 -B3)$($cmd | grep -E "$err_str"|grep -vE "$ignore_str")
 else
-    err=$(   $cmd | grep 'Call Trace' -A5 -B3)$(     $cmd | grep -E "$err_str")
+    err=$($cmd | grep 'Call Trace' -A5 -B3)$($cmd | grep -E "$err_str")
 fi
 
-if [ "$err" ]; then
-    echo "$(date -u '+%Y-%m-%d %T %Z')" "[ERROR]" "Caught dmesg error"
+[[ -z "$err" ]] || {
+    echo "$(date -u '+%Y-%m-%d %T %Z')" "[ERROR]" "Caught kernel log error"
     echo "===========================>>"
     echo "$err"
     echo "<<==========================="
     builtin exit 1
-fi
+}

--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -130,7 +130,7 @@
 begin_line=${1:-1}
 declare err_str ignore_str
 
-platform=$(sof-dump-status.py -p)
+platform=$($(dirname "$0")/sof-dump-status.py -p)
 
 err_str="error|failed|timed out|panic|oops"
 


### PR DESCRIPTION
Use timestamp as checkpoint for each test case.
use journalctl to read kernel logs in sof-kernel-log-check.sh
use journalctl in other kernel read scripts.