### PR TITLE
sof-kernel-log-check: ignore net related error

### DIFF
--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -308,6 +308,12 @@ ignore_str="$ignore_str"'|proc_thermal 0000:00:..\..: No auxiliary DTSs enabled'
 # elan_i2c i2c-ELAN0000:00: invalid report id data (ff)
 ignore_str="$ignore_str"'|elan_i2c i2c-ELAN0000:.*: invalid report id data'
 
+# net related error logs can be ignored
+# origin logs seen on TGL platforms
+ignore_str="$ignore_str"'|asix .*:'
+# origin logs seen on CML platforms
+ignore_str="$ignore_str"'|e1000e .*:'
+
 #
 # SDW related logs
 #


### PR DESCRIPTION
add ignore for asix and e1000e seriers network adapter

Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>

Fix #564 #565