### PR TITLE
sof-kernel-log-check: ignore a usb error on TGL

### DIFF
--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -206,6 +206,7 @@ ignore_str="$ignore_str"'|usb 2-.: .'
 # BugLink: https://github.com/thesofproject/sof-test/issues/482
 ignore_str="$ignore_str"'|usb 3-.+: device descriptor read/64, error .+'
 ignore_str="$ignore_str"'|usb 3-.+.: device not accepting address .+, error .+'
+ignore_str="$ignore_str"'|usb usb.-port.+: unable to enumerate USB device'
 
 # Test cases on some platforms fail because the boot retry message:
 #


### PR DESCRIPTION
After using journalctl, third-party error message
which doesn't contain predefined keywords will be
collected, too. Ignore a USB error on TGL in this
patch.

Signed-off-by: Amery Song <chao.song@intel.com>