### PR TITLE
func_exit_handler: print 'Test Result: FAIL!' for unknown exit codes

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -93,6 +93,8 @@ function func_exit_handler()
         exit_status=$ret
     fi
 
+    # We must always print some 'Test Result' otherwise some callers
+    # will time out
     case $exit_status in
         0)
             dlogi "Test Result: PASS!"
@@ -105,6 +107,7 @@ function func_exit_handler()
         ;;
         *)
             dlogi "Unknown exit code: $exit_status"
+            dlogi "Test Result: FAIL!"
         ;;
     esac
 


### PR DESCRIPTION
We must always print some 'Test Result' otherwise some callers will time
out, see alsabat example in
https://sof-ci.01.org/linuxpr/PR2501/build4685/devicetest/

Fixes: #441

Signed-off-by: Marc Herbert <marc.herbert@intel.com>