### PR TITLE
sof-kernel-log-check: refine filter string for USB error

### DIFF
--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -204,8 +204,8 @@ ignore_str="$ignore_str"'|usb 2-.: .'
 
 # TGL devices with USB 3.1 devices, issues reported by sof-test
 # BugLink: https://github.com/thesofproject/sof-test/issues/482
-ignore_str="$ignore_str"'|usb 3-.+: device descriptor read/64, error .+'
-ignore_str="$ignore_str"'|usb 3-.+.: device not accepting address .+, error .+'
+ignore_str="$ignore_str"'|usb 3-.+: device descriptor read/64, error'
+ignore_str="$ignore_str"'|usb 3-.+.: device not accepting address .+, error'
 ignore_str="$ignore_str"'|usb usb.-port.+: unable to enumerate USB device'
 
 # Test cases on some platforms fail because the boot retry message:


### PR DESCRIPTION
Remove the ending '.+' to avoid shadowing of preceeding
filter string.

Fixes: b5138778

Signed-off-by: Amery Song <chao.song@intel.com>

suggested by @marc-hb , thanks