### PR TITLE
multiple-pipeline: replace pidof->ps to catch uninterruptible sleep

### DIFF
--- a/test-case/multiple-pipeline.sh
+++ b/test-case/multiple-pipeline.sh
@@ -66,8 +66,6 @@ DEV_LST['playback']='/dev/zero'
 APP_LST['capture']='arecord_opts'
 DEV_LST['capture']='/dev/null'
 
-tmp_count=$max_count
-
 # define for load pipeline
 func_run_pipeline_with_type()
 {
@@ -117,10 +115,12 @@ do
     f_arg=${OPT_VALUE_lst['f']}
     case "$f_arg" in
         'p')
+            tmp_count=$max_count
             func_run_pipeline_with_type "playback"
             func_run_pipeline_with_type "capture"
             ;;
         'c')
+            tmp_count=$max_count
             func_run_pipeline_with_type "capture"
             func_run_pipeline_with_type "playback"
             ;;


### PR DESCRIPTION
pidof ignores processes in uninterruptable sleep by default, probably
because sending them signals is futile. pidof has a -z option but it's
just simpler to use "ps".

Also de-duplicate code into new ps_checks() function

Fixes: #472

Any aplay or arecord process can be in uninterruptable sleep when doing
I/O but the easiest way to reproduce is to wait a few seconds and let the
DSP go to sleep.