### PR TITLE
kmod-load-reload: don't hide FW load check logs

### DIFF
--- a/test-case/check-kmod-load-unload.sh
+++ b/test-case/check-kmod-load-unload.sh
@@ -91,7 +91,7 @@ do
         die "Found error(s) in kernel log after module insertion"
 
     dlogi "checking if firmware is loaded successfully"
-    "$(dirname "${BASH_SOURCE[0]}")"/verify-sof-firmware-load.sh > /dev/null ||
+    "$(dirname "${BASH_SOURCE[0]}")"/verify-sof-firmware-load.sh ||
          die "Failed to load firmware after module insertion"
 
     # successful remove/insert module pass


### PR DESCRIPTION
The output of sub-case verify-sof-firmware-load.sh
gives hints on why test case failed, should not hide
its output.

Signed-off-by: Amery Song <chao.song@intel.com>