### PR TITLE
multiple-pipeline: remove initial sleep and clarify second sleep

### DIFF
--- a/test-case/multiple-pipeline.sh
+++ b/test-case/multiple-pipeline.sh
@@ -47,7 +47,7 @@ OPT_NAME['f']='first'
 OPT_DESC['f']='Fill either playback (p) or capture (c) first or any (a) for all pipelines'
 OPT_HAS_ARG['f']=1         OPT_VAL['f']='p'
 
-OPT_NAME['w']='wait'     OPT_DESC['w']='perpare wait time by sleep'
+OPT_NAME['w']='wait'     OPT_DESC['w']='duration of one (sub)test iteration'
 OPT_HAS_ARG['w']=1         OPT_VAL['w']=5
 
 OPT_NAME['r']='random'   OPT_DESC['r']='random load pipeline'
@@ -163,13 +163,10 @@ do
             die "Wrong -f argument $f_arg, see -h"
     esac
 
-    dlogi "sleep ${OPT_VAL['w']}s for sound device wakeup"
-    sleep ${OPT_VAL['w']}
-
     dlogi "checking pipeline status"
     ps_checks
 
-    dlogi "preparing sleep ${OPT_VAL['w']}"
+    dlogi "Letting playback/capture run for ${OPT_VAL['w']}s"
     sleep ${OPT_VAL['w']}
 
     # check processes again


### PR DESCRIPTION
Having the same -w parameter for both this initial sleep and the test
duration made no sense: fixed by removing the first sleep.

It's not clear what the purpose of this first sleep was, it has been in
multiple-pipeline-capture/playback.sh since the dawn of time (= commit
39cd964ddc776c) For sure this first sleep was helping hide
"uninterruptible state" bug #472 by giving the DSP more time to wake up!

Signed-off-by: Marc Herbert <marc.herbert@intel.com>