### PR TITLE
sof-test: rename OPT_OPT_lst and OPT_DESC_lst

### DIFF
--- a/case-lib/opt.sh
+++ b/case-lib/opt.sh
@@ -3,26 +3,26 @@
 # Before using this, you must define these option arrays in your test
 # script. They must all be indexed by some unique, one-character
 # codename for each of your option.
-declare -A OPT_DESC_lst OPT_NAME OPT_PARM_lst OPT_VALUE_lst
+declare -A OPT_DESC OPT_NAME OPT_PARM_lst OPT_VALUE_lst
 
 # option setup && parse function
 func_opt_parse_option()
 {
     # OPT_NAME     (long) option name
-    # OPT_DESC_lst    short sentence describing the option
+    # OPT_DESC    short sentence describing the option
     # OPT_PARM_lst    0 or 1: number of argument required
     # OPT_VALUE_lst   default value overwritten by command line
     #                 input if any. Set to 0 or 1 when PARM=0
 
     # for example
     # OPT_NAME['r']='remote'
-    # OPT_DESC_lst['r']='Run for the remote machine'
+    # OPT_DESC['r']='Run for the remote machine'
     # OPT_PARM_lst['r']=1
     # OPT_VALUE_lst['r']='' ## if PARM=1, must be set, if PARM=0, can ignore
 
     # h & help is default option, so don't need to add into option list
     OPT_NAME['h']='help'
-    OPT_DESC_lst['h']='this message'
+    OPT_DESC['h']='this message'
     OPT_PARM_lst['h']=0
     OPT_VALUE_lst['h']=0
 
@@ -48,7 +48,7 @@ func_opt_parse_option()
     {
          # options in getopt format
         local i _short_opt _long_opt
-        for i in ${!OPT_DESC_lst[*]}
+        for i in ${!OPT_DESC[*]}
         do
             _short_opt=$_short_opt"$i"
             _op_short_lst["-$i"]="$i"
@@ -76,7 +76,7 @@ func_opt_parse_option()
     {
         local i
         printf 'Usage: %s [OPTION]\n' "$0"
-        for i in ${!OPT_DESC_lst[*]}
+        for i in ${!OPT_DESC[*]}
         do
                 [ "X$i" = "Xh" ] && continue
                 # display short option
@@ -90,7 +90,7 @@ func_opt_parse_option()
                     printf '%s' "--${OPT_NAME[$i]}"
                     [ "X${OPT_PARM_lst[$i]}" == "X1" ] && printf ' parameter'
                 fi
-                printf '\n\t%s\n' "${OPT_DESC_lst[$i]}"
+                printf '\n\t%s\n' "${OPT_DESC[$i]}"
                 if [ "${OPT_VALUE_lst[$i]}" ]; then
                     if [ "${OPT_PARM_lst[$i]}" -eq 1 ]; then
                         printf '\tDefault Value: %s\n' "${OPT_VALUE_lst[$i]}"

--- a/case-lib/opt.sh
+++ b/case-lib/opt.sh
@@ -3,25 +3,25 @@
 # Before using this, you must define these option arrays in your test
 # script. They must all be indexed by some unique, one-character
 # codename for each of your option.
-declare -A OPT_DESC_lst OPT_OPT_lst OPT_PARM_lst OPT_VALUE_lst
+declare -A OPT_DESC_lst OPT_NAME OPT_PARM_lst OPT_VALUE_lst
 
 # option setup && parse function
 func_opt_parse_option()
 {
-    # OPT_OPT_lst     (long) option name
+    # OPT_NAME     (long) option name
     # OPT_DESC_lst    short sentence describing the option
     # OPT_PARM_lst    0 or 1: number of argument required
     # OPT_VALUE_lst   default value overwritten by command line
     #                 input if any. Set to 0 or 1 when PARM=0
 
     # for example
-    # OPT_OPT_lst['r']='remote'
+    # OPT_NAME['r']='remote'
     # OPT_DESC_lst['r']='Run for the remote machine'
     # OPT_PARM_lst['r']=1
     # OPT_VALUE_lst['r']='' ## if PARM=1, must be set, if PARM=0, can ignore
 
     # h & help is default option, so don't need to add into option list
-    OPT_OPT_lst['h']='help'
+    OPT_NAME['h']='help'
     OPT_DESC_lst['h']='this message'
     OPT_PARM_lst['h']=0
     OPT_VALUE_lst['h']=0
@@ -53,9 +53,9 @@ func_opt_parse_option()
             _short_opt=$_short_opt"$i"
             _op_short_lst["-$i"]="$i"
             [ "$_long_opt" ] && _long_opt="$_long_opt"','
-            if [ "${OPT_OPT_lst[$i]}" ]; then
-                _long_opt=$_long_opt"${OPT_OPT_lst[$i]}"
-                _op_long_lst["--${OPT_OPT_lst[$i]}"]="$i"
+            if [ "${OPT_NAME[$i]}" ]; then
+                _long_opt=$_long_opt"${OPT_NAME[$i]}"
+                _op_long_lst["--${OPT_NAME[$i]}"]="$i"
             fi
             # append ':' if the option accepts an argument
             [ ${OPT_PARM_lst[$i]} -eq 1 ] && _short_opt=$_short_opt':' && _long_opt=$_long_opt':'
@@ -84,10 +84,10 @@ func_opt_parse_option()
                 # have parameter
                 [ "X${OPT_PARM_lst[$i]}" == "X1" ] && printf ' parameter'
                 # display long option
-                if [ "${OPT_OPT_lst[$i]}" ]; then
+                if [ "${OPT_NAME[$i]}" ]; then
                     # whether display short option
                     [ "$i" ] && printf ' |  ' || printf '    '
-                    printf '%s' "--${OPT_OPT_lst[$i]}"
+                    printf '%s' "--${OPT_NAME[$i]}"
                     [ "X${OPT_PARM_lst[$i]}" == "X1" ] && printf ' parameter'
                 fi
                 printf '\n\t%s\n' "${OPT_DESC_lst[$i]}"
@@ -118,7 +118,7 @@ func_opt_parse_option()
 
     # Iterate over command line input and overwrite OPT_VALUE_lst
     # default values.
-    # declare -p OPT_OPT_lst OPT_VALUE_lst
+    # declare -p OPT_NAME OPT_VALUE_lst
     local idx
     while true ; do
         # idx is our internal one-character code name unique for each option

--- a/test-case/check-alsabat.sh
+++ b/test-case/check-alsabat.sh
@@ -21,19 +21,19 @@ rm -f /tmp/bat.wav.*
 # shellcheck source=case-lib/lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
-OPT_NAME['p']='pcm_p'     	OPT_DESC_lst['p']='pcm for playback. Example: hw:0,0'
+OPT_NAME['p']='pcm_p'     	OPT_DESC['p']='pcm for playback. Example: hw:0,0'
 OPT_PARM_lst['p']=1          	OPT_VALUE_lst['p']=''
 
-OPT_NAME['c']='pcm_c'      	OPT_DESC_lst['c']='pcm for capture. Example: hw:1,0'
+OPT_NAME['c']='pcm_c'      	OPT_DESC['c']='pcm for capture. Example: hw:1,0'
 OPT_PARM_lst['c']=1             OPT_VALUE_lst['c']=''
 
-OPT_NAME['f']='frequency'    OPT_DESC_lst['f']='target frequency'
+OPT_NAME['f']='frequency'    OPT_DESC['f']='target frequency'
 OPT_PARM_lst['f']=1             OPT_VALUE_lst['f']=997
 
-OPT_NAME['n']='frames'     OPT_DESC_lst['n']='test frames'
+OPT_NAME['n']='frames'     OPT_DESC['n']='test frames'
 OPT_PARM_lst['n']=1             OPT_VALUE_lst['n']=240000
 
-OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
 func_opt_parse_option "$@"

--- a/test-case/check-alsabat.sh
+++ b/test-case/check-alsabat.sh
@@ -21,19 +21,19 @@ rm -f /tmp/bat.wav.*
 # shellcheck source=case-lib/lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
-OPT_OPT_lst['p']='pcm_p'     	OPT_DESC_lst['p']='pcm for playback. Example: hw:0,0'
+OPT_NAME['p']='pcm_p'     	OPT_DESC_lst['p']='pcm for playback. Example: hw:0,0'
 OPT_PARM_lst['p']=1          	OPT_VALUE_lst['p']=''
 
-OPT_OPT_lst['c']='pcm_c'      	OPT_DESC_lst['c']='pcm for capture. Example: hw:1,0'
+OPT_NAME['c']='pcm_c'      	OPT_DESC_lst['c']='pcm for capture. Example: hw:1,0'
 OPT_PARM_lst['c']=1             OPT_VALUE_lst['c']=''
 
-OPT_OPT_lst['f']='frequency'    OPT_DESC_lst['f']='target frequency'
+OPT_NAME['f']='frequency'    OPT_DESC_lst['f']='target frequency'
 OPT_PARM_lst['f']=1             OPT_VALUE_lst['f']=997
 
-OPT_OPT_lst['n']='frames'     OPT_DESC_lst['n']='test frames'
+OPT_NAME['n']='frames'     OPT_DESC_lst['n']='test frames'
 OPT_PARM_lst['n']=1             OPT_VALUE_lst['n']=240000
 
-OPT_OPT_lst['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
 func_opt_parse_option "$@"

--- a/test-case/check-audio-equalizer.sh
+++ b/test-case/check-audio-equalizer.sh
@@ -20,16 +20,16 @@ set -e
 my_dir=$(dirname "${BASH_SOURCE[0]}")
 source "$my_dir"/../case-lib/lib.sh
 
-OPT_NAME['t']='tplg'     OPT_DESC_lst['t']="tplg file, default value is env TPLG: $TPLG"
+OPT_NAME['t']='tplg'     OPT_DESC['t']="tplg file, default value is env TPLG: $TPLG"
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
-OPT_NAME['d']='duration' OPT_DESC_lst['d']='aplay duration in second'
+OPT_NAME['d']='duration' OPT_DESC['d']='aplay duration in second'
 OPT_PARM_lst['d']=1         OPT_VALUE_lst['d']=5
 
-OPT_NAME['l']='loop'     OPT_DESC_lst['l']='loop count'
+OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=1
 
-OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
 func_opt_parse_option "$@"

--- a/test-case/check-audio-equalizer.sh
+++ b/test-case/check-audio-equalizer.sh
@@ -20,16 +20,16 @@ set -e
 my_dir=$(dirname "${BASH_SOURCE[0]}")
 source "$my_dir"/../case-lib/lib.sh
 
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']="tplg file, default value is env TPLG: $TPLG"
+OPT_NAME['t']='tplg'     OPT_DESC_lst['t']="tplg file, default value is env TPLG: $TPLG"
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
-OPT_OPT_lst['d']='duration' OPT_DESC_lst['d']='aplay duration in second'
+OPT_NAME['d']='duration' OPT_DESC_lst['d']='aplay duration in second'
 OPT_PARM_lst['d']=1         OPT_VALUE_lst['d']=5
 
-OPT_OPT_lst['l']='loop'     OPT_DESC_lst['l']='loop count'
+OPT_NAME['l']='loop'     OPT_DESC_lst['l']='loop count'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=1
 
-OPT_OPT_lst['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
 func_opt_parse_option "$@"

--- a/test-case/check-capture.sh
+++ b/test-case/check-capture.sh
@@ -21,31 +21,31 @@ set -e
 # shellcheck source=case-lib/lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
-OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $''TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $''TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
-OPT_NAME['r']='round'     OPT_DESC_lst['r']='round count'
+OPT_NAME['r']='round'     OPT_DESC['r']='round count'
 OPT_PARM_lst['r']=1         OPT_VALUE_lst['r']=1
 
-OPT_NAME['d']='duration' OPT_DESC_lst['d']='arecord duration in second'
+OPT_NAME['d']='duration' OPT_DESC['d']='arecord duration in second'
 OPT_PARM_lst['d']=1         OPT_VALUE_lst['d']=10
 
-OPT_NAME['l']='loop'     OPT_DESC_lst['l']='loop count'
+OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=3
 
-OPT_NAME['o']='output'   OPT_DESC_lst['o']='output dir'
+OPT_NAME['o']='output'   OPT_DESC['o']='output dir'
 OPT_PARM_lst['o']=1         OPT_VALUE_lst['o']="$LOG_ROOT/wavs"
 
-OPT_NAME['f']='file'   OPT_DESC_lst['f']='file name prefix'
+OPT_NAME['f']='file'   OPT_DESC['f']='file name prefix'
 OPT_PARM_lst['f']=1         OPT_VALUE_lst['f']=''
 
-OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
-OPT_NAME['F']='fmts'   OPT_DESC_lst['F']='Iterate all supported formats'
+OPT_NAME['F']='fmts'   OPT_DESC['F']='Iterate all supported formats'
 OPT_PARM_lst['F']=0         OPT_VALUE_lst['F']=0
 
-OPT_NAME['S']='filter_string'   OPT_DESC_lst['S']="run this case on specified pipelines"
+OPT_NAME['S']='filter_string'   OPT_DESC['S']="run this case on specified pipelines"
 OPT_PARM_lst['S']=1             OPT_VALUE_lst['S']="id:any"
 
 func_opt_parse_option "$@"

--- a/test-case/check-capture.sh
+++ b/test-case/check-capture.sh
@@ -21,31 +21,31 @@ set -e
 # shellcheck source=case-lib/lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $''TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $''TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
-OPT_OPT_lst['r']='round'     OPT_DESC_lst['r']='round count'
+OPT_NAME['r']='round'     OPT_DESC_lst['r']='round count'
 OPT_PARM_lst['r']=1         OPT_VALUE_lst['r']=1
 
-OPT_OPT_lst['d']='duration' OPT_DESC_lst['d']='arecord duration in second'
+OPT_NAME['d']='duration' OPT_DESC_lst['d']='arecord duration in second'
 OPT_PARM_lst['d']=1         OPT_VALUE_lst['d']=10
 
-OPT_OPT_lst['l']='loop'     OPT_DESC_lst['l']='loop count'
+OPT_NAME['l']='loop'     OPT_DESC_lst['l']='loop count'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=3
 
-OPT_OPT_lst['o']='output'   OPT_DESC_lst['o']='output dir'
+OPT_NAME['o']='output'   OPT_DESC_lst['o']='output dir'
 OPT_PARM_lst['o']=1         OPT_VALUE_lst['o']="$LOG_ROOT/wavs"
 
-OPT_OPT_lst['f']='file'   OPT_DESC_lst['f']='file name prefix'
+OPT_NAME['f']='file'   OPT_DESC_lst['f']='file name prefix'
 OPT_PARM_lst['f']=1         OPT_VALUE_lst['f']=''
 
-OPT_OPT_lst['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
-OPT_OPT_lst['F']='fmts'   OPT_DESC_lst['F']='Iterate all supported formats'
+OPT_NAME['F']='fmts'   OPT_DESC_lst['F']='Iterate all supported formats'
 OPT_PARM_lst['F']=0         OPT_VALUE_lst['F']=0
 
-OPT_OPT_lst['S']='filter_string'   OPT_DESC_lst['S']="run this case on specified pipelines"
+OPT_NAME['S']='filter_string'   OPT_DESC_lst['S']="run this case on specified pipelines"
 OPT_PARM_lst['S']=1             OPT_VALUE_lst['S']="id:any"
 
 func_opt_parse_option "$@"

--- a/test-case/check-fw-echo-reference.sh
+++ b/test-case/check-fw-echo-reference.sh
@@ -23,15 +23,15 @@ rm -f /tmp/bat.wav.*
 libdir=$(dirname "${BASH_SOURCE[0]}")
 source "$libdir"/../case-lib/lib.sh
 
-OPT_OPT_lst['t']='tplg'         OPT_DESC_lst['t']='tplg file, default value is env TPLG: $''TPLG'
+OPT_NAME['t']='tplg'         OPT_DESC_lst['t']='tplg file, default value is env TPLG: $''TPLG'
 OPT_PARM_lst['t']=1             OPT_VALUE_lst['t']="$TPLG"
-OPT_OPT_lst['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
-OPT_OPT_lst['l']='loop'         OPT_DESC_lst['l']='loop count'
+OPT_NAME['l']='loop'         OPT_DESC_lst['l']='loop count'
 OPT_PARM_lst['l']=1             OPT_VALUE_lst['l']=1
-OPT_OPT_lst['n']='frames'       OPT_DESC_lst['n']='test frames'
+OPT_NAME['n']='frames'       OPT_DESC_lst['n']='test frames'
 OPT_PARM_lst['n']=1             OPT_VALUE_lst['n']=240000
-OPT_OPT_lst['f']='frequency'    OPT_DESC_lst['f']='target frequency'
+OPT_NAME['f']='frequency'    OPT_DESC_lst['f']='target frequency'
 OPT_PARM_lst['f']=1             OPT_VALUE_lst['f']=997
 
 func_opt_parse_option "$@"

--- a/test-case/check-fw-echo-reference.sh
+++ b/test-case/check-fw-echo-reference.sh
@@ -23,15 +23,15 @@ rm -f /tmp/bat.wav.*
 libdir=$(dirname "${BASH_SOURCE[0]}")
 source "$libdir"/../case-lib/lib.sh
 
-OPT_NAME['t']='tplg'         OPT_DESC_lst['t']='tplg file, default value is env TPLG: $''TPLG'
+OPT_NAME['t']='tplg'         OPT_DESC['t']='tplg file, default value is env TPLG: $''TPLG'
 OPT_PARM_lst['t']=1             OPT_VALUE_lst['t']="$TPLG"
-OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
-OPT_NAME['l']='loop'         OPT_DESC_lst['l']='loop count'
+OPT_NAME['l']='loop'         OPT_DESC['l']='loop count'
 OPT_PARM_lst['l']=1             OPT_VALUE_lst['l']=1
-OPT_NAME['n']='frames'       OPT_DESC_lst['n']='test frames'
+OPT_NAME['n']='frames'       OPT_DESC['n']='test frames'
 OPT_PARM_lst['n']=1             OPT_VALUE_lst['n']=240000
-OPT_NAME['f']='frequency'    OPT_DESC_lst['f']='target frequency'
+OPT_NAME['f']='frequency'    OPT_DESC['f']='target frequency'
 OPT_PARM_lst['f']=1             OPT_VALUE_lst['f']=997
 
 func_opt_parse_option "$@"

--- a/test-case/check-ipc-flood.sh
+++ b/test-case/check-ipc-flood.sh
@@ -15,13 +15,13 @@
 
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_OPT_lst['c']='cnt'      OPT_DESC_lst['c']='ipc loop count'
+OPT_NAME['c']='cnt'      OPT_DESC_lst['c']='ipc loop count'
 OPT_PARM_lst['c']=1         OPT_VALUE_lst['c']=10000
 
-OPT_OPT_lst['f']='dfs'      OPT_DESC_lst['f']='system dfs file'
+OPT_NAME['f']='dfs'      OPT_DESC_lst['f']='system dfs file'
 OPT_PARM_lst['f']=1         OPT_VALUE_lst['f']="/sys/kernel/debug/sof/ipc_flood_count"
 
-OPT_OPT_lst['l']='loop'     OPT_DESC_lst['l']='loop count'
+OPT_NAME['l']='loop'     OPT_DESC_lst['l']='loop count'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=1
 
 func_opt_parse_option "$@"

--- a/test-case/check-ipc-flood.sh
+++ b/test-case/check-ipc-flood.sh
@@ -15,13 +15,13 @@
 
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_NAME['c']='cnt'      OPT_DESC_lst['c']='ipc loop count'
+OPT_NAME['c']='cnt'      OPT_DESC['c']='ipc loop count'
 OPT_PARM_lst['c']=1         OPT_VALUE_lst['c']=10000
 
-OPT_NAME['f']='dfs'      OPT_DESC_lst['f']='system dfs file'
+OPT_NAME['f']='dfs'      OPT_DESC['f']='system dfs file'
 OPT_PARM_lst['f']=1         OPT_VALUE_lst['f']="/sys/kernel/debug/sof/ipc_flood_count"
 
-OPT_NAME['l']='loop'     OPT_DESC_lst['l']='loop count'
+OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=1
 
 func_opt_parse_option "$@"

--- a/test-case/check-keyword-detection.sh
+++ b/test-case/check-keyword-detection.sh
@@ -22,25 +22,25 @@ libdir=$(dirname "${BASH_SOURCE[0]}")
 # shellcheck source=case-lib/lib.sh
 source "$libdir"/../case-lib/lib.sh
 
-OPT_OPT_lst['t']='tplg'              OPT_DESC_lst['t']='tplg file, default value is env TPLG: $''TPLG'
+OPT_NAME['t']='tplg'              OPT_DESC_lst['t']='tplg file, default value is env TPLG: $''TPLG'
 OPT_PARM_lst['t']=1                  OPT_VALUE_lst['t']="$TPLG"
 
-OPT_OPT_lst['s']='sof-logger'        OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'        OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0                  OPT_VALUE_lst['s']=1
 
-OPT_OPT_lst['p']='preamble-time'     OPT_DESC_lst['p']='key phrase preamble length'
+OPT_NAME['p']='preamble-time'     OPT_DESC_lst['p']='key phrase preamble length'
 OPT_PARM_lst['p']=1                  OPT_VALUE_lst['p']=2100
 
-OPT_OPT_lst['s']='history-depth'     OPT_DESC_lst['s']='draining size'
+OPT_NAME['s']='history-depth'     OPT_DESC_lst['s']='draining size'
 OPT_PARM_lst['s']=1                  OPT_VALUE_lst['s']=2100
 
-OPT_OPT_lst['b']='buffer'            OPT_DESC_lst['b']='buffer size'
+OPT_NAME['b']='buffer'            OPT_DESC_lst['b']='buffer size'
 OPT_PARM_lst['b']=1                  OPT_VALUE_lst['b']=67200
 
-OPT_OPT_lst['l']='loop'              OPT_DESC_lst['l']='loop count'
+OPT_NAME['l']='loop'              OPT_DESC_lst['l']='loop count'
 OPT_PARM_lst['l']=1                  OPT_VALUE_lst['l']=1
 
-OPT_OPT_lst['d']='duration'          OPT_DESC_lst['d']='interrupt kwd pipeline in # seconds'
+OPT_NAME['d']='duration'          OPT_DESC_lst['d']='interrupt kwd pipeline in # seconds'
 OPT_PARM_lst['d']=1                  OPT_VALUE_lst['d']=10
 
 func_opt_parse_option "$@"

--- a/test-case/check-keyword-detection.sh
+++ b/test-case/check-keyword-detection.sh
@@ -22,25 +22,25 @@ libdir=$(dirname "${BASH_SOURCE[0]}")
 # shellcheck source=case-lib/lib.sh
 source "$libdir"/../case-lib/lib.sh
 
-OPT_NAME['t']='tplg'              OPT_DESC_lst['t']='tplg file, default value is env TPLG: $''TPLG'
+OPT_NAME['t']='tplg'              OPT_DESC['t']='tplg file, default value is env TPLG: $''TPLG'
 OPT_PARM_lst['t']=1                  OPT_VALUE_lst['t']="$TPLG"
 
-OPT_NAME['s']='sof-logger'        OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'        OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0                  OPT_VALUE_lst['s']=1
 
-OPT_NAME['p']='preamble-time'     OPT_DESC_lst['p']='key phrase preamble length'
+OPT_NAME['p']='preamble-time'     OPT_DESC['p']='key phrase preamble length'
 OPT_PARM_lst['p']=1                  OPT_VALUE_lst['p']=2100
 
-OPT_NAME['s']='history-depth'     OPT_DESC_lst['s']='draining size'
+OPT_NAME['s']='history-depth'     OPT_DESC['s']='draining size'
 OPT_PARM_lst['s']=1                  OPT_VALUE_lst['s']=2100
 
-OPT_NAME['b']='buffer'            OPT_DESC_lst['b']='buffer size'
+OPT_NAME['b']='buffer'            OPT_DESC['b']='buffer size'
 OPT_PARM_lst['b']=1                  OPT_VALUE_lst['b']=67200
 
-OPT_NAME['l']='loop'              OPT_DESC_lst['l']='loop count'
+OPT_NAME['l']='loop'              OPT_DESC['l']='loop count'
 OPT_PARM_lst['l']=1                  OPT_VALUE_lst['l']=1
 
-OPT_NAME['d']='duration'          OPT_DESC_lst['d']='interrupt kwd pipeline in # seconds'
+OPT_NAME['d']='duration'          OPT_DESC['d']='interrupt kwd pipeline in # seconds'
 OPT_PARM_lst['d']=1                  OPT_VALUE_lst['d']=10
 
 func_opt_parse_option "$@"

--- a/test-case/check-kmod-load-unload-after-playback.sh
+++ b/test-case/check-kmod-load-unload-after-playback.sh
@@ -35,17 +35,17 @@ set -e
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 case_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)
 
-OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
 OPT_NAME['l']='loop'
-OPT_DESC_lst['l']='loop of PCM aplay check - module remove / insert - PCM aplay check'
+OPT_DESC['l']='loop of PCM aplay check - module remove / insert - PCM aplay check'
 OPT_PARM_lst['l']=1          OPT_VALUE_lst['l']=2
 
-OPT_NAME['d']='duration' OPT_DESC_lst['d']='duration of playback process'
+OPT_NAME['d']='duration' OPT_DESC['d']='duration of playback process'
 OPT_PARM_lst['d']=1         OPT_VALUE_lst['d']=3
 
-OPT_NAME['p']='pulseaudio'   OPT_DESC_lst['p']='disable pulseaudio on the test process'
+OPT_NAME['p']='pulseaudio'   OPT_DESC['p']='disable pulseaudio on the test process'
 OPT_PARM_lst['p']=0             OPT_VALUE_lst['p']=1
 
 func_opt_parse_option "$@"

--- a/test-case/check-kmod-load-unload-after-playback.sh
+++ b/test-case/check-kmod-load-unload-after-playback.sh
@@ -35,17 +35,17 @@ set -e
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 case_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)
 
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
-OPT_OPT_lst['l']='loop'
+OPT_NAME['l']='loop'
 OPT_DESC_lst['l']='loop of PCM aplay check - module remove / insert - PCM aplay check'
 OPT_PARM_lst['l']=1          OPT_VALUE_lst['l']=2
 
-OPT_OPT_lst['d']='duration' OPT_DESC_lst['d']='duration of playback process'
+OPT_NAME['d']='duration' OPT_DESC_lst['d']='duration of playback process'
 OPT_PARM_lst['d']=1         OPT_VALUE_lst['d']=3
 
-OPT_OPT_lst['p']='pulseaudio'   OPT_DESC_lst['p']='disable pulseaudio on the test process'
+OPT_NAME['p']='pulseaudio'   OPT_DESC_lst['p']='disable pulseaudio on the test process'
 OPT_PARM_lst['p']=0             OPT_VALUE_lst['p']=1
 
 func_opt_parse_option "$@"

--- a/test-case/check-kmod-load-unload.sh
+++ b/test-case/check-kmod-load-unload.sh
@@ -26,10 +26,10 @@ set -e
 source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
 OPT_NAME['l']='loop_cnt'
-OPT_DESC_lst['l']='remove / insert module loop count -- per device'
+OPT_DESC['l']='remove / insert module loop count -- per device'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=2
 
-OPT_NAME['p']='pulseaudio'   OPT_DESC_lst['p']='disable pulseaudio on the test process'
+OPT_NAME['p']='pulseaudio'   OPT_DESC['p']='disable pulseaudio on the test process'
 OPT_PARM_lst['p']=0             OPT_VALUE_lst['p']=1
 
 func_opt_parse_option "$@"

--- a/test-case/check-kmod-load-unload.sh
+++ b/test-case/check-kmod-load-unload.sh
@@ -25,11 +25,11 @@ set -e
 # shellcheck source=case-lib/lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
-OPT_OPT_lst['l']='loop_cnt'
+OPT_NAME['l']='loop_cnt'
 OPT_DESC_lst['l']='remove / insert module loop count -- per device'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=2
 
-OPT_OPT_lst['p']='pulseaudio'   OPT_DESC_lst['p']='disable pulseaudio on the test process'
+OPT_NAME['p']='pulseaudio'   OPT_DESC_lst['p']='disable pulseaudio on the test process'
 OPT_PARM_lst['p']=0             OPT_VALUE_lst['p']=1
 
 func_opt_parse_option "$@"

--- a/test-case/check-pause-release-suspend-resume.sh
+++ b/test-case/check-pause-release-suspend-resume.sh
@@ -53,31 +53,31 @@ set -e
 
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_NAME['m']='mode'         OPT_DESC_lst['m']='test mode. Example: playback; capture'
+OPT_NAME['m']='mode'         OPT_DESC['m']='test mode. Example: playback; capture'
 OPT_PARM_lst['m']=1             OPT_VALUE_lst['m']='playback'
 
-OPT_NAME['p']='pcm'          OPT_DESC_lst['p']='audio pcm. Example: hw:0,0'
+OPT_NAME['p']='pcm'          OPT_DESC['p']='audio pcm. Example: hw:0,0'
 OPT_PARM_lst['p']=1             OPT_VALUE_lst['p']='hw:0,0'
 
-OPT_NAME['f']='fmt'          OPT_DESC_lst['f']='audio format value'
+OPT_NAME['f']='fmt'          OPT_DESC['f']='audio format value'
 OPT_PARM_lst['f']=1             OPT_VALUE_lst['f']='S16_LE'
 
-OPT_NAME['c']='channel'      OPT_DESC_lst['c']='audio channel count'
+OPT_NAME['c']='channel'      OPT_DESC['c']='audio channel count'
 OPT_PARM_lst['c']=1             OPT_VALUE_lst['c']='2'
 
-OPT_NAME['r']='rate'         OPT_DESC_lst['r']='audio rate'
+OPT_NAME['r']='rate'         OPT_DESC['r']='audio rate'
 OPT_PARM_lst['r']=1             OPT_VALUE_lst['r']='48000'
 
-OPT_NAME['F']='file'         OPT_DESC_lst['F']='file name. Example: /dev/zero; /dev/null'
+OPT_NAME['F']='file'         OPT_DESC['F']='file name. Example: /dev/zero; /dev/null'
 OPT_PARM_lst['F']=1             OPT_VALUE_lst['F']=''
 
-OPT_NAME['l']='loop'         OPT_DESC_lst['l']='loop count'
+OPT_NAME['l']='loop'         OPT_DESC['l']='loop count'
 OPT_PARM_lst['l']=1             OPT_VALUE_lst['l']=5
 
-OPT_NAME['i']='sleep-period' OPT_DESC_lst['i']='sleep period of aplay, unit is ms'
+OPT_NAME['i']='sleep-period' OPT_DESC['i']='sleep period of aplay, unit is ms'
 OPT_PARM_lst['i']=1             OPT_VALUE_lst['i']='100'
 
-OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
 func_opt_parse_option "$@"

--- a/test-case/check-pause-release-suspend-resume.sh
+++ b/test-case/check-pause-release-suspend-resume.sh
@@ -53,31 +53,31 @@ set -e
 
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_OPT_lst['m']='mode'         OPT_DESC_lst['m']='test mode. Example: playback; capture'
+OPT_NAME['m']='mode'         OPT_DESC_lst['m']='test mode. Example: playback; capture'
 OPT_PARM_lst['m']=1             OPT_VALUE_lst['m']='playback'
 
-OPT_OPT_lst['p']='pcm'          OPT_DESC_lst['p']='audio pcm. Example: hw:0,0'
+OPT_NAME['p']='pcm'          OPT_DESC_lst['p']='audio pcm. Example: hw:0,0'
 OPT_PARM_lst['p']=1             OPT_VALUE_lst['p']='hw:0,0'
 
-OPT_OPT_lst['f']='fmt'          OPT_DESC_lst['f']='audio format value'
+OPT_NAME['f']='fmt'          OPT_DESC_lst['f']='audio format value'
 OPT_PARM_lst['f']=1             OPT_VALUE_lst['f']='S16_LE'
 
-OPT_OPT_lst['c']='channel'      OPT_DESC_lst['c']='audio channel count'
+OPT_NAME['c']='channel'      OPT_DESC_lst['c']='audio channel count'
 OPT_PARM_lst['c']=1             OPT_VALUE_lst['c']='2'
 
-OPT_OPT_lst['r']='rate'         OPT_DESC_lst['r']='audio rate'
+OPT_NAME['r']='rate'         OPT_DESC_lst['r']='audio rate'
 OPT_PARM_lst['r']=1             OPT_VALUE_lst['r']='48000'
 
-OPT_OPT_lst['F']='file'         OPT_DESC_lst['F']='file name. Example: /dev/zero; /dev/null'
+OPT_NAME['F']='file'         OPT_DESC_lst['F']='file name. Example: /dev/zero; /dev/null'
 OPT_PARM_lst['F']=1             OPT_VALUE_lst['F']=''
 
-OPT_OPT_lst['l']='loop'         OPT_DESC_lst['l']='loop count'
+OPT_NAME['l']='loop'         OPT_DESC_lst['l']='loop count'
 OPT_PARM_lst['l']=1             OPT_VALUE_lst['l']=5
 
-OPT_OPT_lst['i']='sleep-period' OPT_DESC_lst['i']='sleep period of aplay, unit is ms'
+OPT_NAME['i']='sleep-period' OPT_DESC_lst['i']='sleep period of aplay, unit is ms'
 OPT_PARM_lst['i']=1             OPT_VALUE_lst['i']='100'
 
-OPT_OPT_lst['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
 func_opt_parse_option "$@"

--- a/test-case/check-pause-resume.sh
+++ b/test-case/check-pause-resume.sh
@@ -20,28 +20,28 @@ set -e
 # shellcheck source=case-lib/lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
-OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $''TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $''TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
-OPT_NAME['m']='mode'     OPT_DESC_lst['m']='test mode'
+OPT_NAME['m']='mode'     OPT_DESC['m']='test mode'
 OPT_PARM_lst['m']=1         OPT_VALUE_lst['m']='playback'
 
-OPT_NAME['c']='count'    OPT_DESC_lst['c']='pause/resume repeat count'
+OPT_NAME['c']='count'    OPT_DESC['c']='pause/resume repeat count'
 OPT_PARM_lst['c']=1         OPT_VALUE_lst['c']=10
 
-OPT_NAME['f']='file'     OPT_DESC_lst['f']='file name'
+OPT_NAME['f']='file'     OPT_DESC['f']='file name'
 OPT_PARM_lst['f']=1         OPT_VALUE_lst['f']=''
 
-OPT_NAME['i']='min'      OPT_DESC_lst['i']='random range min value, unit is ms'
+OPT_NAME['i']='min'      OPT_DESC['i']='random range min value, unit is ms'
 OPT_PARM_lst['i']=1         OPT_VALUE_lst['i']='100'
 
-OPT_NAME['a']='max'      OPT_DESC_lst['a']='random range max value, unit is ms'
+OPT_NAME['a']='max'      OPT_DESC['a']='random range max value, unit is ms'
 OPT_PARM_lst['a']=1         OPT_VALUE_lst['a']='200'
 
-OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
-OPT_NAME['S']='filter_string'   OPT_DESC_lst['S']="run this case on specified pipelines"
+OPT_NAME['S']='filter_string'   OPT_DESC['S']="run this case on specified pipelines"
 OPT_PARM_lst['S']=1             OPT_VALUE_lst['S']="id:any"
 
 func_opt_parse_option "$@"

--- a/test-case/check-pause-resume.sh
+++ b/test-case/check-pause-resume.sh
@@ -20,28 +20,28 @@ set -e
 # shellcheck source=case-lib/lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $''TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $''TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
-OPT_OPT_lst['m']='mode'     OPT_DESC_lst['m']='test mode'
+OPT_NAME['m']='mode'     OPT_DESC_lst['m']='test mode'
 OPT_PARM_lst['m']=1         OPT_VALUE_lst['m']='playback'
 
-OPT_OPT_lst['c']='count'    OPT_DESC_lst['c']='pause/resume repeat count'
+OPT_NAME['c']='count'    OPT_DESC_lst['c']='pause/resume repeat count'
 OPT_PARM_lst['c']=1         OPT_VALUE_lst['c']=10
 
-OPT_OPT_lst['f']='file'     OPT_DESC_lst['f']='file name'
+OPT_NAME['f']='file'     OPT_DESC_lst['f']='file name'
 OPT_PARM_lst['f']=1         OPT_VALUE_lst['f']=''
 
-OPT_OPT_lst['i']='min'      OPT_DESC_lst['i']='random range min value, unit is ms'
+OPT_NAME['i']='min'      OPT_DESC_lst['i']='random range min value, unit is ms'
 OPT_PARM_lst['i']=1         OPT_VALUE_lst['i']='100'
 
-OPT_OPT_lst['a']='max'      OPT_DESC_lst['a']='random range max value, unit is ms'
+OPT_NAME['a']='max'      OPT_DESC_lst['a']='random range max value, unit is ms'
 OPT_PARM_lst['a']=1         OPT_VALUE_lst['a']='200'
 
-OPT_OPT_lst['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
-OPT_OPT_lst['S']='filter_string'   OPT_DESC_lst['S']="run this case on specified pipelines"
+OPT_NAME['S']='filter_string'   OPT_DESC_lst['S']="run this case on specified pipelines"
 OPT_PARM_lst['S']=1             OPT_VALUE_lst['S']="id:any"
 
 func_opt_parse_option "$@"

--- a/test-case/check-playback.sh
+++ b/test-case/check-playback.sh
@@ -21,28 +21,28 @@ set -e
 # shellcheck source=case-lib/lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $''TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $''TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
-OPT_OPT_lst['r']='round'     OPT_DESC_lst['r']='round count'
+OPT_NAME['r']='round'     OPT_DESC_lst['r']='round count'
 OPT_PARM_lst['r']=1         OPT_VALUE_lst['r']=1
 
-OPT_OPT_lst['d']='duration' OPT_DESC_lst['d']='aplay duration in second'
+OPT_NAME['d']='duration' OPT_DESC_lst['d']='aplay duration in second'
 OPT_PARM_lst['d']=1         OPT_VALUE_lst['d']=10
 
-OPT_OPT_lst['l']='loop'     OPT_DESC_lst['l']='loop count'
+OPT_NAME['l']='loop'     OPT_DESC_lst['l']='loop count'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=3
 
-OPT_OPT_lst['f']='file'   OPT_DESC_lst['f']='source file path'
+OPT_NAME['f']='file'   OPT_DESC_lst['f']='source file path'
 OPT_PARM_lst['f']=1         OPT_VALUE_lst['f']=''
 
-OPT_OPT_lst['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
-OPT_OPT_lst['F']='fmts'   OPT_DESC_lst['F']='Iterate all supported formats'
+OPT_NAME['F']='fmts'   OPT_DESC_lst['F']='Iterate all supported formats'
 OPT_PARM_lst['F']=0         OPT_VALUE_lst['F']=0
 
-OPT_OPT_lst['S']='filter_string'   OPT_DESC_lst['S']="run this case on specified pipelines"
+OPT_NAME['S']='filter_string'   OPT_DESC_lst['S']="run this case on specified pipelines"
 OPT_PARM_lst['S']=1             OPT_VALUE_lst['S']="id:any"
 
 func_opt_parse_option "$@"

--- a/test-case/check-playback.sh
+++ b/test-case/check-playback.sh
@@ -21,28 +21,28 @@ set -e
 # shellcheck source=case-lib/lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
-OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $''TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $''TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
-OPT_NAME['r']='round'     OPT_DESC_lst['r']='round count'
+OPT_NAME['r']='round'     OPT_DESC['r']='round count'
 OPT_PARM_lst['r']=1         OPT_VALUE_lst['r']=1
 
-OPT_NAME['d']='duration' OPT_DESC_lst['d']='aplay duration in second'
+OPT_NAME['d']='duration' OPT_DESC['d']='aplay duration in second'
 OPT_PARM_lst['d']=1         OPT_VALUE_lst['d']=10
 
-OPT_NAME['l']='loop'     OPT_DESC_lst['l']='loop count'
+OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=3
 
-OPT_NAME['f']='file'   OPT_DESC_lst['f']='source file path'
+OPT_NAME['f']='file'   OPT_DESC['f']='source file path'
 OPT_PARM_lst['f']=1         OPT_VALUE_lst['f']=''
 
-OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
-OPT_NAME['F']='fmts'   OPT_DESC_lst['F']='Iterate all supported formats'
+OPT_NAME['F']='fmts'   OPT_DESC['F']='Iterate all supported formats'
 OPT_PARM_lst['F']=0         OPT_VALUE_lst['F']=0
 
-OPT_NAME['S']='filter_string'   OPT_DESC_lst['S']="run this case on specified pipelines"
+OPT_NAME['S']='filter_string'   OPT_DESC['S']="run this case on specified pipelines"
 OPT_PARM_lst['S']=1             OPT_VALUE_lst['S']="id:any"
 
 func_opt_parse_option "$@"

--- a/test-case/check-reboot.sh
+++ b/test-case/check-reboot.sh
@@ -18,13 +18,13 @@ set -e
 
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_NAME['l']='loop'     OPT_DESC_lst['l']='loop count'
+OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=3
 
-OPT_NAME['t']='timeout'  OPT_DESC_lst['t']='timeout after system boot up'
+OPT_NAME['t']='timeout'  OPT_DESC['t']='timeout after system boot up'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']=30
 
-OPT_NAME['d']='delay'    OPT_DESC_lst['d']='delay time mapping to sub-case PM status'
+OPT_NAME['d']='delay'    OPT_DESC['d']='delay time mapping to sub-case PM status'
 OPT_PARM_lst['d']=1         OPT_VALUE_lst['d']=10
 
 func_opt_parse_option "$@"

--- a/test-case/check-reboot.sh
+++ b/test-case/check-reboot.sh
@@ -18,13 +18,13 @@ set -e
 
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_OPT_lst['l']='loop'     OPT_DESC_lst['l']='loop count'
+OPT_NAME['l']='loop'     OPT_DESC_lst['l']='loop count'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=3
 
-OPT_OPT_lst['t']='timeout'  OPT_DESC_lst['t']='timeout after system boot up'
+OPT_NAME['t']='timeout'  OPT_DESC_lst['t']='timeout after system boot up'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']=30
 
-OPT_OPT_lst['d']='delay'    OPT_DESC_lst['d']='delay time mapping to sub-case PM status'
+OPT_NAME['d']='delay'    OPT_DESC_lst['d']='delay time mapping to sub-case PM status'
 OPT_PARM_lst['d']=1         OPT_VALUE_lst['d']=10
 
 func_opt_parse_option "$@"

--- a/test-case/check-runtime-pm-double-active.sh
+++ b/test-case/check-runtime-pm-double-active.sh
@@ -21,16 +21,16 @@
 
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
-OPT_NAME['l']='loop'     OPT_DESC_lst['l']='loop count'
+OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=3
 
-OPT_NAME['d']='delay'    OPT_DESC_lst['d']='max delay time for state convert'
+OPT_NAME['d']='delay'    OPT_DESC['d']='max delay time for state convert'
 OPT_PARM_lst['d']=1         OPT_VALUE_lst['d']=15
 
-OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
 # param: $1 -> max delay time for dsp pm status switch, unit is second

--- a/test-case/check-runtime-pm-double-active.sh
+++ b/test-case/check-runtime-pm-double-active.sh
@@ -21,16 +21,16 @@
 
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
-OPT_OPT_lst['l']='loop'     OPT_DESC_lst['l']='loop count'
+OPT_NAME['l']='loop'     OPT_DESC_lst['l']='loop count'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=3
 
-OPT_OPT_lst['d']='delay'    OPT_DESC_lst['d']='max delay time for state convert'
+OPT_NAME['d']='delay'    OPT_DESC_lst['d']='max delay time for state convert'
 OPT_PARM_lst['d']=1         OPT_VALUE_lst['d']=15
 
-OPT_OPT_lst['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
 # param: $1 -> max delay time for dsp pm status switch, unit is second

--- a/test-case/check-runtime-pm-status.sh
+++ b/test-case/check-runtime-pm-status.sh
@@ -19,16 +19,16 @@
 
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
-OPT_NAME['l']='loop'     OPT_DESC_lst['l']='loop count'
+OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=3
 
-OPT_NAME['d']='delay'    OPT_DESC_lst['d']='max delay time for state convert'
+OPT_NAME['d']='delay'    OPT_DESC['d']='max delay time for state convert'
 OPT_PARM_lst['d']=1         OPT_VALUE_lst['d']=15
 
-OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
 # param: $1 -> max delay time for dsp pm status switch

--- a/test-case/check-runtime-pm-status.sh
+++ b/test-case/check-runtime-pm-status.sh
@@ -19,16 +19,16 @@
 
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
-OPT_OPT_lst['l']='loop'     OPT_DESC_lst['l']='loop count'
+OPT_NAME['l']='loop'     OPT_DESC_lst['l']='loop count'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=3
 
-OPT_OPT_lst['d']='delay'    OPT_DESC_lst['d']='max delay time for state convert'
+OPT_NAME['d']='delay'    OPT_DESC_lst['d']='max delay time for state convert'
 OPT_PARM_lst['d']=1         OPT_VALUE_lst['d']=15
 
-OPT_OPT_lst['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
 # param: $1 -> max delay time for dsp pm status switch

--- a/test-case/check-signal-stop-start.sh
+++ b/test-case/check-signal-stop-start.sh
@@ -18,19 +18,19 @@
 
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
-OPT_OPT_lst['m']='mode'     OPT_DESC_lst['m']='test mode'
+OPT_NAME['m']='mode'     OPT_DESC_lst['m']='test mode'
 OPT_PARM_lst['m']=1         OPT_VALUE_lst['m']='playback'
 
-OPT_OPT_lst['i']='sleep'    OPT_DESC_lst['i']='interval time for stop/start'
+OPT_NAME['i']='sleep'    OPT_DESC_lst['i']='interval time for stop/start'
 OPT_PARM_lst['i']=1         OPT_VALUE_lst['i']=0.5
 
-OPT_OPT_lst['c']='count'    OPT_DESC_lst['c']='test count of stop/start'
+OPT_NAME['c']='count'    OPT_DESC_lst['c']='test count of stop/start'
 OPT_PARM_lst['c']=1         OPT_VALUE_lst['c']=10
 
-OPT_OPT_lst['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
 func_opt_parse_option "$@"

--- a/test-case/check-signal-stop-start.sh
+++ b/test-case/check-signal-stop-start.sh
@@ -18,19 +18,19 @@
 
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
-OPT_NAME['m']='mode'     OPT_DESC_lst['m']='test mode'
+OPT_NAME['m']='mode'     OPT_DESC['m']='test mode'
 OPT_PARM_lst['m']=1         OPT_VALUE_lst['m']='playback'
 
-OPT_NAME['i']='sleep'    OPT_DESC_lst['i']='interval time for stop/start'
+OPT_NAME['i']='sleep'    OPT_DESC['i']='interval time for stop/start'
 OPT_PARM_lst['i']=1         OPT_VALUE_lst['i']=0.5
 
-OPT_NAME['c']='count'    OPT_DESC_lst['c']='test count of stop/start'
+OPT_NAME['c']='count'    OPT_DESC['c']='test count of stop/start'
 OPT_PARM_lst['c']=1         OPT_VALUE_lst['c']=10
 
-OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
 func_opt_parse_option "$@"

--- a/test-case/check-smart-amplifier.sh
+++ b/test-case/check-smart-amplifier.sh
@@ -29,24 +29,24 @@ source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
 # What we want here is the "$TPLG" string
 # shellcheck disable=SC2016
-OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
 # $TPLG is assigned outside this script as env variable
 # shellcheck disable=SC2153
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
-OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
-OPT_NAME['l']='loop'     OPT_DESC_lst['l']='loop count'
+OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=1
 
-OPT_NAME['d']='duration' OPT_DESC_lst['d']='playback/capture duration in second'
+OPT_NAME['d']='duration' OPT_DESC['d']='playback/capture duration in second'
 OPT_PARM_lst['d']=1         OPT_VALUE_lst['d']=6
 
 # We need OPT_NAME to tell what the command option is, and OPT_PARM_lst to tell
 # how many arguments this option required, though they are not used.
 # shellcheck disable=SC2034
-OPT_NAME['F']='fmts'   OPT_DESC_lst['F']='Iterate all supported formats'
+OPT_NAME['F']='fmts'   OPT_DESC['F']='Iterate all supported formats'
 # shellcheck disable=SC2034
 OPT_PARM_lst['F']=0         OPT_VALUE_lst['F']=0
 

--- a/test-case/check-smart-amplifier.sh
+++ b/test-case/check-smart-amplifier.sh
@@ -29,24 +29,24 @@ source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
 # What we want here is the "$TPLG" string
 # shellcheck disable=SC2016
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
 # $TPLG is assigned outside this script as env variable
 # shellcheck disable=SC2153
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
-OPT_OPT_lst['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
-OPT_OPT_lst['l']='loop'     OPT_DESC_lst['l']='loop count'
+OPT_NAME['l']='loop'     OPT_DESC_lst['l']='loop count'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=1
 
-OPT_OPT_lst['d']='duration' OPT_DESC_lst['d']='playback/capture duration in second'
+OPT_NAME['d']='duration' OPT_DESC_lst['d']='playback/capture duration in second'
 OPT_PARM_lst['d']=1         OPT_VALUE_lst['d']=6
 
-# We need OPT_OPT_lst to tell what the command option is, and OPT_PARM_lst to tell
+# We need OPT_NAME to tell what the command option is, and OPT_PARM_lst to tell
 # how many arguments this option required, though they are not used.
 # shellcheck disable=SC2034
-OPT_OPT_lst['F']='fmts'   OPT_DESC_lst['F']='Iterate all supported formats'
+OPT_NAME['F']='fmts'   OPT_DESC_lst['F']='Iterate all supported formats'
 # shellcheck disable=SC2034
 OPT_PARM_lst['F']=0         OPT_VALUE_lst['F']=0
 

--- a/test-case/check-suspend-resume-with-audio.sh
+++ b/test-case/check-suspend-resume-with-audio.sh
@@ -24,34 +24,34 @@ set -e
 
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_NAME['l']='loop'     OPT_DESC_lst['l']='suspend/resume loop count'
+OPT_NAME['l']='loop'     OPT_DESC['l']='suspend/resume loop count'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=3
 
-OPT_NAME['T']='type'     OPT_DESC_lst['T']="suspend/resume type from /sys/power/mem_sleep"
+OPT_NAME['T']='type'     OPT_DESC['T']="suspend/resume type from /sys/power/mem_sleep"
 OPT_PARM_lst['T']=1         OPT_VALUE_lst['T']=""
 
-OPT_NAME['S']='sleep'    OPT_DESC_lst['S']='suspend/resume command:rtcwake sleep duration'
+OPT_NAME['S']='sleep'    OPT_DESC['S']='suspend/resume command:rtcwake sleep duration'
 OPT_PARM_lst['S']=1         OPT_VALUE_lst['S']=5
 
-OPT_NAME['w']='wait'     OPT_DESC_lst['w']='idle time after suspend/resume wakeup'
+OPT_NAME['w']='wait'     OPT_DESC['w']='idle time after suspend/resume wakeup'
 OPT_PARM_lst['w']=1         OPT_VALUE_lst['w']=5
 
-OPT_NAME['r']='random'   OPT_DESC_lst['r']="Randomly setup wait/sleep time, this option will overwrite s & w option"
+OPT_NAME['r']='random'   OPT_DESC['r']="Randomly setup wait/sleep time, this option will overwrite s & w option"
 OPT_PARM_lst['r']=0         OPT_VALUE_lst['r']=0
 
-OPT_NAME['m']='mode'     OPT_DESC_lst['m']='alsa application type: playback/capture'
+OPT_NAME['m']='mode'     OPT_DESC['m']='alsa application type: playback/capture'
 OPT_PARM_lst['m']=1         OPT_VALUE_lst['m']='playback'
 
-OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
-OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
-OPT_NAME['f']='file'     OPT_DESC_lst['f']='file name'
+OPT_NAME['f']='file'     OPT_DESC['f']='file name'
 OPT_PARM_lst['f']=1         OPT_VALUE_lst['f']=''
 
-OPT_NAME['P']='pipelines'   OPT_DESC_lst['P']="run test case on specified pipelines"
+OPT_NAME['P']='pipelines'   OPT_DESC['P']="run test case on specified pipelines"
 OPT_PARM_lst['P']=1             OPT_VALUE_lst['P']="id:any"
 
 func_opt_parse_option "$@"

--- a/test-case/check-suspend-resume-with-audio.sh
+++ b/test-case/check-suspend-resume-with-audio.sh
@@ -24,34 +24,34 @@ set -e
 
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_OPT_lst['l']='loop'     OPT_DESC_lst['l']='suspend/resume loop count'
+OPT_NAME['l']='loop'     OPT_DESC_lst['l']='suspend/resume loop count'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=3
 
-OPT_OPT_lst['T']='type'     OPT_DESC_lst['T']="suspend/resume type from /sys/power/mem_sleep"
+OPT_NAME['T']='type'     OPT_DESC_lst['T']="suspend/resume type from /sys/power/mem_sleep"
 OPT_PARM_lst['T']=1         OPT_VALUE_lst['T']=""
 
-OPT_OPT_lst['S']='sleep'    OPT_DESC_lst['S']='suspend/resume command:rtcwake sleep duration'
+OPT_NAME['S']='sleep'    OPT_DESC_lst['S']='suspend/resume command:rtcwake sleep duration'
 OPT_PARM_lst['S']=1         OPT_VALUE_lst['S']=5
 
-OPT_OPT_lst['w']='wait'     OPT_DESC_lst['w']='idle time after suspend/resume wakeup'
+OPT_NAME['w']='wait'     OPT_DESC_lst['w']='idle time after suspend/resume wakeup'
 OPT_PARM_lst['w']=1         OPT_VALUE_lst['w']=5
 
-OPT_OPT_lst['r']='random'   OPT_DESC_lst['r']="Randomly setup wait/sleep time, this option will overwrite s & w option"
+OPT_NAME['r']='random'   OPT_DESC_lst['r']="Randomly setup wait/sleep time, this option will overwrite s & w option"
 OPT_PARM_lst['r']=0         OPT_VALUE_lst['r']=0
 
-OPT_OPT_lst['m']='mode'     OPT_DESC_lst['m']='alsa application type: playback/capture'
+OPT_NAME['m']='mode'     OPT_DESC_lst['m']='alsa application type: playback/capture'
 OPT_PARM_lst['m']=1         OPT_VALUE_lst['m']='playback'
 
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
-OPT_OPT_lst['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
-OPT_OPT_lst['f']='file'     OPT_DESC_lst['f']='file name'
+OPT_NAME['f']='file'     OPT_DESC_lst['f']='file name'
 OPT_PARM_lst['f']=1         OPT_VALUE_lst['f']=''
 
-OPT_OPT_lst['P']='pipelines'   OPT_DESC_lst['P']="run test case on specified pipelines"
+OPT_NAME['P']='pipelines'   OPT_DESC_lst['P']="run test case on specified pipelines"
 OPT_PARM_lst['P']=1             OPT_VALUE_lst['P']="id:any"
 
 func_opt_parse_option "$@"

--- a/test-case/check-suspend-resume.sh
+++ b/test-case/check-suspend-resume.sh
@@ -24,19 +24,19 @@ source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 random_min=3    # wait time should >= 3 for other device wakeup from sleep
 random_max=20
 
-OPT_OPT_lst['l']='loop'     OPT_DESC_lst['l']='loop count'
+OPT_NAME['l']='loop'     OPT_DESC_lst['l']='loop count'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=5
 
-OPT_OPT_lst['T']='type'    OPT_DESC_lst['T']="suspend/resume type from /sys/power/mem_sleep"
+OPT_NAME['T']='type'    OPT_DESC_lst['T']="suspend/resume type from /sys/power/mem_sleep"
 OPT_PARM_lst['T']=1         OPT_VALUE_lst['T']=""
 
-OPT_OPT_lst['S']='sleep'    OPT_DESC_lst['S']='suspend/resume command:rtcwake sleep duration'
+OPT_NAME['S']='sleep'    OPT_DESC_lst['S']='suspend/resume command:rtcwake sleep duration'
 OPT_PARM_lst['S']=1         OPT_VALUE_lst['S']=5
 
-OPT_OPT_lst['w']='wait'     OPT_DESC_lst['w']='idle time after suspend/resume wakeup'
+OPT_NAME['w']='wait'     OPT_DESC_lst['w']='idle time after suspend/resume wakeup'
 OPT_PARM_lst['w']=1         OPT_VALUE_lst['w']=5
 
-OPT_OPT_lst['r']='random'   OPT_DESC_lst['r']="Randomly setup wait/sleep time, range is [$random_min-$random_max], this option will overwrite s & w option"
+OPT_NAME['r']='random'   OPT_DESC_lst['r']="Randomly setup wait/sleep time, range is [$random_min-$random_max], this option will overwrite s & w option"
 OPT_PARM_lst['r']=0         OPT_VALUE_lst['r']=0
 
 func_opt_parse_option "$@"

--- a/test-case/check-suspend-resume.sh
+++ b/test-case/check-suspend-resume.sh
@@ -24,19 +24,19 @@ source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 random_min=3    # wait time should >= 3 for other device wakeup from sleep
 random_max=20
 
-OPT_NAME['l']='loop'     OPT_DESC_lst['l']='loop count'
+OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=5
 
-OPT_NAME['T']='type'    OPT_DESC_lst['T']="suspend/resume type from /sys/power/mem_sleep"
+OPT_NAME['T']='type'    OPT_DESC['T']="suspend/resume type from /sys/power/mem_sleep"
 OPT_PARM_lst['T']=1         OPT_VALUE_lst['T']=""
 
-OPT_NAME['S']='sleep'    OPT_DESC_lst['S']='suspend/resume command:rtcwake sleep duration'
+OPT_NAME['S']='sleep'    OPT_DESC['S']='suspend/resume command:rtcwake sleep duration'
 OPT_PARM_lst['S']=1         OPT_VALUE_lst['S']=5
 
-OPT_NAME['w']='wait'     OPT_DESC_lst['w']='idle time after suspend/resume wakeup'
+OPT_NAME['w']='wait'     OPT_DESC['w']='idle time after suspend/resume wakeup'
 OPT_PARM_lst['w']=1         OPT_VALUE_lst['w']=5
 
-OPT_NAME['r']='random'   OPT_DESC_lst['r']="Randomly setup wait/sleep time, range is [$random_min-$random_max], this option will overwrite s & w option"
+OPT_NAME['r']='random'   OPT_DESC['r']="Randomly setup wait/sleep time, range is [$random_min-$random_max], this option will overwrite s & w option"
 OPT_PARM_lst['r']=0         OPT_VALUE_lst['r']=0
 
 func_opt_parse_option "$@"

--- a/test-case/check-volume-levels.sh
+++ b/test-case/check-volume-levels.sh
@@ -31,7 +31,7 @@ TESTDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 # shellcheck source=case-lib/lib.sh
 source "$TESTDIR/case-lib/lib.sh"
 
-OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $''TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $''TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
 func_opt_parse_option "$@"

--- a/test-case/check-volume-levels.sh
+++ b/test-case/check-volume-levels.sh
@@ -31,7 +31,7 @@ TESTDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 # shellcheck source=case-lib/lib.sh
 source "$TESTDIR/case-lib/lib.sh"
 
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $''TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $''TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
 func_opt_parse_option "$@"

--- a/test-case/check-xrun-injection.sh
+++ b/test-case/check-xrun-injection.sh
@@ -19,19 +19,19 @@
 
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
-OPT_OPT_lst['m']='mode'     OPT_DESC_lst['m']='test mode'
+OPT_NAME['m']='mode'     OPT_DESC_lst['m']='test mode'
 OPT_PARM_lst['m']=1         OPT_VALUE_lst['m']='playback'
 
-OPT_OPT_lst['c']='count' OPT_DESC_lst['c']='test count of xrun injection'
+OPT_NAME['c']='count' OPT_DESC_lst['c']='test count of xrun injection'
 OPT_PARM_lst['c']=1         OPT_VALUE_lst['c']=10
 
-OPT_OPT_lst['i']='interval'     OPT_DESC_lst['i']='interval time of xrun injection'
+OPT_NAME['i']='interval'     OPT_DESC_lst['i']='interval time of xrun injection'
 OPT_PARM_lst['i']=1         OPT_VALUE_lst['i']=0.5
 
-OPT_OPT_lst['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
 func_opt_parse_option "$@"

--- a/test-case/check-xrun-injection.sh
+++ b/test-case/check-xrun-injection.sh
@@ -19,19 +19,19 @@
 
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
-OPT_NAME['m']='mode'     OPT_DESC_lst['m']='test mode'
+OPT_NAME['m']='mode'     OPT_DESC['m']='test mode'
 OPT_PARM_lst['m']=1         OPT_VALUE_lst['m']='playback'
 
-OPT_NAME['c']='count' OPT_DESC_lst['c']='test count of xrun injection'
+OPT_NAME['c']='count' OPT_DESC['c']='test count of xrun injection'
 OPT_PARM_lst['c']=1         OPT_VALUE_lst['c']=10
 
-OPT_NAME['i']='interval'     OPT_DESC_lst['i']='interval time of xrun injection'
+OPT_NAME['i']='interval'     OPT_DESC['i']='interval time of xrun injection'
 OPT_PARM_lst['i']=1         OPT_VALUE_lst['i']=0.5
 
-OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
 func_opt_parse_option "$@"

--- a/test-case/multiple-pause-resume.sh
+++ b/test-case/multiple-pause-resume.sh
@@ -23,25 +23,25 @@ set -e
 # shellcheck source=case-lib/lib.sh
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
-OPT_OPT_lst['l']='loop'     OPT_DESC_lst['l']='loop count'
+OPT_NAME['l']='loop'     OPT_DESC_lst['l']='loop count'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=3
 
-OPT_OPT_lst['c']='count'    OPT_DESC_lst['c']='combine test pipeline count'
+OPT_NAME['c']='count'    OPT_DESC_lst['c']='combine test pipeline count'
 OPT_PARM_lst['c']=1         OPT_VALUE_lst['c']=2
 
-OPT_OPT_lst['r']='loop'     OPT_DESC_lst['r']='pause resume repeat count'
+OPT_NAME['r']='loop'     OPT_DESC_lst['r']='pause resume repeat count'
 OPT_PARM_lst['r']=1         OPT_VALUE_lst['r']=3
 
-OPT_OPT_lst['i']='min'      OPT_DESC_lst['i']='random range min value, unit is ms'
+OPT_NAME['i']='min'      OPT_DESC_lst['i']='random range min value, unit is ms'
 OPT_PARM_lst['i']=1         OPT_VALUE_lst['i']='100'
 
-OPT_OPT_lst['a']='max'      OPT_DESC_lst['a']='random range max value, unit is ms'
+OPT_NAME['a']='max'      OPT_DESC_lst['a']='random range max value, unit is ms'
 OPT_PARM_lst['a']=1         OPT_VALUE_lst['a']='200'
 
-OPT_OPT_lst['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
 func_opt_parse_option "$@"

--- a/test-case/multiple-pause-resume.sh
+++ b/test-case/multiple-pause-resume.sh
@@ -23,25 +23,25 @@ set -e
 # shellcheck source=case-lib/lib.sh
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
-OPT_NAME['l']='loop'     OPT_DESC_lst['l']='loop count'
+OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=3
 
-OPT_NAME['c']='count'    OPT_DESC_lst['c']='combine test pipeline count'
+OPT_NAME['c']='count'    OPT_DESC['c']='combine test pipeline count'
 OPT_PARM_lst['c']=1         OPT_VALUE_lst['c']=2
 
-OPT_NAME['r']='loop'     OPT_DESC_lst['r']='pause resume repeat count'
+OPT_NAME['r']='loop'     OPT_DESC['r']='pause resume repeat count'
 OPT_PARM_lst['r']=1         OPT_VALUE_lst['r']=3
 
-OPT_NAME['i']='min'      OPT_DESC_lst['i']='random range min value, unit is ms'
+OPT_NAME['i']='min'      OPT_DESC['i']='random range min value, unit is ms'
 OPT_PARM_lst['i']=1         OPT_VALUE_lst['i']='100'
 
-OPT_NAME['a']='max'      OPT_DESC_lst['a']='random range max value, unit is ms'
+OPT_NAME['a']='max'      OPT_DESC['a']='random range max value, unit is ms'
 OPT_PARM_lst['a']=1         OPT_VALUE_lst['a']='200'
 
-OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
 func_opt_parse_option "$@"

--- a/test-case/multiple-pipeline.sh
+++ b/test-case/multiple-pipeline.sh
@@ -35,26 +35,26 @@ set -e
 # shellcheck source=case-lib/lib.sh
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
-OPT_NAME['c']='count'    OPT_DESC_lst['c']='test pipeline count'
+OPT_NAME['c']='count'    OPT_DESC['c']='test pipeline count'
 OPT_PARM_lst['c']=1         OPT_VALUE_lst['c']=4
 
 OPT_NAME['f']='first'
-OPT_DESC_lst['f']='Fill either playback (p) or capture (c) first'
+OPT_DESC['f']='Fill either playback (p) or capture (c) first'
 OPT_PARM_lst['f']=1         OPT_VALUE_lst['f']='p'
 
-OPT_NAME['w']='wait'     OPT_DESC_lst['w']='perpare wait time by sleep'
+OPT_NAME['w']='wait'     OPT_DESC['w']='perpare wait time by sleep'
 OPT_PARM_lst['w']=1         OPT_VALUE_lst['w']=5
 
-OPT_NAME['r']='random'   OPT_DESC_lst['r']='random load pipeline'
+OPT_NAME['r']='random'   OPT_DESC['r']='random load pipeline'
 OPT_PARM_lst['r']=0         OPT_VALUE_lst['r']=0
 
-OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
-OPT_NAME['l']='loop'     OPT_DESC_lst['l']='loop count'
+OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=1
 
 func_opt_parse_option "$@"

--- a/test-case/multiple-pipeline.sh
+++ b/test-case/multiple-pipeline.sh
@@ -35,26 +35,26 @@ set -e
 # shellcheck source=case-lib/lib.sh
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
-OPT_OPT_lst['c']='count'    OPT_DESC_lst['c']='test pipeline count'
+OPT_NAME['c']='count'    OPT_DESC_lst['c']='test pipeline count'
 OPT_PARM_lst['c']=1         OPT_VALUE_lst['c']=4
 
-OPT_OPT_lst['f']='first'
+OPT_NAME['f']='first'
 OPT_DESC_lst['f']='Fill either playback (p) or capture (c) first'
 OPT_PARM_lst['f']=1         OPT_VALUE_lst['f']='p'
 
-OPT_OPT_lst['w']='wait'     OPT_DESC_lst['w']='perpare wait time by sleep'
+OPT_NAME['w']='wait'     OPT_DESC_lst['w']='perpare wait time by sleep'
 OPT_PARM_lst['w']=1         OPT_VALUE_lst['w']=5
 
-OPT_OPT_lst['r']='random'   OPT_DESC_lst['r']='random load pipeline'
+OPT_NAME['r']='random'   OPT_DESC_lst['r']='random load pipeline'
 OPT_PARM_lst['r']=0         OPT_VALUE_lst['r']=0
 
-OPT_OPT_lst['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
-OPT_OPT_lst['l']='loop'     OPT_DESC_lst['l']='loop count'
+OPT_NAME['l']='loop'     OPT_DESC_lst['l']='loop count'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=1
 
 func_opt_parse_option "$@"

--- a/test-case/simultaneous-playback-capture.sh
+++ b/test-case/simultaneous-playback-capture.sh
@@ -20,16 +20,16 @@
 
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
-OPT_NAME['w']='wait'     OPT_DESC_lst['w']='sleep for wait duration'
+OPT_NAME['w']='wait'     OPT_DESC['w']='sleep for wait duration'
 OPT_PARM_lst['w']=1         OPT_VALUE_lst['w']=5
 
-OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
-OPT_NAME['l']='loop'     OPT_DESC_lst['l']='loop count'
+OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=1
 
 func_opt_parse_option "$@"

--- a/test-case/simultaneous-playback-capture.sh
+++ b/test-case/simultaneous-playback-capture.sh
@@ -20,16 +20,16 @@
 
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
-OPT_OPT_lst['w']='wait'     OPT_DESC_lst['w']='sleep for wait duration'
+OPT_NAME['w']='wait'     OPT_DESC_lst['w']='sleep for wait duration'
 OPT_PARM_lst['w']=1         OPT_VALUE_lst['w']=5
 
-OPT_OPT_lst['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
-OPT_OPT_lst['l']='loop'     OPT_DESC_lst['l']='loop count'
+OPT_NAME['l']='loop'     OPT_DESC_lst['l']='loop count'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=1
 
 func_opt_parse_option "$@"

--- a/test-case/test-speaker.sh
+++ b/test-case/test-speaker.sh
@@ -17,13 +17,13 @@
 
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
-OPT_NAME['l']='loop'     OPT_DESC_lst['l']='option of speaker-test'
+OPT_NAME['l']='loop'     OPT_DESC['l']='option of speaker-test'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=3
 
-OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
 func_opt_parse_option "$@"

--- a/test-case/test-speaker.sh
+++ b/test-case/test-speaker.sh
@@ -17,13 +17,13 @@
 
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
-OPT_OPT_lst['l']='loop'     OPT_DESC_lst['l']='option of speaker-test'
+OPT_NAME['l']='loop'     OPT_DESC_lst['l']='option of speaker-test'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=3
 
-OPT_OPT_lst['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
 func_opt_parse_option "$@"

--- a/test-case/verify-pcm-list.sh
+++ b/test-case/verify-pcm-list.sh
@@ -20,7 +20,7 @@ set -e
 # shellcheck source=case-lib/lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")/../case-lib/lib.sh"
 
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $''TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $''TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="${TPLG:-}"
 
 func_opt_parse_option "$@"

--- a/test-case/verify-pcm-list.sh
+++ b/test-case/verify-pcm-list.sh
@@ -20,7 +20,7 @@ set -e
 # shellcheck source=case-lib/lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")/../case-lib/lib.sh"
 
-OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $''TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $''TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="${TPLG:-}"
 
 func_opt_parse_option "$@"

--- a/test-case/verify-tplg-binary.sh
+++ b/test-case/verify-tplg-binary.sh
@@ -19,7 +19,7 @@ set -e
 # shellcheck source=case-lib/lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
-OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $''TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $''TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
 func_opt_parse_option "$@"

--- a/test-case/verify-tplg-binary.sh
+++ b/test-case/verify-tplg-binary.sh
@@ -19,7 +19,7 @@ set -e
 # shellcheck source=case-lib/lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $''TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $''TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
 func_opt_parse_option "$@"

--- a/test-case/volume-basic-test.sh
+++ b/test-case/volume-basic-test.sh
@@ -18,13 +18,13 @@
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
 volume_array=("0%" "10%" "20%" "30%" "40%" "50%" "60%" "70%" "80%" "90%" "100%")
-OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
-OPT_NAME['l']='loop'     OPT_DESC_lst['l']='loop count'
+OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=2
 
-OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
 func_opt_parse_option "$@"

--- a/test-case/volume-basic-test.sh
+++ b/test-case/volume-basic-test.sh
@@ -18,13 +18,13 @@
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
 volume_array=("0%" "10%" "20%" "30%" "40%" "50%" "60%" "70%" "80%" "90%" "100%")
-OPT_OPT_lst['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC_lst['t']='tplg file, default value is env TPLG: $TPLG'
 OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
-OPT_OPT_lst['l']='loop'     OPT_DESC_lst['l']='loop count'
+OPT_NAME['l']='loop'     OPT_DESC_lst['l']='loop count'
 OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=2
 
-OPT_OPT_lst['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_NAME['s']='sof-logger'   OPT_DESC_lst['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
 
 func_opt_parse_option "$@"


### PR DESCRIPTION
This PR renames two variable names used to define script command line options, `OPT_OPT_lst` to `OPT_NAME`, `OPT_DESC_lst` to `OPT_DESC`

No functional change, only repo wide search and replace. check discussion https://github.com/thesofproject/sof-test/issues