### PR TITLE
Make multiple-pipeline-playback 99% identical to -capture again

### DIFF
--- a/test-case/multiple-pipeline-capture.sh
+++ b/test-case/multiple-pipeline-capture.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+### WARNING: this file is 99% COPY/PASTE from multiple-pipeline-playback.sh! ###
+
 ##
 ## Case Name: Run multiple pipelines for capture
 ## Preconditions:


### PR DESCRIPTION
While making recent changes to multiple-pipeline-capture.sh I had
vaguely noticed some similarities with multiple-pipeline-playback.sh but
I had naively not realized that they were both an exact copy/paste of
each other except for a couple lines. This commit make -playback catch
up with recent -capture enhancements. It also makes them nearly
identical again which is the first step before (painful) deduplication.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>