### PR TITLE
sof-kernel-log-check: revise ignore_str for usb errors

### DIFF
--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -204,8 +204,10 @@ ignore_str="$ignore_str"'|usb 2-.: .'
 
 # TGL devices with USB 3.1 devices, issues reported by sof-test
 # BugLink: https://github.com/thesofproject/sof-test/issues/482
-ignore_str="$ignore_str"'|usb 3-.+: device descriptor read/64, error'
-ignore_str="$ignore_str"'|usb 3-.+.: device not accepting address .+, error'
+# CML Helios reported usb errors in kmod test, and caused false failure
+# BugLink: https://github.com/thesofproject/sof-test/issues/567
+ignore_str="$ignore_str"'|usb .-.+: device descriptor read/.+, error'
+ignore_str="$ignore_str"'|usb .-.+.: device not accepting address .+, error'
 ignore_str="$ignore_str"'|usb usb.-port.+: unable to enumerate USB device'
 
 # Test cases on some platforms fail because the boot retry message:


### PR DESCRIPTION
Helios reported some usb errors, and caused false
failure.

This patch revises ignore_str to also ignore the usb
errors on Helios.

Fixes: #567

Signed-off-by: Amery Song <chao.song@intel.com>