### PR TITLE
sof-kernel-log-check: fix to filter out USB3.1 suspend/resume error

### DIFF
--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -204,8 +204,8 @@ ignore_str="$ignore_str"'|usb 2-.: .'
 
 # TGL devices with USB 3.1 devices, issues reported by sof-test
 # BugLink: https://github.com/thesofproject/sof-test/issues/482
-ignore_str="$ignore_str"'|usb 3-.: device descriptor read/64, error .'
-ignore_str="$ignore_str"'|usb 3-.: device not accepting address ., error .'
+ignore_str="$ignore_str"'|usb 3-.+: device descriptor read/64, error .+'
+ignore_str="$ignore_str"'|usb 3-.+.: device not accepting address .+, error .+'
 
 # Test cases on some platforms fail because the boot retry message:
 #


### PR DESCRIPTION
'.' is single charactor. Template string doesn't need error number
to have.

Signed-off-by: Fred Oh <fred.oh@linux.intel.com>

Still test will be failed due to this errors without this fix.
```
[   28.970627] kernel: usb 3-10: device descriptor read/64, error -71
[   29.193611] kernel: usb 3-10: device descriptor read/64, error -71
[   29.526684] kernel: usb 3-10: device descriptor read/64, error -71
[   29.746289] kernel: usb 3-10: device descriptor read/64, error -71
[   30.887534] kernel: usb 3-10: device not accepting address 13, error -71
[   31.415512] kernel: usb 3-10: device not accepting address 14, error -71
```