### PR TITLE
sof-process-state: print errors on stderr

### DIFF
--- a/tools/sof-process-state.sh
+++ b/tools/sof-process-state.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
 
-[[ $# -ne 1 ]] && echo "This script needs parameter: pid/process-name to dump its state" && builtin exit 2
+# This script uses ps to inspect the state of either:
+#
+# - a single process specified by its PID number, or
+# - all running instances of a given command like "aplay" or "arecord"
+#
+# Exit status
+# 0  if at least one process was found and they're _all_ OK
+# 1  if at least one process was found at least one of them is abnormal
+# 2  if no process match, or
+#       wrong number of arguments given
+
+[[ $# -ne 1 ]] && >&2 echo "This script needs parameter: pid/process-name to dump its state" && builtin exit 2
 
 # catch from man ps: PROCESS STATE CODES
 declare -A PS_STATUS
@@ -19,7 +30,7 @@ process=$1
 exit_code=1
 # process does not exist
 [[ ! "$(ps $opt $process -o state --no-header)" ]] && \
-    builtin echo "process: $process status: process run finished/not run" && builtin exit 2
+    >&2 builtin echo "process: $process, status: not found" && builtin exit 2
 
 abnormal_status=0
 # process status detect


### PR DESCRIPTION
... because its normal output is typically discarded.

This would have avoided regression 202507fe0c71 / #497 fixed by #521.

This could help with other multi pipelines issues.

Also add a documentation header so not everyone has to read the entire
code.

Also add a warning about the massive copy/paste across
multiple-pipeline-playback and multiple-pipeline-capture (these are the
heaviest sof-process-state users).

Signed-off-by: Marc Herbert <marc.herbert@intel.com>