### PR TITLE
check-alsabat: use aplay/arecord exit status in precheck

### DIFF
--- a/test-case/check-alsabat.sh
+++ b/test-case/check-alsabat.sh
@@ -66,8 +66,8 @@ function __upload_wav_file
 
 # check the PCMs before alsabat test
 dlogi "check the PCMs before alsabat test"
-[[ $(aplay -Dplug$pcm_p -d 1 /dev/zero -q) ]] && die "Failed to play on PCM: $pcm_p"
-[[ $(arecord -Dplug$pcm_c -d 1 /dev/null -q) ]] && die "Failed to capture on PCM: $pcm_c"
+aplay   -Dplug$pcm_p -d 1 /dev/zero -q || die "Failed to play on PCM: $pcm_p"
+arecord -Dplug$pcm_c -d 1 /dev/null -q || die "Failed to capture on PCM: $pcm_c"
 
 # alsabat test
 # different PCMs may support different audio formats(like samplerate, channel-counting, etc.).


### PR DESCRIPTION
... as opposed to assuming that any -q output is an error message.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>