### PR TITLE
pipeline.sh: fail if no pipeline found from proc

### DIFF
--- a/case-lib/pipeline.sh
+++ b/case-lib/pipeline.sh
@@ -25,6 +25,7 @@ func_pipeline_export()
         # shellcheck disable=SC1090
         source "$tmp_pipeline_params" || return 1
         rm "$tmp_pipeline_params"
+        [ "$PIPELINE_COUNT" -ne 0 ] || die "No pipeline found from proc file system"
         return 0
     }
 


### PR DESCRIPTION
As we discussed in https://github.com/thesofproject/sof-test/issues/504, let fail the case if no pipeline found from proc.

BTW, if no pipeline found from proc, we must have some serious P1 issues.

Signed-off-by: Amery Song <chao.song@intel.com>