### PR TITLE
kmod: add max98373_i2c codec driver name

### DIFF
--- a/tools/kmod/sof_insert.sh
+++ b/tools/kmod/sof_insert.sh
@@ -35,6 +35,7 @@ insert_module snd_soc_wm8804_i2c
 insert_module snd_soc_max98357a
 insert_module snd_soc_max98090
 insert_module snd_soc_max98373
+insert_module snd_soc_max98373_i2c
 insert_module snd_soc_max98373_sdw
 
 insert_module snd_soc_rt700

--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -117,6 +117,7 @@ remove_module snd_soc_max98090
 remove_module snd_soc_ts3a227e
 remove_module snd_soc_max98357a
 remove_module snd_soc_max98373_sdw
+remove_module snd_soc_max98373_i2c
 remove_module snd_soc_max98373
 
 remove_module snd_soc_hdac_hda


### PR DESCRIPTION
max98373_i2c driver is spilt from max98373 codec driver.

Signed-off-by: Zhang Keqiao <keqiao.zhang@linux.intel.com>