### PR TITLE
multiple-pipeline-capture: simplify func_error_exit()

### DIFF
--- a/test-case/multiple-pipeline-capture.sh
+++ b/test-case/multiple-pipeline-capture.sh
@@ -98,12 +98,10 @@ func_run_pipeline_with_type()
 func_error_exit()
 {
     dloge "$*"
-    ( set +e
-      pgrep -a aplay
-      pgrep -a arecord
-      pkill -9 aplay
-      pkill -9 arecord
-    )
+
+    pgrep -a aplay   &&  pkill -9 aplay
+    pgrep -a arecord &&  pkill -9 arecord
+
     exit 1
 }
 


### PR DESCRIPTION
As suggested by Chao in #521

Also remove no-op exit $? on the last line.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>