### PR TITLE
sof-test: rename OPT_PARM_lst and OPT_VALUE_lst

### DIFF
--- a/case-lib/opt.sh
+++ b/case-lib/opt.sh
@@ -3,27 +3,27 @@
 # Before using this, you must define these option arrays in your test
 # script. They must all be indexed by some unique, one-character
 # codename for each of your option.
-declare -A OPT_DESC OPT_NAME OPT_PARM_lst OPT_VALUE_lst
+declare -A OPT_DESC OPT_NAME OPT_HAS_ARG OPT_VALUE_lst
 
 # option setup && parse function
 func_opt_parse_option()
 {
     # OPT_NAME     (long) option name
     # OPT_DESC    short sentence describing the option
-    # OPT_PARM_lst    0 or 1: number of argument required
+    # OPT_HAS_ARG    0 or 1: number of argument required
     # OPT_VALUE_lst   default value overwritten by command line
     #                 input if any. Set to 0 or 1 when PARM=0
 
     # for example
     # OPT_NAME['r']='remote'
     # OPT_DESC['r']='Run for the remote machine'
-    # OPT_PARM_lst['r']=1
+    # OPT_HAS_ARG['r']=1
     # OPT_VALUE_lst['r']='' ## if PARM=1, must be set, if PARM=0, can ignore
 
     # h & help is default option, so don't need to add into option list
     OPT_NAME['h']='help'
     OPT_DESC['h']='this message'
-    OPT_PARM_lst['h']=0
+    OPT_HAS_ARG['h']=0
     OPT_VALUE_lst['h']=0
 
     local _op_temp_script
@@ -58,7 +58,7 @@ func_opt_parse_option()
                 _op_long_lst["--${OPT_NAME[$i]}"]="$i"
             fi
             # append ':' if the option accepts an argument
-            [ ${OPT_PARM_lst[$i]} -eq 1 ] && _short_opt=$_short_opt':' && _long_opt=$_long_opt':'
+            [ ${OPT_HAS_ARG[$i]} -eq 1 ] && _short_opt=$_short_opt':' && _long_opt=$_long_opt':'
         done
 
         if  ! _op_temp_script=$(
@@ -82,17 +82,17 @@ func_opt_parse_option()
                 # display short option
                 [ "$i" ] && printf '    -%s' "$i"
                 # have parameter
-                [ "X${OPT_PARM_lst[$i]}" == "X1" ] && printf ' parameter'
+                [ "X${OPT_HAS_ARG[$i]}" == "X1" ] && printf ' parameter'
                 # display long option
                 if [ "${OPT_NAME[$i]}" ]; then
                     # whether display short option
                     [ "$i" ] && printf ' |  ' || printf '    '
                     printf '%s' "--${OPT_NAME[$i]}"
-                    [ "X${OPT_PARM_lst[$i]}" == "X1" ] && printf ' parameter'
+                    [ "X${OPT_HAS_ARG[$i]}" == "X1" ] && printf ' parameter'
                 fi
                 printf '\n\t%s\n' "${OPT_DESC[$i]}"
                 if [ "${OPT_VALUE_lst[$i]}" ]; then
-                    if [ "${OPT_PARM_lst[$i]}" -eq 1 ]; then
+                    if [ "${OPT_HAS_ARG[$i]}" -eq 1 ]; then
                         printf '\tDefault Value: %s\n' "${OPT_VALUE_lst[$i]}"
                     elif [ "${OPT_VALUE_lst[$i]}" -eq 0 ]; then
                         printf '\tDefault Value: Off\n'
@@ -125,7 +125,7 @@ func_opt_parse_option()
         idx="${_op_short_lst[$1]}"
         [ ! "$idx" ] && idx="${_op_long_lst[$1]}"
         if [ "$idx" ]; then
-            if [ ${OPT_PARM_lst[$idx]} -eq 1 ]; then
+            if [ ${OPT_HAS_ARG[$idx]} -eq 1 ]; then
                 [ ! "$2" ] && printf 'option: %s missing parameter, parsing error' "$1" && exit 2
                 OPT_VALUE_lst[$idx]="$2"
                 shift 2

--- a/case-lib/opt.sh
+++ b/case-lib/opt.sh
@@ -3,7 +3,7 @@
 # Before using this, you must define these option arrays in your test
 # script. They must all be indexed by some unique, one-character
 # codename for each of your option.
-declare -A OPT_DESC OPT_NAME OPT_HAS_ARG OPT_VALUE_lst
+declare -A OPT_DESC OPT_NAME OPT_HAS_ARG OPT_VAL
 
 # option setup && parse function
 func_opt_parse_option()
@@ -11,20 +11,20 @@ func_opt_parse_option()
     # OPT_NAME     (long) option name
     # OPT_DESC    short sentence describing the option
     # OPT_HAS_ARG    0 or 1: number of argument required
-    # OPT_VALUE_lst   default value overwritten by command line
+    # OPT_VAL   default value overwritten by command line
     #                 input if any. Set to 0 or 1 when PARM=0
 
     # for example
     # OPT_NAME['r']='remote'
     # OPT_DESC['r']='Run for the remote machine'
     # OPT_HAS_ARG['r']=1
-    # OPT_VALUE_lst['r']='' ## if PARM=1, must be set, if PARM=0, can ignore
+    # OPT_VAL['r']='' ## if PARM=1, must be set, if PARM=0, can ignore
 
     # h & help is default option, so don't need to add into option list
     OPT_NAME['h']='help'
     OPT_DESC['h']='this message'
     OPT_HAS_ARG['h']=0
-    OPT_VALUE_lst['h']=0
+    OPT_VAL['h']=0
 
     local _op_temp_script
     local -A _op_short_lst _op_long_lst
@@ -91,10 +91,10 @@ func_opt_parse_option()
                     [ "X${OPT_HAS_ARG[$i]}" == "X1" ] && printf ' parameter'
                 fi
                 printf '\n\t%s\n' "${OPT_DESC[$i]}"
-                if [ "${OPT_VALUE_lst[$i]}" ]; then
+                if [ "${OPT_VAL[$i]}" ]; then
                     if [ "${OPT_HAS_ARG[$i]}" -eq 1 ]; then
-                        printf '\tDefault Value: %s\n' "${OPT_VALUE_lst[$i]}"
-                    elif [ "${OPT_VALUE_lst[$i]}" -eq 0 ]; then
+                        printf '\tDefault Value: %s\n' "${OPT_VAL[$i]}"
+                    elif [ "${OPT_VAL[$i]}" -eq 0 ]; then
                         printf '\tDefault Value: Off\n'
                     else
                         printf '\tDefault Value: On\n'
@@ -116,9 +116,9 @@ func_opt_parse_option()
     # FIXME: what is this supposed to do!?
     eval set -- "$_op_temp_script"
 
-    # Iterate over command line input and overwrite OPT_VALUE_lst
+    # Iterate over command line input and overwrite OPT_VAL
     # default values.
-    # declare -p OPT_NAME OPT_VALUE_lst
+    # declare -p OPT_NAME OPT_VAL
     local idx
     while true ; do
         # idx is our internal one-character code name unique for each option
@@ -127,10 +127,10 @@ func_opt_parse_option()
         if [ "$idx" ]; then
             if [ ${OPT_HAS_ARG[$idx]} -eq 1 ]; then
                 [ ! "$2" ] && printf 'option: %s missing parameter, parsing error' "$1" && exit 2
-                OPT_VALUE_lst[$idx]="$2"
+                OPT_VAL[$idx]="$2"
                 shift 2
             else # boolean flag: reverse the default value
-                OPT_VALUE_lst[$idx]=$((!${OPT_VALUE_lst[$idx]}))
+                OPT_VAL[$idx]=$((!${OPT_VAL[$idx]}))
                 shift
             fi
         elif [ "X$1" == "X--" ]; then
@@ -139,9 +139,9 @@ func_opt_parse_option()
             printf 'option: %s unknown, error!' "$1" && exit 2
         fi
     done
-    # declare -p OPT_VALUE_lst
+    # declare -p OPT_VAL
 
-    [ "${OPT_VALUE_lst['h']}" -eq 1 ] && _func_opt_dump_help
+    [ "${OPT_VAL['h']}" -eq 1 ] && _func_opt_dump_help
     # record the full parameter to the cmd
     if [[ ! -f "$LOG_ROOT/version.txt" ]] && [[ -f "$SCRIPT_HOME/.git/config" ]]; then
         {

--- a/case-lib/opt.sh
+++ b/case-lib/opt.sh
@@ -1,30 +1,23 @@
 #!/bin/bash
 
-# Before using this, you must define these option arrays in your test
-# script. They must all be indexed by some unique, one-character
-# codename for each of your option.
-declare -A OPT_DESC OPT_NAME OPT_HAS_ARG OPT_VAL
+# These four arrays are used to define script options, and they should be
+# indexed by a character [a-zA-Z], which is the option short name.
+# OPT_NAME: option long name
+# OPT_HAS_ARG:
+#    1: this option requires an extra argument
+#    0: this option behaves like boolean, and requires no argument
+# OPT_VAL: the extra argument required, or 0 if option requires no argument
+# OPT_DESC: description for this option
+declare -A OPT_NAME OPT_HAS_ARG OPT_VAL OPT_DESC
 
 # option setup && parse function
 func_opt_parse_option()
 {
-    # OPT_NAME     (long) option name
-    # OPT_DESC    short sentence describing the option
-    # OPT_HAS_ARG    0 or 1: number of argument required
-    # OPT_VAL   default value overwritten by command line
-    #                 input if any. Set to 0 or 1 when PARM=0
-
-    # for example
-    # OPT_NAME['r']='remote'
-    # OPT_DESC['r']='Run for the remote machine'
-    # OPT_HAS_ARG['r']=1
-    # OPT_VAL['r']='' ## if PARM=1, must be set, if PARM=0, can ignore
-
-    # h & help is default option, so don't need to add into option list
+    # The help option
     OPT_NAME['h']='help'
-    OPT_DESC['h']='this message'
     OPT_HAS_ARG['h']=0
     OPT_VAL['h']=0
+    OPT_DESC['h']='show help information'
 
     local _op_temp_script
     local -A _op_short_lst _op_long_lst
@@ -81,7 +74,7 @@ func_opt_parse_option()
                 [ "X$i" = "Xh" ] && continue
                 # display short option
                 [ "$i" ] && printf '    -%s' "$i"
-                # have parameter
+                # if option requires extra argument
                 [ "X${OPT_HAS_ARG[$i]}" == "X1" ] && printf ' parameter'
                 # display long option
                 if [ "${OPT_NAME[$i]}" ]; then

--- a/test-case/check-alsabat.sh
+++ b/test-case/check-alsabat.sh
@@ -22,25 +22,25 @@ rm -f /tmp/bat.wav.*
 source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
 OPT_NAME['p']='pcm_p'     	OPT_DESC['p']='pcm for playback. Example: hw:0,0'
-OPT_PARM_lst['p']=1          	OPT_VALUE_lst['p']=''
+OPT_HAS_ARG['p']=1          	OPT_VALUE_lst['p']=''
 
 OPT_NAME['C']='channel_c'       OPT_DESC['C']='channel number for capture.'
-OPT_PARM_lst['C']=1             OPT_VALUE_lst['C']='1'
+OPT_HAS_ARG['C']=1             OPT_VALUE_lst['C']='1'
 
 OPT_NAME['r']='rate'            OPT_DESC['r']='sample rate'
-OPT_PARM_lst['r']=1             OPT_VALUE_lst['r']=48000
+OPT_HAS_ARG['r']=1             OPT_VALUE_lst['r']=48000
 
 OPT_NAME['c']='pcm_c'      	OPT_DESC['c']='pcm for capture. Example: hw:1,0'
-OPT_PARM_lst['c']=1             OPT_VALUE_lst['c']=''
+OPT_HAS_ARG['c']=1             OPT_VALUE_lst['c']=''
 
 OPT_NAME['f']='frequency'       OPT_DESC['f']='target frequency'
-OPT_PARM_lst['f']=1             OPT_VALUE_lst['f']=997
+OPT_HAS_ARG['f']=1             OPT_VALUE_lst['f']=997
 
 OPT_NAME['n']='frames'          OPT_DESC['n']='test frames'
-OPT_PARM_lst['n']=1             OPT_VALUE_lst['n']=240000
+OPT_HAS_ARG['n']=1             OPT_VALUE_lst['n']=240000
 
 OPT_NAME['s']='sof-logger'      OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
 
 func_opt_parse_option "$@"
 

--- a/test-case/check-alsabat.sh
+++ b/test-case/check-alsabat.sh
@@ -22,34 +22,34 @@ rm -f /tmp/bat.wav.*
 source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
 OPT_NAME['p']='pcm_p'     	OPT_DESC['p']='pcm for playback. Example: hw:0,0'
-OPT_HAS_ARG['p']=1          	OPT_VALUE_lst['p']=''
+OPT_HAS_ARG['p']=1          	OPT_VAL['p']=''
 
 OPT_NAME['C']='channel_c'       OPT_DESC['C']='channel number for capture.'
-OPT_HAS_ARG['C']=1             OPT_VALUE_lst['C']='1'
+OPT_HAS_ARG['C']=1             OPT_VAL['C']='1'
 
 OPT_NAME['r']='rate'            OPT_DESC['r']='sample rate'
-OPT_HAS_ARG['r']=1             OPT_VALUE_lst['r']=48000
+OPT_HAS_ARG['r']=1             OPT_VAL['r']=48000
 
 OPT_NAME['c']='pcm_c'      	OPT_DESC['c']='pcm for capture. Example: hw:1,0'
-OPT_HAS_ARG['c']=1             OPT_VALUE_lst['c']=''
+OPT_HAS_ARG['c']=1             OPT_VAL['c']=''
 
 OPT_NAME['f']='frequency'       OPT_DESC['f']='target frequency'
-OPT_HAS_ARG['f']=1             OPT_VALUE_lst['f']=997
+OPT_HAS_ARG['f']=1             OPT_VAL['f']=997
 
 OPT_NAME['n']='frames'          OPT_DESC['n']='test frames'
-OPT_HAS_ARG['n']=1             OPT_VALUE_lst['n']=240000
+OPT_HAS_ARG['n']=1             OPT_VAL['n']=240000
 
 OPT_NAME['s']='sof-logger'      OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VAL['s']=1
 
 func_opt_parse_option "$@"
 
-pcm_p=${OPT_VALUE_lst['p']}
-pcm_c=${OPT_VALUE_lst['c']}
-rate=${OPT_VALUE_lst['r']}
-channel_c=${OPT_VALUE_lst['C']}
-frequency=${OPT_VALUE_lst['f']}
-frames=${OPT_VALUE_lst['n']}
+pcm_p=${OPT_VAL['p']}
+pcm_c=${OPT_VAL['c']}
+rate=${OPT_VAL['r']}
+channel_c=${OPT_VAL['C']}
+frequency=${OPT_VAL['f']}
+frames=${OPT_VAL['n']}
 
 if [ "$pcm_p" = "" ]||[ "$pcm_c" = "" ];
 then
@@ -57,7 +57,7 @@ then
 	exit 2
 fi
 
-[[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
+[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
 
 function __upload_wav_file
 {

--- a/test-case/check-audio-equalizer.sh
+++ b/test-case/check-audio-equalizer.sh
@@ -21,16 +21,16 @@ my_dir=$(dirname "${BASH_SOURCE[0]}")
 source "$my_dir"/../case-lib/lib.sh
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']="tplg file, default value is env TPLG: $TPLG"
-OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
 OPT_NAME['d']='duration' OPT_DESC['d']='aplay duration in second'
-OPT_PARM_lst['d']=1         OPT_VALUE_lst['d']=5
+OPT_HAS_ARG['d']=1         OPT_VALUE_lst['d']=5
 
 OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
-OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=1
+OPT_HAS_ARG['l']=1         OPT_VALUE_lst['l']=1
 
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
 
 func_opt_parse_option "$@"
 tplg=${OPT_VALUE_lst['t']}

--- a/test-case/check-audio-equalizer.sh
+++ b/test-case/check-audio-equalizer.sh
@@ -21,21 +21,21 @@ my_dir=$(dirname "${BASH_SOURCE[0]}")
 source "$my_dir"/../case-lib/lib.sh
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']="tplg file, default value is env TPLG: $TPLG"
-OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VAL['t']="$TPLG"
 
 OPT_NAME['d']='duration' OPT_DESC['d']='aplay duration in second'
-OPT_HAS_ARG['d']=1         OPT_VALUE_lst['d']=5
+OPT_HAS_ARG['d']=1         OPT_VAL['d']=5
 
 OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
-OPT_HAS_ARG['l']=1         OPT_VALUE_lst['l']=1
+OPT_HAS_ARG['l']=1         OPT_VAL['l']=1
 
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VAL['s']=1
 
 func_opt_parse_option "$@"
-tplg=${OPT_VALUE_lst['t']}
-duration=${OPT_VALUE_lst['d']}
-loop_cnt=${OPT_VALUE_lst['l']}
+tplg=${OPT_VAL['t']}
+duration=${OPT_VAL['d']}
+loop_cnt=${OPT_VAL['l']}
 
 # import only EQ pipeline from topology
 func_pipeline_export "$tplg" "eq:any"

--- a/test-case/check-capture.sh
+++ b/test-case/check-capture.sh
@@ -22,46 +22,46 @@ set -e
 source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $''TPLG'
-OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VAL['t']="$TPLG"
 
 OPT_NAME['r']='round'     OPT_DESC['r']='round count'
-OPT_HAS_ARG['r']=1         OPT_VALUE_lst['r']=1
+OPT_HAS_ARG['r']=1         OPT_VAL['r']=1
 
 OPT_NAME['d']='duration' OPT_DESC['d']='arecord duration in second'
-OPT_HAS_ARG['d']=1         OPT_VALUE_lst['d']=10
+OPT_HAS_ARG['d']=1         OPT_VAL['d']=10
 
 OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
-OPT_HAS_ARG['l']=1         OPT_VALUE_lst['l']=3
+OPT_HAS_ARG['l']=1         OPT_VAL['l']=3
 
 OPT_NAME['o']='output'   OPT_DESC['o']='output dir'
-OPT_HAS_ARG['o']=1         OPT_VALUE_lst['o']="$LOG_ROOT/wavs"
+OPT_HAS_ARG['o']=1         OPT_VAL['o']="$LOG_ROOT/wavs"
 
 OPT_NAME['f']='file'   OPT_DESC['f']='file name prefix'
-OPT_HAS_ARG['f']=1         OPT_VALUE_lst['f']=''
+OPT_HAS_ARG['f']=1         OPT_VAL['f']=''
 
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VAL['s']=1
 
 OPT_NAME['F']='fmts'   OPT_DESC['F']='Iterate all supported formats'
-OPT_HAS_ARG['F']=0         OPT_VALUE_lst['F']=0
+OPT_HAS_ARG['F']=0         OPT_VAL['F']=0
 
 OPT_NAME['S']='filter_string'   OPT_DESC['S']="run this case on specified pipelines"
-OPT_HAS_ARG['S']=1             OPT_VALUE_lst['S']="id:any"
+OPT_HAS_ARG['S']=1             OPT_VAL['S']="id:any"
 
 func_opt_parse_option "$@"
 
-tplg=${OPT_VALUE_lst['t']}
-round_cnt=${OPT_VALUE_lst['r']}
-duration=${OPT_VALUE_lst['d']}
-loop_cnt=${OPT_VALUE_lst['l']}
-out_dir=${OPT_VALUE_lst['o']}
-file_prefix=${OPT_VALUE_lst['f']}
+tplg=${OPT_VAL['t']}
+round_cnt=${OPT_VAL['r']}
+duration=${OPT_VAL['d']}
+loop_cnt=${OPT_VAL['l']}
+out_dir=${OPT_VAL['o']}
+file_prefix=${OPT_VAL['f']}
 
-[[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
+[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
 
 func_lib_setup_kernel_checkpoint
 func_lib_check_sudo
-func_pipeline_export "$tplg" "type:capture & ${OPT_VALUE_lst['S']}"
+func_pipeline_export "$tplg" "type:capture & ${OPT_VAL['S']}"
 
 for round in $(seq 1 $round_cnt)
 do
@@ -75,7 +75,7 @@ do
         type=$(func_pipeline_parse_value $idx type)
         snd=$(func_pipeline_parse_value $idx snd)
 
-        if [ ${OPT_VALUE_lst['F']} = '1' ]; then
+        if [ ${OPT_VAL['F']} = '1' ]; then
             fmt=$(func_pipeline_parse_value $idx fmts)
         fi
         # clean up dmesg

--- a/test-case/check-capture.sh
+++ b/test-case/check-capture.sh
@@ -22,31 +22,31 @@ set -e
 source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $''TPLG'
-OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
 OPT_NAME['r']='round'     OPT_DESC['r']='round count'
-OPT_PARM_lst['r']=1         OPT_VALUE_lst['r']=1
+OPT_HAS_ARG['r']=1         OPT_VALUE_lst['r']=1
 
 OPT_NAME['d']='duration' OPT_DESC['d']='arecord duration in second'
-OPT_PARM_lst['d']=1         OPT_VALUE_lst['d']=10
+OPT_HAS_ARG['d']=1         OPT_VALUE_lst['d']=10
 
 OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
-OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=3
+OPT_HAS_ARG['l']=1         OPT_VALUE_lst['l']=3
 
 OPT_NAME['o']='output'   OPT_DESC['o']='output dir'
-OPT_PARM_lst['o']=1         OPT_VALUE_lst['o']="$LOG_ROOT/wavs"
+OPT_HAS_ARG['o']=1         OPT_VALUE_lst['o']="$LOG_ROOT/wavs"
 
 OPT_NAME['f']='file'   OPT_DESC['f']='file name prefix'
-OPT_PARM_lst['f']=1         OPT_VALUE_lst['f']=''
+OPT_HAS_ARG['f']=1         OPT_VALUE_lst['f']=''
 
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
 
 OPT_NAME['F']='fmts'   OPT_DESC['F']='Iterate all supported formats'
-OPT_PARM_lst['F']=0         OPT_VALUE_lst['F']=0
+OPT_HAS_ARG['F']=0         OPT_VALUE_lst['F']=0
 
 OPT_NAME['S']='filter_string'   OPT_DESC['S']="run this case on specified pipelines"
-OPT_PARM_lst['S']=1             OPT_VALUE_lst['S']="id:any"
+OPT_HAS_ARG['S']=1             OPT_VALUE_lst['S']="id:any"
 
 func_opt_parse_option "$@"
 

--- a/test-case/check-fw-echo-reference.sh
+++ b/test-case/check-fw-echo-reference.sh
@@ -24,15 +24,15 @@ libdir=$(dirname "${BASH_SOURCE[0]}")
 source "$libdir"/../case-lib/lib.sh
 
 OPT_NAME['t']='tplg'         OPT_DESC['t']='tplg file, default value is env TPLG: $''TPLG'
-OPT_PARM_lst['t']=1             OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1             OPT_VALUE_lst['t']="$TPLG"
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
 OPT_NAME['l']='loop'         OPT_DESC['l']='loop count'
-OPT_PARM_lst['l']=1             OPT_VALUE_lst['l']=1
+OPT_HAS_ARG['l']=1             OPT_VALUE_lst['l']=1
 OPT_NAME['n']='frames'       OPT_DESC['n']='test frames'
-OPT_PARM_lst['n']=1             OPT_VALUE_lst['n']=240000
+OPT_HAS_ARG['n']=1             OPT_VALUE_lst['n']=240000
 OPT_NAME['f']='frequency'    OPT_DESC['f']='target frequency'
-OPT_PARM_lst['f']=1             OPT_VALUE_lst['f']=997
+OPT_HAS_ARG['f']=1             OPT_VALUE_lst['f']=997
 
 func_opt_parse_option "$@"
 

--- a/test-case/check-fw-echo-reference.sh
+++ b/test-case/check-fw-echo-reference.sh
@@ -24,24 +24,24 @@ libdir=$(dirname "${BASH_SOURCE[0]}")
 source "$libdir"/../case-lib/lib.sh
 
 OPT_NAME['t']='tplg'         OPT_DESC['t']='tplg file, default value is env TPLG: $''TPLG'
-OPT_HAS_ARG['t']=1             OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1             OPT_VAL['t']="$TPLG"
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VAL['s']=1
 OPT_NAME['l']='loop'         OPT_DESC['l']='loop count'
-OPT_HAS_ARG['l']=1             OPT_VALUE_lst['l']=1
+OPT_HAS_ARG['l']=1             OPT_VAL['l']=1
 OPT_NAME['n']='frames'       OPT_DESC['n']='test frames'
-OPT_HAS_ARG['n']=1             OPT_VALUE_lst['n']=240000
+OPT_HAS_ARG['n']=1             OPT_VAL['n']=240000
 OPT_NAME['f']='frequency'    OPT_DESC['f']='target frequency'
-OPT_HAS_ARG['f']=1             OPT_VALUE_lst['f']=997
+OPT_HAS_ARG['f']=1             OPT_VAL['f']=997
 
 func_opt_parse_option "$@"
 
-tplg=${OPT_VALUE_lst['t']}
-loop_cnt=${OPT_VALUE_lst['l']}
-frames=${OPT_VALUE_lst['n']}
-frequency=${OPT_VALUE_lst['f']}
+tplg=${OPT_VAL['t']}
+loop_cnt=${OPT_VAL['l']}
+frames=${OPT_VAL['n']}
+frequency=${OPT_VAL['f']}
 
-[[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
+[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
 
 func_pipeline_export "$tplg" "echo:any"
 func_lib_setup_kernel_checkpoint

--- a/test-case/check-ipc-flood.sh
+++ b/test-case/check-ipc-flood.sh
@@ -16,19 +16,19 @@
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
 OPT_NAME['c']='cnt'      OPT_DESC['c']='ipc loop count'
-OPT_HAS_ARG['c']=1         OPT_VALUE_lst['c']=10000
+OPT_HAS_ARG['c']=1         OPT_VAL['c']=10000
 
 OPT_NAME['f']='dfs'      OPT_DESC['f']='system dfs file'
-OPT_HAS_ARG['f']=1         OPT_VALUE_lst['f']="/sys/kernel/debug/sof/ipc_flood_count"
+OPT_HAS_ARG['f']=1         OPT_VAL['f']="/sys/kernel/debug/sof/ipc_flood_count"
 
 OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
-OPT_HAS_ARG['l']=1         OPT_VALUE_lst['l']=1
+OPT_HAS_ARG['l']=1         OPT_VAL['l']=1
 
 func_opt_parse_option "$@"
 
-lpc_loop_cnt=${OPT_VALUE_lst['c']}
-ipc_flood_dfs=${OPT_VALUE_lst['f']}
-loop_cnt=${OPT_VALUE_lst['l']}
+lpc_loop_cnt=${OPT_VAL['c']}
+ipc_flood_dfs=${OPT_VAL['f']}
+loop_cnt=${OPT_VAL['l']}
 
 [[ ! "$(sof-kernel-dump.sh|grep 'sof-audio'|grep 'Firmware debug build')" ]] && dlogw "${BASH_SOURCE[0]} need debug version firmware" && exit 2
 

--- a/test-case/check-ipc-flood.sh
+++ b/test-case/check-ipc-flood.sh
@@ -16,13 +16,13 @@
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
 OPT_NAME['c']='cnt'      OPT_DESC['c']='ipc loop count'
-OPT_PARM_lst['c']=1         OPT_VALUE_lst['c']=10000
+OPT_HAS_ARG['c']=1         OPT_VALUE_lst['c']=10000
 
 OPT_NAME['f']='dfs'      OPT_DESC['f']='system dfs file'
-OPT_PARM_lst['f']=1         OPT_VALUE_lst['f']="/sys/kernel/debug/sof/ipc_flood_count"
+OPT_HAS_ARG['f']=1         OPT_VALUE_lst['f']="/sys/kernel/debug/sof/ipc_flood_count"
 
 OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
-OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=1
+OPT_HAS_ARG['l']=1         OPT_VALUE_lst['l']=1
 
 func_opt_parse_option "$@"
 

--- a/test-case/check-keyword-detection.sh
+++ b/test-case/check-keyword-detection.sh
@@ -23,36 +23,36 @@ libdir=$(dirname "${BASH_SOURCE[0]}")
 source "$libdir"/../case-lib/lib.sh
 
 OPT_NAME['t']='tplg'              OPT_DESC['t']='tplg file, default value is env TPLG: $''TPLG'
-OPT_HAS_ARG['t']=1                  OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1                  OPT_VAL['t']="$TPLG"
 
 OPT_NAME['s']='sof-logger'        OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_HAS_ARG['s']=0                  OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0                  OPT_VAL['s']=1
 
 OPT_NAME['p']='preamble-time'     OPT_DESC['p']='key phrase preamble length'
-OPT_HAS_ARG['p']=1                  OPT_VALUE_lst['p']=2100
+OPT_HAS_ARG['p']=1                  OPT_VAL['p']=2100
 
 OPT_NAME['s']='history-depth'     OPT_DESC['s']='draining size'
-OPT_HAS_ARG['s']=1                  OPT_VALUE_lst['s']=2100
+OPT_HAS_ARG['s']=1                  OPT_VAL['s']=2100
 
 OPT_NAME['b']='buffer'            OPT_DESC['b']='buffer size'
-OPT_HAS_ARG['b']=1                  OPT_VALUE_lst['b']=67200
+OPT_HAS_ARG['b']=1                  OPT_VAL['b']=67200
 
 OPT_NAME['l']='loop'              OPT_DESC['l']='loop count'
-OPT_HAS_ARG['l']=1                  OPT_VALUE_lst['l']=1
+OPT_HAS_ARG['l']=1                  OPT_VAL['l']=1
 
 OPT_NAME['d']='duration'          OPT_DESC['d']='interrupt kwd pipeline in # seconds'
-OPT_HAS_ARG['d']=1                  OPT_VALUE_lst['d']=10
+OPT_HAS_ARG['d']=1                  OPT_VAL['d']=10
 
 func_opt_parse_option "$@"
 
-tplg=${OPT_VALUE_lst['t']}
-loop_cnt=${OPT_VALUE_lst['l']}
-buffer_size=${OPT_VALUE_lst['b']}
-history_depth=${OPT_VALUE_lst['s']}
-preamble_time=${OPT_VALUE_lst['p']}
-duration=${OPT_VALUE_lst['d']}
+tplg=${OPT_VAL['t']}
+loop_cnt=${OPT_VAL['l']}
+buffer_size=${OPT_VAL['b']}
+history_depth=${OPT_VAL['s']}
+preamble_time=${OPT_VAL['p']}
+duration=${OPT_VAL['d']}
 
-[[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
+[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
 
 func_pipeline_export "$tplg" "kpbm:any"
 func_lib_setup_kernel_checkpoint

--- a/test-case/check-keyword-detection.sh
+++ b/test-case/check-keyword-detection.sh
@@ -23,25 +23,25 @@ libdir=$(dirname "${BASH_SOURCE[0]}")
 source "$libdir"/../case-lib/lib.sh
 
 OPT_NAME['t']='tplg'              OPT_DESC['t']='tplg file, default value is env TPLG: $''TPLG'
-OPT_PARM_lst['t']=1                  OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1                  OPT_VALUE_lst['t']="$TPLG"
 
 OPT_NAME['s']='sof-logger'        OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_PARM_lst['s']=0                  OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0                  OPT_VALUE_lst['s']=1
 
 OPT_NAME['p']='preamble-time'     OPT_DESC['p']='key phrase preamble length'
-OPT_PARM_lst['p']=1                  OPT_VALUE_lst['p']=2100
+OPT_HAS_ARG['p']=1                  OPT_VALUE_lst['p']=2100
 
 OPT_NAME['s']='history-depth'     OPT_DESC['s']='draining size'
-OPT_PARM_lst['s']=1                  OPT_VALUE_lst['s']=2100
+OPT_HAS_ARG['s']=1                  OPT_VALUE_lst['s']=2100
 
 OPT_NAME['b']='buffer'            OPT_DESC['b']='buffer size'
-OPT_PARM_lst['b']=1                  OPT_VALUE_lst['b']=67200
+OPT_HAS_ARG['b']=1                  OPT_VALUE_lst['b']=67200
 
 OPT_NAME['l']='loop'              OPT_DESC['l']='loop count'
-OPT_PARM_lst['l']=1                  OPT_VALUE_lst['l']=1
+OPT_HAS_ARG['l']=1                  OPT_VALUE_lst['l']=1
 
 OPT_NAME['d']='duration'          OPT_DESC['d']='interrupt kwd pipeline in # seconds'
-OPT_PARM_lst['d']=1                  OPT_VALUE_lst['d']=10
+OPT_HAS_ARG['d']=1                  OPT_VALUE_lst['d']=10
 
 func_opt_parse_option "$@"
 

--- a/test-case/check-kmod-load-unload-after-playback.sh
+++ b/test-case/check-kmod-load-unload-after-playback.sh
@@ -36,17 +36,17 @@ source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 case_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
-OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
 OPT_NAME['l']='loop'
 OPT_DESC['l']='loop of PCM aplay check - module remove / insert - PCM aplay check'
-OPT_PARM_lst['l']=1          OPT_VALUE_lst['l']=2
+OPT_HAS_ARG['l']=1          OPT_VALUE_lst['l']=2
 
 OPT_NAME['d']='duration' OPT_DESC['d']='duration of playback process'
-OPT_PARM_lst['d']=1         OPT_VALUE_lst['d']=3
+OPT_HAS_ARG['d']=1         OPT_VALUE_lst['d']=3
 
 OPT_NAME['p']='pulseaudio'   OPT_DESC['p']='disable pulseaudio on the test process'
-OPT_PARM_lst['p']=0             OPT_VALUE_lst['p']=1
+OPT_HAS_ARG['p']=0             OPT_VALUE_lst['p']=1
 
 func_opt_parse_option "$@"
 tplg=${OPT_VALUE_lst['t']}

--- a/test-case/check-kmod-load-unload-after-playback.sh
+++ b/test-case/check-kmod-load-unload-after-playback.sh
@@ -11,7 +11,7 @@ set -e
 ## Case step:
 ##    1. enter loop for module remove / insert test
 ##    2. for each pcm type == playback:
-##       start playback of duration OPT_VALUE_lst['d]'
+##       start playback of duration OPT_VAL['d]'
 ##    3. check for playback errors
 ##    4. remove all loaded modules listed in sof_remove.sh
 ##       (only once, not per PCM)
@@ -22,9 +22,9 @@ set -e
 ##    8. check for successful sof-firmware boot
 ##    9. check for dmesg errors
 ##    10. for each pcm type == playback:
-##        start playback of duration OPT_VALUE_lst['d]'
+##        start playback of duration OPT_VAL['d]'
 ##    11. check for playback errors
-##    12. loop to beginning (max OPT_VALUE_lst['l'])
+##    12. loop to beginning (max OPT_VAL['l'])
 ## Expect result:
 ##    aplay is successful before module removal/insert process per PCM
 ##    removal/insert process is successful (only onc --- not per PCM)
@@ -36,28 +36,28 @@ source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 case_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
-OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VAL['t']="$TPLG"
 
 OPT_NAME['l']='loop'
 OPT_DESC['l']='loop of PCM aplay check - module remove / insert - PCM aplay check'
-OPT_HAS_ARG['l']=1          OPT_VALUE_lst['l']=2
+OPT_HAS_ARG['l']=1          OPT_VAL['l']=2
 
 OPT_NAME['d']='duration' OPT_DESC['d']='duration of playback process'
-OPT_HAS_ARG['d']=1         OPT_VALUE_lst['d']=3
+OPT_HAS_ARG['d']=1         OPT_VAL['d']=3
 
 OPT_NAME['p']='pulseaudio'   OPT_DESC['p']='disable pulseaudio on the test process'
-OPT_HAS_ARG['p']=0             OPT_VALUE_lst['p']=1
+OPT_HAS_ARG['p']=0             OPT_VAL['p']=1
 
 func_opt_parse_option "$@"
-tplg=${OPT_VALUE_lst['t']}
-loop_cnt=${OPT_VALUE_lst['l']}
-pb_duration=${OPT_VALUE_lst['d']}
+tplg=${OPT_VAL['t']}
+loop_cnt=${OPT_VAL['l']}
+pb_duration=${OPT_VAL['d']}
 
 func_pipeline_export "$tplg" "type:playback"
 
 func_lib_check_sudo
 
-if [ ${OPT_VALUE_lst['p']} -eq 1 ];then
+if [ ${OPT_VAL['p']} -eq 1 ];then
     func_lib_disable_pulseaudio
 fi
 

--- a/test-case/check-kmod-load-unload.sh
+++ b/test-case/check-kmod-load-unload.sh
@@ -27,10 +27,10 @@ source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
 OPT_NAME['l']='loop_cnt'
 OPT_DESC['l']='remove / insert module loop count -- per device'
-OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=2
+OPT_HAS_ARG['l']=1         OPT_VALUE_lst['l']=2
 
 OPT_NAME['p']='pulseaudio'   OPT_DESC['p']='disable pulseaudio on the test process'
-OPT_PARM_lst['p']=0             OPT_VALUE_lst['p']=1
+OPT_HAS_ARG['p']=0             OPT_VALUE_lst['p']=1
 
 func_opt_parse_option "$@"
 func_lib_setup_kernel_checkpoint

--- a/test-case/check-kmod-load-unload.sh
+++ b/test-case/check-kmod-load-unload.sh
@@ -16,7 +16,7 @@ set -e
 ##    5. insert all in-tree modules listed in sof_insert.sh
 ##    6. check for successful sof-firmware boot
 ##    7. check for dmesg errors
-##    8. loop to beginning (max OPT_VALUE_lst['r'])
+##    8. loop to beginning (max OPT_VAL['r'])
 ## Expect result:
 ##    kernel module removal / insert process is successful
 ##    check kernel log and find no errors
@@ -27,20 +27,20 @@ source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
 OPT_NAME['l']='loop_cnt'
 OPT_DESC['l']='remove / insert module loop count -- per device'
-OPT_HAS_ARG['l']=1         OPT_VALUE_lst['l']=2
+OPT_HAS_ARG['l']=1         OPT_VAL['l']=2
 
 OPT_NAME['p']='pulseaudio'   OPT_DESC['p']='disable pulseaudio on the test process'
-OPT_HAS_ARG['p']=0             OPT_VALUE_lst['p']=1
+OPT_HAS_ARG['p']=0             OPT_VAL['p']=1
 
 func_opt_parse_option "$@"
 func_lib_setup_kernel_checkpoint
 
-loop_cnt=${OPT_VALUE_lst['l']}
+loop_cnt=${OPT_VAL['l']}
 
 PATH="${PATH%%:*}/kmod:$PATH"
 func_lib_check_sudo 'unloading modules'
 
-if [ ${OPT_VALUE_lst['p']} -eq 1 ];then
+if [ ${OPT_VAL['p']} -eq 1 ];then
     func_lib_disable_pulseaudio
 fi
 

--- a/test-case/check-pause-release-suspend-resume.sh
+++ b/test-case/check-pause-release-suspend-resume.sh
@@ -54,42 +54,42 @@ set -e
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
 OPT_NAME['m']='mode'         OPT_DESC['m']='test mode. Example: playback; capture'
-OPT_HAS_ARG['m']=1             OPT_VALUE_lst['m']='playback'
+OPT_HAS_ARG['m']=1             OPT_VAL['m']='playback'
 
 OPT_NAME['p']='pcm'          OPT_DESC['p']='audio pcm. Example: hw:0,0'
-OPT_HAS_ARG['p']=1             OPT_VALUE_lst['p']='hw:0,0'
+OPT_HAS_ARG['p']=1             OPT_VAL['p']='hw:0,0'
 
 OPT_NAME['f']='fmt'          OPT_DESC['f']='audio format value'
-OPT_HAS_ARG['f']=1             OPT_VALUE_lst['f']='S16_LE'
+OPT_HAS_ARG['f']=1             OPT_VAL['f']='S16_LE'
 
 OPT_NAME['c']='channel'      OPT_DESC['c']='audio channel count'
-OPT_HAS_ARG['c']=1             OPT_VALUE_lst['c']='2'
+OPT_HAS_ARG['c']=1             OPT_VAL['c']='2'
 
 OPT_NAME['r']='rate'         OPT_DESC['r']='audio rate'
-OPT_HAS_ARG['r']=1             OPT_VALUE_lst['r']='48000'
+OPT_HAS_ARG['r']=1             OPT_VAL['r']='48000'
 
 OPT_NAME['F']='file'         OPT_DESC['F']='file name. Example: /dev/zero; /dev/null'
-OPT_HAS_ARG['F']=1             OPT_VALUE_lst['F']=''
+OPT_HAS_ARG['F']=1             OPT_VAL['F']=''
 
 OPT_NAME['l']='loop'         OPT_DESC['l']='loop count'
-OPT_HAS_ARG['l']=1             OPT_VALUE_lst['l']=5
+OPT_HAS_ARG['l']=1             OPT_VAL['l']=5
 
 OPT_NAME['i']='sleep-period' OPT_DESC['i']='sleep period of aplay, unit is ms'
-OPT_HAS_ARG['i']=1             OPT_VALUE_lst['i']='100'
+OPT_HAS_ARG['i']=1             OPT_VAL['i']='100'
 
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VAL['s']=1
 
 func_opt_parse_option "$@"
 
-pcm=${OPT_VALUE_lst['p']}
-fmt=${OPT_VALUE_lst['f']}
-channel=${OPT_VALUE_lst['c']}
-rate=${OPT_VALUE_lst['r']}
-repeat_count=${OPT_VALUE_lst['l']}
-sleep_period=${OPT_VALUE_lst['i']}
-test_mode=${OPT_VALUE_lst['m']}
-file_name=${OPT_VALUE_lst['F']}
+pcm=${OPT_VAL['p']}
+fmt=${OPT_VAL['f']}
+channel=${OPT_VAL['c']}
+rate=${OPT_VAL['r']}
+repeat_count=${OPT_VAL['l']}
+sleep_period=${OPT_VAL['i']}
+test_mode=${OPT_VAL['m']}
+file_name=${OPT_VAL['F']}
 
 case $test_mode in
     "playback")
@@ -108,7 +108,7 @@ esac
 [[ -z $file_name ]] && file_name=$dummy_file
 
 
-[[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
+[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
 
 func_lib_setup_kernel_checkpoint
 

--- a/test-case/check-pause-release-suspend-resume.sh
+++ b/test-case/check-pause-release-suspend-resume.sh
@@ -54,31 +54,31 @@ set -e
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
 OPT_NAME['m']='mode'         OPT_DESC['m']='test mode. Example: playback; capture'
-OPT_PARM_lst['m']=1             OPT_VALUE_lst['m']='playback'
+OPT_HAS_ARG['m']=1             OPT_VALUE_lst['m']='playback'
 
 OPT_NAME['p']='pcm'          OPT_DESC['p']='audio pcm. Example: hw:0,0'
-OPT_PARM_lst['p']=1             OPT_VALUE_lst['p']='hw:0,0'
+OPT_HAS_ARG['p']=1             OPT_VALUE_lst['p']='hw:0,0'
 
 OPT_NAME['f']='fmt'          OPT_DESC['f']='audio format value'
-OPT_PARM_lst['f']=1             OPT_VALUE_lst['f']='S16_LE'
+OPT_HAS_ARG['f']=1             OPT_VALUE_lst['f']='S16_LE'
 
 OPT_NAME['c']='channel'      OPT_DESC['c']='audio channel count'
-OPT_PARM_lst['c']=1             OPT_VALUE_lst['c']='2'
+OPT_HAS_ARG['c']=1             OPT_VALUE_lst['c']='2'
 
 OPT_NAME['r']='rate'         OPT_DESC['r']='audio rate'
-OPT_PARM_lst['r']=1             OPT_VALUE_lst['r']='48000'
+OPT_HAS_ARG['r']=1             OPT_VALUE_lst['r']='48000'
 
 OPT_NAME['F']='file'         OPT_DESC['F']='file name. Example: /dev/zero; /dev/null'
-OPT_PARM_lst['F']=1             OPT_VALUE_lst['F']=''
+OPT_HAS_ARG['F']=1             OPT_VALUE_lst['F']=''
 
 OPT_NAME['l']='loop'         OPT_DESC['l']='loop count'
-OPT_PARM_lst['l']=1             OPT_VALUE_lst['l']=5
+OPT_HAS_ARG['l']=1             OPT_VALUE_lst['l']=5
 
 OPT_NAME['i']='sleep-period' OPT_DESC['i']='sleep period of aplay, unit is ms'
-OPT_PARM_lst['i']=1             OPT_VALUE_lst['i']='100'
+OPT_HAS_ARG['i']=1             OPT_VALUE_lst['i']='100'
 
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
 
 func_opt_parse_option "$@"
 

--- a/test-case/check-pause-resume.sh
+++ b/test-case/check-pause-resume.sh
@@ -21,28 +21,28 @@ set -e
 source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $''TPLG'
-OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
 OPT_NAME['m']='mode'     OPT_DESC['m']='test mode'
-OPT_PARM_lst['m']=1         OPT_VALUE_lst['m']='playback'
+OPT_HAS_ARG['m']=1         OPT_VALUE_lst['m']='playback'
 
 OPT_NAME['c']='count'    OPT_DESC['c']='pause/resume repeat count'
-OPT_PARM_lst['c']=1         OPT_VALUE_lst['c']=10
+OPT_HAS_ARG['c']=1         OPT_VALUE_lst['c']=10
 
 OPT_NAME['f']='file'     OPT_DESC['f']='file name'
-OPT_PARM_lst['f']=1         OPT_VALUE_lst['f']=''
+OPT_HAS_ARG['f']=1         OPT_VALUE_lst['f']=''
 
 OPT_NAME['i']='min'      OPT_DESC['i']='random range min value, unit is ms'
-OPT_PARM_lst['i']=1         OPT_VALUE_lst['i']='100'
+OPT_HAS_ARG['i']=1         OPT_VALUE_lst['i']='100'
 
 OPT_NAME['a']='max'      OPT_DESC['a']='random range max value, unit is ms'
-OPT_PARM_lst['a']=1         OPT_VALUE_lst['a']='200'
+OPT_HAS_ARG['a']=1         OPT_VALUE_lst['a']='200'
 
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
 
 OPT_NAME['S']='filter_string'   OPT_DESC['S']="run this case on specified pipelines"
-OPT_PARM_lst['S']=1             OPT_VALUE_lst['S']="id:any"
+OPT_HAS_ARG['S']=1             OPT_VALUE_lst['S']="id:any"
 
 func_opt_parse_option "$@"
 

--- a/test-case/check-pause-resume.sh
+++ b/test-case/check-pause-resume.sh
@@ -21,39 +21,39 @@ set -e
 source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $''TPLG'
-OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VAL['t']="$TPLG"
 
 OPT_NAME['m']='mode'     OPT_DESC['m']='test mode'
-OPT_HAS_ARG['m']=1         OPT_VALUE_lst['m']='playback'
+OPT_HAS_ARG['m']=1         OPT_VAL['m']='playback'
 
 OPT_NAME['c']='count'    OPT_DESC['c']='pause/resume repeat count'
-OPT_HAS_ARG['c']=1         OPT_VALUE_lst['c']=10
+OPT_HAS_ARG['c']=1         OPT_VAL['c']=10
 
 OPT_NAME['f']='file'     OPT_DESC['f']='file name'
-OPT_HAS_ARG['f']=1         OPT_VALUE_lst['f']=''
+OPT_HAS_ARG['f']=1         OPT_VAL['f']=''
 
 OPT_NAME['i']='min'      OPT_DESC['i']='random range min value, unit is ms'
-OPT_HAS_ARG['i']=1         OPT_VALUE_lst['i']='100'
+OPT_HAS_ARG['i']=1         OPT_VAL['i']='100'
 
 OPT_NAME['a']='max'      OPT_DESC['a']='random range max value, unit is ms'
-OPT_HAS_ARG['a']=1         OPT_VALUE_lst['a']='200'
+OPT_HAS_ARG['a']=1         OPT_VAL['a']='200'
 
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VAL['s']=1
 
 OPT_NAME['S']='filter_string'   OPT_DESC['S']="run this case on specified pipelines"
-OPT_HAS_ARG['S']=1             OPT_VALUE_lst['S']="id:any"
+OPT_HAS_ARG['S']=1             OPT_VAL['S']="id:any"
 
 func_opt_parse_option "$@"
 
-tplg=${OPT_VALUE_lst['t']}
-test_mode=${OPT_VALUE_lst['m']}
-repeat_count=${OPT_VALUE_lst['c']}
+tplg=${OPT_VAL['t']}
+test_mode=${OPT_VAL['m']}
+repeat_count=${OPT_VAL['c']}
 #TODO: file name salt for capture
-file_name=${OPT_VALUE_lst['f']}
+file_name=${OPT_VAL['f']}
 # configure random value range
-rnd_min=${OPT_VALUE_lst['i']}
-rnd_max=${OPT_VALUE_lst['a']}
+rnd_min=${OPT_VAL['i']}
+rnd_max=${OPT_VAL['a']}
 rnd_range=$(( rnd_max -  rnd_min ))
 [[ $rnd_range -le 0 ]] && dlogw "Error random range scope [ min:$rnd_min - max:$rnd_max ]" && exit 2
 
@@ -73,11 +73,11 @@ case $test_mode in
     ;;
 esac
 
-[[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
+[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
 
 [[ -z $file_name ]] && file_name=$dummy_file
 
-func_pipeline_export "$tplg" "type:$test_mode & ${OPT_VALUE_lst['S']}"
+func_pipeline_export "$tplg" "type:$test_mode & ${OPT_VAL['S']}"
 for idx in $(seq 0 $((PIPELINE_COUNT - 1)))
 do
     # set up checkpoint for each iteration

--- a/test-case/check-playback.sh
+++ b/test-case/check-playback.sh
@@ -22,28 +22,28 @@ set -e
 source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $''TPLG'
-OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
 OPT_NAME['r']='round'     OPT_DESC['r']='round count'
-OPT_PARM_lst['r']=1         OPT_VALUE_lst['r']=1
+OPT_HAS_ARG['r']=1         OPT_VALUE_lst['r']=1
 
 OPT_NAME['d']='duration' OPT_DESC['d']='aplay duration in second'
-OPT_PARM_lst['d']=1         OPT_VALUE_lst['d']=10
+OPT_HAS_ARG['d']=1         OPT_VALUE_lst['d']=10
 
 OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
-OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=3
+OPT_HAS_ARG['l']=1         OPT_VALUE_lst['l']=3
 
 OPT_NAME['f']='file'   OPT_DESC['f']='source file path'
-OPT_PARM_lst['f']=1         OPT_VALUE_lst['f']=''
+OPT_HAS_ARG['f']=1         OPT_VALUE_lst['f']=''
 
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
 
 OPT_NAME['F']='fmts'   OPT_DESC['F']='Iterate all supported formats'
-OPT_PARM_lst['F']=0         OPT_VALUE_lst['F']=0
+OPT_HAS_ARG['F']=0         OPT_VALUE_lst['F']=0
 
 OPT_NAME['S']='filter_string'   OPT_DESC['S']="run this case on specified pipelines"
-OPT_PARM_lst['S']=1             OPT_VALUE_lst['S']="id:any"
+OPT_HAS_ARG['S']=1             OPT_VALUE_lst['S']="id:any"
 
 func_opt_parse_option "$@"
 

--- a/test-case/check-playback.sh
+++ b/test-case/check-playback.sh
@@ -22,39 +22,39 @@ set -e
 source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $''TPLG'
-OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VAL['t']="$TPLG"
 
 OPT_NAME['r']='round'     OPT_DESC['r']='round count'
-OPT_HAS_ARG['r']=1         OPT_VALUE_lst['r']=1
+OPT_HAS_ARG['r']=1         OPT_VAL['r']=1
 
 OPT_NAME['d']='duration' OPT_DESC['d']='aplay duration in second'
-OPT_HAS_ARG['d']=1         OPT_VALUE_lst['d']=10
+OPT_HAS_ARG['d']=1         OPT_VAL['d']=10
 
 OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
-OPT_HAS_ARG['l']=1         OPT_VALUE_lst['l']=3
+OPT_HAS_ARG['l']=1         OPT_VAL['l']=3
 
 OPT_NAME['f']='file'   OPT_DESC['f']='source file path'
-OPT_HAS_ARG['f']=1         OPT_VALUE_lst['f']=''
+OPT_HAS_ARG['f']=1         OPT_VAL['f']=''
 
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VAL['s']=1
 
 OPT_NAME['F']='fmts'   OPT_DESC['F']='Iterate all supported formats'
-OPT_HAS_ARG['F']=0         OPT_VALUE_lst['F']=0
+OPT_HAS_ARG['F']=0         OPT_VAL['F']=0
 
 OPT_NAME['S']='filter_string'   OPT_DESC['S']="run this case on specified pipelines"
-OPT_HAS_ARG['S']=1             OPT_VALUE_lst['S']="id:any"
+OPT_HAS_ARG['S']=1             OPT_VAL['S']="id:any"
 
 func_opt_parse_option "$@"
 
-tplg=${OPT_VALUE_lst['t']}
-round_cnt=${OPT_VALUE_lst['r']}
-duration=${OPT_VALUE_lst['d']}
-loop_cnt=${OPT_VALUE_lst['l']}
-file=${OPT_VALUE_lst['f']}
+tplg=${OPT_VAL['t']}
+round_cnt=${OPT_VAL['r']}
+duration=${OPT_VAL['d']}
+loop_cnt=${OPT_VAL['l']}
+file=${OPT_VAL['f']}
 
 
-[[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
+[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
 
 # checking if source file exists
 if [[ -z $file ]]; then
@@ -69,7 +69,7 @@ fi
 
 func_lib_setup_kernel_checkpoint
 func_lib_check_sudo
-func_pipeline_export "$tplg" "type:playback & ${OPT_VALUE_lst['S']}"
+func_pipeline_export "$tplg" "type:playback & ${OPT_VAL['S']}"
 
 for round in $(seq 1 $round_cnt)
 do
@@ -83,7 +83,7 @@ do
         type=$(func_pipeline_parse_value "$idx" type)
         snd=$(func_pipeline_parse_value "$idx" snd)
 
-        if [ ${OPT_VALUE_lst['F']} = '1' ]; then
+        if [ ${OPT_VAL['F']} = '1' ]; then
             fmts=$(func_pipeline_parse_value "$idx" fmts)
         fi
         # clean up dmesg

--- a/test-case/check-reboot.sh
+++ b/test-case/check-reboot.sh
@@ -19,13 +19,13 @@ set -e
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
 OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
-OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=3
+OPT_HAS_ARG['l']=1         OPT_VALUE_lst['l']=3
 
 OPT_NAME['t']='timeout'  OPT_DESC['t']='timeout after system boot up'
-OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']=30
+OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']=30
 
 OPT_NAME['d']='delay'    OPT_DESC['d']='delay time mapping to sub-case PM status'
-OPT_PARM_lst['d']=1         OPT_VALUE_lst['d']=10
+OPT_HAS_ARG['d']=1         OPT_VALUE_lst['d']=10
 
 func_opt_parse_option "$@"
 

--- a/test-case/check-reboot.sh
+++ b/test-case/check-reboot.sh
@@ -19,20 +19,20 @@ set -e
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
 OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
-OPT_HAS_ARG['l']=1         OPT_VALUE_lst['l']=3
+OPT_HAS_ARG['l']=1         OPT_VAL['l']=3
 
 OPT_NAME['t']='timeout'  OPT_DESC['t']='timeout after system boot up'
-OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']=30
+OPT_HAS_ARG['t']=1         OPT_VAL['t']=30
 
 OPT_NAME['d']='delay'    OPT_DESC['d']='delay time mapping to sub-case PM status'
-OPT_HAS_ARG['d']=1         OPT_VALUE_lst['d']=10
+OPT_HAS_ARG['d']=1         OPT_VAL['d']=10
 
 func_opt_parse_option "$@"
 
 func_lib_check_sudo
-loop_count=${OPT_VALUE_lst['l']}
-delay=${OPT_VALUE_lst['d']}
-timeout=${OPT_VALUE_lst['t']}
+loop_count=${OPT_VAL['l']}
+delay=${OPT_VAL['d']}
+timeout=${OPT_VAL['t']}
 
 # write the total & current count to the status file
 status_log=$LOG_ROOT/status.txt

--- a/test-case/check-runtime-pm-double-active.sh
+++ b/test-case/check-runtime-pm-double-active.sh
@@ -22,16 +22,16 @@
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
-OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
 OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
-OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=3
+OPT_HAS_ARG['l']=1         OPT_VALUE_lst['l']=3
 
 OPT_NAME['d']='delay'    OPT_DESC['d']='max delay time for state convert'
-OPT_PARM_lst['d']=1         OPT_VALUE_lst['d']=15
+OPT_HAS_ARG['d']=1         OPT_VALUE_lst['d']=15
 
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
 
 # param: $1 -> max delay time for dsp pm status switch, unit is second
 func_check_dsp_status()

--- a/test-case/check-runtime-pm-double-active.sh
+++ b/test-case/check-runtime-pm-double-active.sh
@@ -22,16 +22,16 @@
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
-OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VAL['t']="$TPLG"
 
 OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
-OPT_HAS_ARG['l']=1         OPT_VALUE_lst['l']=3
+OPT_HAS_ARG['l']=1         OPT_VAL['l']=3
 
 OPT_NAME['d']='delay'    OPT_DESC['d']='max delay time for state convert'
-OPT_HAS_ARG['d']=1         OPT_VALUE_lst['d']=15
+OPT_HAS_ARG['d']=1         OPT_VAL['d']=15
 
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VAL['s']=1
 
 # param: $1 -> max delay time for dsp pm status switch, unit is second
 func_check_dsp_status()
@@ -56,8 +56,8 @@ func_check_dsp_status()
 }
 
 func_opt_parse_option "$@"
-tplg=${OPT_VALUE_lst['t']}
-loop_count=${OPT_VALUE_lst['l']}
+tplg=${OPT_VAL['t']}
+loop_count=${OPT_VAL['l']}
 [[ -z $tplg ]] && dloge "Miss tplg file to run" && exit 2
 
 [[ $(sof-dump-status.py --dsp_status 0) == "unsupported" ]] &&
@@ -69,7 +69,7 @@ DEV_LST['playback']='/dev/zero'
 APP_LST['capture']='arecord'
 DEV_LST['capture']='/dev/null'
 
-[[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
+[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
 func_pipeline_export "$tplg" "type:any"
 
 for idx in $(seq 0 $(expr $PIPELINE_COUNT - 1))
@@ -115,7 +115,7 @@ do
             dlogi "$cmd killed"
 
             # check runtime pm status with maxmium timeout value, it will exit if dsp is not suspended
-            func_check_dsp_status ${OPT_VALUE_lst['d']}
+            func_check_dsp_status ${OPT_VAL['d']}
 
             result=`sof-dump-status.py --dsp_status 0`
             dlogi "runtime status: $result"

--- a/test-case/check-runtime-pm-status.sh
+++ b/test-case/check-runtime-pm-status.sh
@@ -20,16 +20,16 @@
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
-OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VAL['t']="$TPLG"
 
 OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
-OPT_HAS_ARG['l']=1         OPT_VALUE_lst['l']=3
+OPT_HAS_ARG['l']=1         OPT_VAL['l']=3
 
 OPT_NAME['d']='delay'    OPT_DESC['d']='max delay time for state convert'
-OPT_HAS_ARG['d']=1         OPT_VALUE_lst['d']=15
+OPT_HAS_ARG['d']=1         OPT_VAL['d']=15
 
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VAL['s']=1
 
 # param: $1 -> max delay time for dsp pm status switch
 func_check_dsp_status()
@@ -50,8 +50,8 @@ func_check_dsp_status()
 }
 
 func_opt_parse_option "$@"
-tplg=${OPT_VALUE_lst['t']}
-loop_count=${OPT_VALUE_lst['l']}
+tplg=${OPT_VAL['t']}
+loop_count=${OPT_VAL['l']}
 [[ -z $tplg ]] && die "Miss tplg file to run"
 
 [[ $(sof-dump-status.py --dsp_status 0) == "unsupported" ]] &&
@@ -63,7 +63,7 @@ DEV_LST['playback']='/dev/zero'
 APP_LST['capture']='arecord'
 DEV_LST['capture']='/dev/null'
 
-[[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
+[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
 func_pipeline_export "$tplg" "type:any"
 
 for idx in $(seq 0 $(expr $PIPELINE_COUNT - 1))
@@ -107,7 +107,7 @@ do
             dlogc "kill process: kill -9 $pid"
             kill -9 $pid && wait $pid 2>/dev/null
             dlogi "$cmd killed"
-            func_check_dsp_status ${OPT_VALUE_lst['d']}
+            func_check_dsp_status ${OPT_VAL['d']}
             result=`sof-dump-status.py --dsp_status 0`
 
             dlogi "runtime status: $result"

--- a/test-case/check-runtime-pm-status.sh
+++ b/test-case/check-runtime-pm-status.sh
@@ -20,16 +20,16 @@
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
-OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
 OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
-OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=3
+OPT_HAS_ARG['l']=1         OPT_VALUE_lst['l']=3
 
 OPT_NAME['d']='delay'    OPT_DESC['d']='max delay time for state convert'
-OPT_PARM_lst['d']=1         OPT_VALUE_lst['d']=15
+OPT_HAS_ARG['d']=1         OPT_VALUE_lst['d']=15
 
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
 
 # param: $1 -> max delay time for dsp pm status switch
 func_check_dsp_status()

--- a/test-case/check-signal-stop-start.sh
+++ b/test-case/check-signal-stop-start.sh
@@ -19,19 +19,19 @@
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
-OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
 OPT_NAME['m']='mode'     OPT_DESC['m']='test mode'
-OPT_PARM_lst['m']=1         OPT_VALUE_lst['m']='playback'
+OPT_HAS_ARG['m']=1         OPT_VALUE_lst['m']='playback'
 
 OPT_NAME['i']='sleep'    OPT_DESC['i']='interval time for stop/start'
-OPT_PARM_lst['i']=1         OPT_VALUE_lst['i']=0.5
+OPT_HAS_ARG['i']=1         OPT_VALUE_lst['i']=0.5
 
 OPT_NAME['c']='count'    OPT_DESC['c']='test count of stop/start'
-OPT_PARM_lst['c']=1         OPT_VALUE_lst['c']=10
+OPT_HAS_ARG['c']=1         OPT_VALUE_lst['c']=10
 
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
 
 func_opt_parse_option "$@"
 

--- a/test-case/check-signal-stop-start.sh
+++ b/test-case/check-signal-stop-start.sh
@@ -19,28 +19,28 @@
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
-OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VAL['t']="$TPLG"
 
 OPT_NAME['m']='mode'     OPT_DESC['m']='test mode'
-OPT_HAS_ARG['m']=1         OPT_VALUE_lst['m']='playback'
+OPT_HAS_ARG['m']=1         OPT_VAL['m']='playback'
 
 OPT_NAME['i']='sleep'    OPT_DESC['i']='interval time for stop/start'
-OPT_HAS_ARG['i']=1         OPT_VALUE_lst['i']=0.5
+OPT_HAS_ARG['i']=1         OPT_VAL['i']=0.5
 
 OPT_NAME['c']='count'    OPT_DESC['c']='test count of stop/start'
-OPT_HAS_ARG['c']=1         OPT_VALUE_lst['c']=10
+OPT_HAS_ARG['c']=1         OPT_VAL['c']=10
 
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VAL['s']=1
 
 func_opt_parse_option "$@"
 
-tplg=${OPT_VALUE_lst['t']}
-count=${OPT_VALUE_lst['c']}
-interval=${OPT_VALUE_lst['i']}
-test_mode=${OPT_VALUE_lst['m']}
+tplg=${OPT_VAL['t']}
+count=${OPT_VAL['c']}
+interval=${OPT_VAL['i']}
+test_mode=${OPT_VAL['m']}
 
-[[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
+[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
 
 case $test_mode in
     "playback")

--- a/test-case/check-smart-amplifier.sh
+++ b/test-case/check-smart-amplifier.sh
@@ -32,23 +32,23 @@ source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
 # $TPLG is assigned outside this script as env variable
 # shellcheck disable=SC2153
-OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
 
 OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
-OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=1
+OPT_HAS_ARG['l']=1         OPT_VALUE_lst['l']=1
 
 OPT_NAME['d']='duration' OPT_DESC['d']='playback/capture duration in second'
-OPT_PARM_lst['d']=1         OPT_VALUE_lst['d']=6
+OPT_HAS_ARG['d']=1         OPT_VALUE_lst['d']=6
 
-# We need OPT_NAME to tell what the command option is, and OPT_PARM_lst to tell
+# We need OPT_NAME to tell what the command option is, and OPT_HAS_ARG to tell
 # how many arguments this option required, though they are not used.
 # shellcheck disable=SC2034
 OPT_NAME['F']='fmts'   OPT_DESC['F']='Iterate all supported formats'
 # shellcheck disable=SC2034
-OPT_PARM_lst['F']=0         OPT_VALUE_lst['F']=0
+OPT_HAS_ARG['F']=0         OPT_VALUE_lst['F']=0
 
 func_opt_parse_option "$@"
 

--- a/test-case/check-smart-amplifier.sh
+++ b/test-case/check-smart-amplifier.sh
@@ -32,31 +32,31 @@ source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
 # $TPLG is assigned outside this script as env variable
 # shellcheck disable=SC2153
-OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VAL['t']="$TPLG"
 
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VAL['s']=1
 
 OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
-OPT_HAS_ARG['l']=1         OPT_VALUE_lst['l']=1
+OPT_HAS_ARG['l']=1         OPT_VAL['l']=1
 
 OPT_NAME['d']='duration' OPT_DESC['d']='playback/capture duration in second'
-OPT_HAS_ARG['d']=1         OPT_VALUE_lst['d']=6
+OPT_HAS_ARG['d']=1         OPT_VAL['d']=6
 
 # We need OPT_NAME to tell what the command option is, and OPT_HAS_ARG to tell
 # how many arguments this option required, though they are not used.
 # shellcheck disable=SC2034
 OPT_NAME['F']='fmts'   OPT_DESC['F']='Iterate all supported formats'
 # shellcheck disable=SC2034
-OPT_HAS_ARG['F']=0         OPT_VALUE_lst['F']=0
+OPT_HAS_ARG['F']=0         OPT_VAL['F']=0
 
 func_opt_parse_option "$@"
 
-duration=${OPT_VALUE_lst['d']}
-loop_cnt=${OPT_VALUE_lst['l']}
-tplg=${OPT_VALUE_lst['t']}
+duration=${OPT_VAL['d']}
+loop_cnt=${OPT_VAL['l']}
+tplg=${OPT_VAL['t']}
 
-[[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
+[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
 
 func_pipeline_export "$tplg" "smart_amp:any"
 func_lib_setup_kernel_checkpoint
@@ -80,7 +80,7 @@ do
 done
 
 fmts="$cp_fmt"
-if [ ${OPT_VALUE_lst['F']} = '1' ]; then
+if [ ${OPT_VAL['F']} = '1' ]; then
     fmts="$cp_fmts"
 fi
 

--- a/test-case/check-suspend-resume-with-audio.sh
+++ b/test-case/check-suspend-resume-with-audio.sh
@@ -25,40 +25,40 @@ set -e
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
 OPT_NAME['l']='loop'     OPT_DESC['l']='suspend/resume loop count'
-OPT_HAS_ARG['l']=1         OPT_VALUE_lst['l']=3
+OPT_HAS_ARG['l']=1         OPT_VAL['l']=3
 
 OPT_NAME['T']='type'     OPT_DESC['T']="suspend/resume type from /sys/power/mem_sleep"
-OPT_HAS_ARG['T']=1         OPT_VALUE_lst['T']=""
+OPT_HAS_ARG['T']=1         OPT_VAL['T']=""
 
 OPT_NAME['S']='sleep'    OPT_DESC['S']='suspend/resume command:rtcwake sleep duration'
-OPT_HAS_ARG['S']=1         OPT_VALUE_lst['S']=5
+OPT_HAS_ARG['S']=1         OPT_VAL['S']=5
 
 OPT_NAME['w']='wait'     OPT_DESC['w']='idle time after suspend/resume wakeup'
-OPT_HAS_ARG['w']=1         OPT_VALUE_lst['w']=5
+OPT_HAS_ARG['w']=1         OPT_VAL['w']=5
 
 OPT_NAME['r']='random'   OPT_DESC['r']="Randomly setup wait/sleep time, this option will overwrite s & w option"
-OPT_HAS_ARG['r']=0         OPT_VALUE_lst['r']=0
+OPT_HAS_ARG['r']=0         OPT_VAL['r']=0
 
 OPT_NAME['m']='mode'     OPT_DESC['m']='alsa application type: playback/capture'
-OPT_HAS_ARG['m']=1         OPT_VALUE_lst['m']='playback'
+OPT_HAS_ARG['m']=1         OPT_VAL['m']='playback'
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
-OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VAL['t']="$TPLG"
 
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VAL['s']=1
 
 OPT_NAME['f']='file'     OPT_DESC['f']='file name'
-OPT_HAS_ARG['f']=1         OPT_VALUE_lst['f']=''
+OPT_HAS_ARG['f']=1         OPT_VAL['f']=''
 
 OPT_NAME['P']='pipelines'   OPT_DESC['P']="run test case on specified pipelines"
-OPT_HAS_ARG['P']=1             OPT_VALUE_lst['P']="id:any"
+OPT_HAS_ARG['P']=1             OPT_VAL['P']="id:any"
 
 func_opt_parse_option "$@"
 func_lib_check_sudo
 
-tplg=${OPT_VALUE_lst['t']}
-[[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
+tplg=${OPT_VAL['t']}
+[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
 
 # overwrite the subscript: test-case LOG_ROOT environment
 # so when load the test-case in current script
@@ -66,24 +66,24 @@ tplg=${OPT_VALUE_lst['t']}
 # which is current script log folder
 export LOG_ROOT=$LOG_ROOT
 
-if [ "${OPT_VALUE_lst['m']}" == "playback" ]; then
+if [ "${OPT_VAL['m']}" == "playback" ]; then
     cmd='aplay'     dummy_file='/dev/zero'
-elif [ "${OPT_VALUE_lst['m']}" == "capture" ]; then
+elif [ "${OPT_VAL['m']}" == "capture" ]; then
     cmd='arecord'   dummy_file='/dev/null'
 else
-    dlogw "Error alsa application type: ${OPT_VALUE_lst['m']}"
+    dlogw "Error alsa application type: ${OPT_VAL['m']}"
 fi
 [[ -z $file_name ]] && file_name=$dummy_file
 
-func_pipeline_export "$tplg" "type:${OPT_VALUE_lst['m']} & ${OPT_VALUE_lst['P']}"
+func_pipeline_export "$tplg" "type:${OPT_VAL['m']} & ${OPT_VAL['P']}"
 
-if [ "${OPT_VALUE_lst['T']}" ]; then
-    opt="-l ${OPT_VALUE_lst['l']} -T ${OPT_VALUE_lst['T']}"
+if [ "${OPT_VAL['T']}" ]; then
+    opt="-l ${OPT_VAL['l']} -T ${OPT_VAL['T']}"
 else
-    opt="-l ${OPT_VALUE_lst['l']}"
+    opt="-l ${OPT_VAL['l']}"
 fi
-if [ ${OPT_VALUE_lst['r']} -eq 0  ]; then
-    opt="$opt -S ${OPT_VALUE_lst['S']} -w ${OPT_VALUE_lst['w']}"
+if [ ${OPT_VAL['r']} -eq 0  ]; then
+    opt="$opt -S ${OPT_VAL['S']} -w ${OPT_VAL['w']}"
 else
     opt="$opt -r"
 fi

--- a/test-case/check-suspend-resume-with-audio.sh
+++ b/test-case/check-suspend-resume-with-audio.sh
@@ -25,34 +25,34 @@ set -e
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
 OPT_NAME['l']='loop'     OPT_DESC['l']='suspend/resume loop count'
-OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=3
+OPT_HAS_ARG['l']=1         OPT_VALUE_lst['l']=3
 
 OPT_NAME['T']='type'     OPT_DESC['T']="suspend/resume type from /sys/power/mem_sleep"
-OPT_PARM_lst['T']=1         OPT_VALUE_lst['T']=""
+OPT_HAS_ARG['T']=1         OPT_VALUE_lst['T']=""
 
 OPT_NAME['S']='sleep'    OPT_DESC['S']='suspend/resume command:rtcwake sleep duration'
-OPT_PARM_lst['S']=1         OPT_VALUE_lst['S']=5
+OPT_HAS_ARG['S']=1         OPT_VALUE_lst['S']=5
 
 OPT_NAME['w']='wait'     OPT_DESC['w']='idle time after suspend/resume wakeup'
-OPT_PARM_lst['w']=1         OPT_VALUE_lst['w']=5
+OPT_HAS_ARG['w']=1         OPT_VALUE_lst['w']=5
 
 OPT_NAME['r']='random'   OPT_DESC['r']="Randomly setup wait/sleep time, this option will overwrite s & w option"
-OPT_PARM_lst['r']=0         OPT_VALUE_lst['r']=0
+OPT_HAS_ARG['r']=0         OPT_VALUE_lst['r']=0
 
 OPT_NAME['m']='mode'     OPT_DESC['m']='alsa application type: playback/capture'
-OPT_PARM_lst['m']=1         OPT_VALUE_lst['m']='playback'
+OPT_HAS_ARG['m']=1         OPT_VALUE_lst['m']='playback'
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
-OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
 
 OPT_NAME['f']='file'     OPT_DESC['f']='file name'
-OPT_PARM_lst['f']=1         OPT_VALUE_lst['f']=''
+OPT_HAS_ARG['f']=1         OPT_VALUE_lst['f']=''
 
 OPT_NAME['P']='pipelines'   OPT_DESC['P']="run test case on specified pipelines"
-OPT_PARM_lst['P']=1             OPT_VALUE_lst['P']="id:any"
+OPT_HAS_ARG['P']=1             OPT_VALUE_lst['P']="id:any"
 
 func_opt_parse_option "$@"
 func_lib_check_sudo

--- a/test-case/check-suspend-resume.sh
+++ b/test-case/check-suspend-resume.sh
@@ -25,24 +25,24 @@ random_min=3    # wait time should >= 3 for other device wakeup from sleep
 random_max=20
 
 OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
-OPT_HAS_ARG['l']=1         OPT_VALUE_lst['l']=5
+OPT_HAS_ARG['l']=1         OPT_VAL['l']=5
 
 OPT_NAME['T']='type'    OPT_DESC['T']="suspend/resume type from /sys/power/mem_sleep"
-OPT_HAS_ARG['T']=1         OPT_VALUE_lst['T']=""
+OPT_HAS_ARG['T']=1         OPT_VAL['T']=""
 
 OPT_NAME['S']='sleep'    OPT_DESC['S']='suspend/resume command:rtcwake sleep duration'
-OPT_HAS_ARG['S']=1         OPT_VALUE_lst['S']=5
+OPT_HAS_ARG['S']=1         OPT_VAL['S']=5
 
 OPT_NAME['w']='wait'     OPT_DESC['w']='idle time after suspend/resume wakeup'
-OPT_HAS_ARG['w']=1         OPT_VALUE_lst['w']=5
+OPT_HAS_ARG['w']=1         OPT_VAL['w']=5
 
 OPT_NAME['r']='random'   OPT_DESC['r']="Randomly setup wait/sleep time, range is [$random_min-$random_max], this option will overwrite s & w option"
-OPT_HAS_ARG['r']=0         OPT_VALUE_lst['r']=0
+OPT_HAS_ARG['r']=0         OPT_VAL['r']=0
 
 func_opt_parse_option "$@"
 func_lib_check_sudo
 
-type=${OPT_VALUE_lst['T']}
+type=${OPT_VAL['T']}
 # switch type
 if [ "$type" ]; then
     # check for type value effect
@@ -52,10 +52,10 @@ if [ "$type" ]; then
 fi
 dlogi "Current suspend/resume type mode: $(cat /sys/power/mem_sleep)"
 
-loop_count=${OPT_VALUE_lst['l']}
+loop_count=${OPT_VAL['l']}
 declare -a sleep_lst wait_lst
 
-if [ ${OPT_VALUE_lst['r']} -eq 1 ]; then
+if [ ${OPT_VAL['r']} -eq 1 ]; then
     # create random number list
     for i in $(seq 1 $loop_count)
     do
@@ -65,8 +65,8 @@ if [ ${OPT_VALUE_lst['r']} -eq 1 ]; then
 else
     for i in $(seq 1 $loop_count)
     do
-        sleep_lst[$i]=${OPT_VALUE_lst['S']}
-        wait_lst[$i]=${OPT_VALUE_lst['w']}
+        sleep_lst[$i]=${OPT_VAL['S']}
+        wait_lst[$i]=${OPT_VAL['w']}
     done
 fi
 

--- a/test-case/check-suspend-resume.sh
+++ b/test-case/check-suspend-resume.sh
@@ -25,19 +25,19 @@ random_min=3    # wait time should >= 3 for other device wakeup from sleep
 random_max=20
 
 OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
-OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=5
+OPT_HAS_ARG['l']=1         OPT_VALUE_lst['l']=5
 
 OPT_NAME['T']='type'    OPT_DESC['T']="suspend/resume type from /sys/power/mem_sleep"
-OPT_PARM_lst['T']=1         OPT_VALUE_lst['T']=""
+OPT_HAS_ARG['T']=1         OPT_VALUE_lst['T']=""
 
 OPT_NAME['S']='sleep'    OPT_DESC['S']='suspend/resume command:rtcwake sleep duration'
-OPT_PARM_lst['S']=1         OPT_VALUE_lst['S']=5
+OPT_HAS_ARG['S']=1         OPT_VALUE_lst['S']=5
 
 OPT_NAME['w']='wait'     OPT_DESC['w']='idle time after suspend/resume wakeup'
-OPT_PARM_lst['w']=1         OPT_VALUE_lst['w']=5
+OPT_HAS_ARG['w']=1         OPT_VALUE_lst['w']=5
 
 OPT_NAME['r']='random'   OPT_DESC['r']="Randomly setup wait/sleep time, range is [$random_min-$random_max], this option will overwrite s & w option"
-OPT_PARM_lst['r']=0         OPT_VALUE_lst['r']=0
+OPT_HAS_ARG['r']=0         OPT_VALUE_lst['r']=0
 
 func_opt_parse_option "$@"
 func_lib_check_sudo

--- a/test-case/check-volume-levels.sh
+++ b/test-case/check-volume-levels.sh
@@ -32,7 +32,7 @@ TESTDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 source "$TESTDIR/case-lib/lib.sh"
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $''TPLG'
-OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
 func_opt_parse_option "$@"
 

--- a/test-case/check-volume-levels.sh
+++ b/test-case/check-volume-levels.sh
@@ -32,11 +32,11 @@ TESTDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 source "$TESTDIR/case-lib/lib.sh"
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $''TPLG'
-OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VAL['t']="$TPLG"
 
 func_opt_parse_option "$@"
 
-tplg=${OPT_VALUE_lst['t']}
+tplg=${OPT_VAL['t']}
 
 TPLGREADER="$TESTDIR"/tools/sof-tplgreader.py
 PCM_ID=0

--- a/test-case/check-xrun-injection.sh
+++ b/test-case/check-xrun-injection.sh
@@ -20,19 +20,19 @@
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
-OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
 OPT_NAME['m']='mode'     OPT_DESC['m']='test mode'
-OPT_PARM_lst['m']=1         OPT_VALUE_lst['m']='playback'
+OPT_HAS_ARG['m']=1         OPT_VALUE_lst['m']='playback'
 
 OPT_NAME['c']='count' OPT_DESC['c']='test count of xrun injection'
-OPT_PARM_lst['c']=1         OPT_VALUE_lst['c']=10
+OPT_HAS_ARG['c']=1         OPT_VALUE_lst['c']=10
 
 OPT_NAME['i']='interval'     OPT_DESC['i']='interval time of xrun injection'
-OPT_PARM_lst['i']=1         OPT_VALUE_lst['i']=0.5
+OPT_HAS_ARG['i']=1         OPT_VALUE_lst['i']=0.5
 
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
 
 func_opt_parse_option "$@"
 

--- a/test-case/check-xrun-injection.sh
+++ b/test-case/check-xrun-injection.sh
@@ -20,28 +20,28 @@
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
-OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VAL['t']="$TPLG"
 
 OPT_NAME['m']='mode'     OPT_DESC['m']='test mode'
-OPT_HAS_ARG['m']=1         OPT_VALUE_lst['m']='playback'
+OPT_HAS_ARG['m']=1         OPT_VAL['m']='playback'
 
 OPT_NAME['c']='count' OPT_DESC['c']='test count of xrun injection'
-OPT_HAS_ARG['c']=1         OPT_VALUE_lst['c']=10
+OPT_HAS_ARG['c']=1         OPT_VAL['c']=10
 
 OPT_NAME['i']='interval'     OPT_DESC['i']='interval time of xrun injection'
-OPT_HAS_ARG['i']=1         OPT_VALUE_lst['i']=0.5
+OPT_HAS_ARG['i']=1         OPT_VAL['i']=0.5
 
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VAL['s']=1
 
 func_opt_parse_option "$@"
 
-tplg=${OPT_VALUE_lst['t']}
-test_mode=${OPT_VALUE_lst['m']}
-count=${OPT_VALUE_lst['c']}
-interval=${OPT_VALUE_lst['i']}
+tplg=${OPT_VAL['t']}
+test_mode=${OPT_VAL['m']}
+count=${OPT_VAL['c']}
+interval=${OPT_VAL['i']}
 
-[[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
+[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
 
 func_lib_setup_kernel_checkpoint
 func_lib_check_sudo

--- a/test-case/multiple-pause-resume.sh
+++ b/test-case/multiple-pause-resume.sh
@@ -24,40 +24,40 @@ set -e
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
-OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VAL['t']="$TPLG"
 
 OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
-OPT_HAS_ARG['l']=1         OPT_VALUE_lst['l']=3
+OPT_HAS_ARG['l']=1         OPT_VAL['l']=3
 
 OPT_NAME['c']='count'    OPT_DESC['c']='combine test pipeline count'
-OPT_HAS_ARG['c']=1         OPT_VALUE_lst['c']=2
+OPT_HAS_ARG['c']=1         OPT_VAL['c']=2
 
 OPT_NAME['r']='loop'     OPT_DESC['r']='pause resume repeat count'
-OPT_HAS_ARG['r']=1         OPT_VALUE_lst['r']=3
+OPT_HAS_ARG['r']=1         OPT_VAL['r']=3
 
 OPT_NAME['i']='min'      OPT_DESC['i']='random range min value, unit is ms'
-OPT_HAS_ARG['i']=1         OPT_VALUE_lst['i']='100'
+OPT_HAS_ARG['i']=1         OPT_VAL['i']='100'
 
 OPT_NAME['a']='max'      OPT_DESC['a']='random range max value, unit is ms'
-OPT_HAS_ARG['a']=1         OPT_VALUE_lst['a']='200'
+OPT_HAS_ARG['a']=1         OPT_VAL['a']='200'
 
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VAL['s']=1
 
 func_opt_parse_option "$@"
 
-repeat_count=${OPT_VALUE_lst['r']}
-loop_count=${OPT_VALUE_lst['l']}
+repeat_count=${OPT_VAL['r']}
+loop_count=${OPT_VAL['l']}
 # configure random value range
-rnd_min=${OPT_VALUE_lst['i']}
-rnd_max=${OPT_VALUE_lst['a']}
+rnd_min=${OPT_VAL['i']}
+rnd_max=${OPT_VAL['a']}
 rnd_range=$[ $rnd_max - $rnd_min ]
 [[ $rnd_range -le 0 ]] && dlogw "Error random range scope [ min:$rnd_min - max:$rnd_max ]" && exit 2
 
-tplg=${OPT_VALUE_lst['t']}
+tplg=${OPT_VAL['t']}
 func_pipeline_export "$tplg" "type:any"
 
-[[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
+[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
 
 declare -a pipeline_idx_lst
 declare -a cmd_idx_lst
@@ -87,7 +87,7 @@ do
 done
 
 # get the min value of TPLG:'pipeline count' with Case:'pipeline count'
-[[ ${#pipeline_idx_lst[*]} -gt ${OPT_VALUE_lst['c']} ]] && max_count=${OPT_VALUE_lst['c']} || max_count=${#pipeline_idx_lst[*]}
+[[ ${#pipeline_idx_lst[*]} -gt ${OPT_VAL['c']} ]] && max_count=${OPT_VAL['c']} || max_count=${#pipeline_idx_lst[*]}
 [[ $max_count -eq 1 ]] && dlogw "pipeline count is 1, don't need to run this case" && exit 2
 
 # create combination list

--- a/test-case/multiple-pause-resume.sh
+++ b/test-case/multiple-pause-resume.sh
@@ -24,25 +24,25 @@ set -e
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
-OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
 OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
-OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=3
+OPT_HAS_ARG['l']=1         OPT_VALUE_lst['l']=3
 
 OPT_NAME['c']='count'    OPT_DESC['c']='combine test pipeline count'
-OPT_PARM_lst['c']=1         OPT_VALUE_lst['c']=2
+OPT_HAS_ARG['c']=1         OPT_VALUE_lst['c']=2
 
 OPT_NAME['r']='loop'     OPT_DESC['r']='pause resume repeat count'
-OPT_PARM_lst['r']=1         OPT_VALUE_lst['r']=3
+OPT_HAS_ARG['r']=1         OPT_VALUE_lst['r']=3
 
 OPT_NAME['i']='min'      OPT_DESC['i']='random range min value, unit is ms'
-OPT_PARM_lst['i']=1         OPT_VALUE_lst['i']='100'
+OPT_HAS_ARG['i']=1         OPT_VALUE_lst['i']='100'
 
 OPT_NAME['a']='max'      OPT_DESC['a']='random range max value, unit is ms'
-OPT_PARM_lst['a']=1         OPT_VALUE_lst['a']='200'
+OPT_HAS_ARG['a']=1         OPT_VALUE_lst['a']='200'
 
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
 
 func_opt_parse_option "$@"
 

--- a/test-case/multiple-pipeline.sh
+++ b/test-case/multiple-pipeline.sh
@@ -36,38 +36,38 @@ set -e
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
-OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VAL['t']="$TPLG"
 
 OPT_NAME['c']='count'    OPT_DESC['c']='test pipeline count'
-OPT_HAS_ARG['c']=1         OPT_VALUE_lst['c']=4
+OPT_HAS_ARG['c']=1         OPT_VAL['c']=4
 
 OPT_NAME['f']='first'
 OPT_DESC['f']='Fill either playback (p) or capture (c) first'
-OPT_HAS_ARG['f']=1         OPT_VALUE_lst['f']='p'
+OPT_HAS_ARG['f']=1         OPT_VAL['f']='p'
 
 OPT_NAME['w']='wait'     OPT_DESC['w']='perpare wait time by sleep'
-OPT_HAS_ARG['w']=1         OPT_VALUE_lst['w']=5
+OPT_HAS_ARG['w']=1         OPT_VAL['w']=5
 
 OPT_NAME['r']='random'   OPT_DESC['r']='random load pipeline'
-OPT_HAS_ARG['r']=0         OPT_VALUE_lst['r']=0
+OPT_HAS_ARG['r']=0         OPT_VAL['r']=0
 
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VAL['s']=1
 
 OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
-OPT_HAS_ARG['l']=1         OPT_VALUE_lst['l']=1
+OPT_HAS_ARG['l']=1         OPT_VAL['l']=1
 
 func_opt_parse_option "$@"
-loop_cnt=${OPT_VALUE_lst['l']}
-tplg=${OPT_VALUE_lst['t']}
-[[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
+loop_cnt=${OPT_VAL['l']}
+tplg=${OPT_VAL['t']}
+[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
 
 max_count=0
 # this line will help to get $PIPELINE_COUNT
 func_pipeline_export "$tplg" "type:any"
 # acquire pipeline count that will run in parallel, if the number of pipeline
 # in topology is less than the required pipeline count, all pipeline will be started.
-[[ $PIPELINE_COUNT -gt ${OPT_VALUE_lst['c']} ]] && max_count=${OPT_VALUE_lst['c']} || max_count=$PIPELINE_COUNT
+[[ $PIPELINE_COUNT -gt ${OPT_VAL['c']} ]] && max_count=${OPT_VAL['c']} || max_count=$PIPELINE_COUNT
 
 # now small function define
 declare -A APP_LST DEV_LST
@@ -82,7 +82,7 @@ func_run_pipeline_with_type()
     [[ $tmp_count -le 0 ]] && return
     func_pipeline_export "$tplg" "type:$1"
     local -a idx_lst
-    if [ ${OPT_VALUE_lst['r']} -eq 0 ]; then
+    if [ ${OPT_VAL['r']} -eq 0 ]; then
         idx_lst=( $(seq 0 $(expr $PIPELINE_COUNT - 1)) )
     else
         # convert array to line, shuf to get random line, covert line to array
@@ -143,7 +143,7 @@ do
     dlogi "===== Testing: (Loop: $i/$loop_cnt) ====="
 
     # start capture:
-    f_arg=${OPT_VALUE_lst['f']}
+    f_arg=${OPT_VAL['f']}
     case "$f_arg" in
         'p')
             tmp_count=$max_count
@@ -159,14 +159,14 @@ do
             die "Wrong -f argument $f_arg, see -h"
     esac
 
-    dlogi "sleep ${OPT_VALUE_lst['w']}s for sound device wakeup"
-    sleep ${OPT_VALUE_lst['w']}
+    dlogi "sleep ${OPT_VAL['w']}s for sound device wakeup"
+    sleep ${OPT_VAL['w']}
 
     dlogi "checking pipeline status"
     ps_checks
 
-    dlogi "preparing sleep ${OPT_VALUE_lst['w']}"
-    sleep ${OPT_VALUE_lst['w']}
+    dlogi "preparing sleep ${OPT_VAL['w']}"
+    sleep ${OPT_VAL['w']}
 
     # check processes again
     dlogi "checking pipeline status again"

--- a/test-case/multiple-pipeline.sh
+++ b/test-case/multiple-pipeline.sh
@@ -36,26 +36,26 @@ set -e
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
-OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
 OPT_NAME['c']='count'    OPT_DESC['c']='test pipeline count'
-OPT_PARM_lst['c']=1         OPT_VALUE_lst['c']=4
+OPT_HAS_ARG['c']=1         OPT_VALUE_lst['c']=4
 
 OPT_NAME['f']='first'
 OPT_DESC['f']='Fill either playback (p) or capture (c) first'
-OPT_PARM_lst['f']=1         OPT_VALUE_lst['f']='p'
+OPT_HAS_ARG['f']=1         OPT_VALUE_lst['f']='p'
 
 OPT_NAME['w']='wait'     OPT_DESC['w']='perpare wait time by sleep'
-OPT_PARM_lst['w']=1         OPT_VALUE_lst['w']=5
+OPT_HAS_ARG['w']=1         OPT_VALUE_lst['w']=5
 
 OPT_NAME['r']='random'   OPT_DESC['r']='random load pipeline'
-OPT_PARM_lst['r']=0         OPT_VALUE_lst['r']=0
+OPT_HAS_ARG['r']=0         OPT_VALUE_lst['r']=0
 
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
 
 OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
-OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=1
+OPT_HAS_ARG['l']=1         OPT_VALUE_lst['l']=1
 
 func_opt_parse_option "$@"
 loop_cnt=${OPT_VALUE_lst['l']}

--- a/test-case/simultaneous-playback-capture.sh
+++ b/test-case/simultaneous-playback-capture.sh
@@ -21,21 +21,21 @@
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
-OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VAL['t']="$TPLG"
 
 OPT_NAME['w']='wait'     OPT_DESC['w']='sleep for wait duration'
-OPT_HAS_ARG['w']=1         OPT_VALUE_lst['w']=5
+OPT_HAS_ARG['w']=1         OPT_VAL['w']=5
 
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VAL['s']=1
 
 OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
-OPT_HAS_ARG['l']=1         OPT_VALUE_lst['l']=1
+OPT_HAS_ARG['l']=1         OPT_VAL['l']=1
 
 func_opt_parse_option "$@"
-tplg=${OPT_VALUE_lst['t']}
-wait_time=${OPT_VALUE_lst['w']}
-loop_cnt=${OPT_VALUE_lst['l']}
+tplg=${OPT_VAL['t']}
+wait_time=${OPT_VAL['w']}
+loop_cnt=${OPT_VAL['l']}
 
 # get 'both' pcm, it means pcm have same id with different type
 declare -A tmp_id_lst
@@ -56,7 +56,7 @@ unset tmp_id_lst tplg_path
 id_lst_str=${id_lst_str/,/} # remove 1st, which is not used
 [[ ${#id_lst_str} -eq 0 ]] && dlogw "no pipeline with both playback and capture capabilities found in $tplg" && exit 2
 func_pipeline_export "$tplg" "id:$id_lst_str"
-[[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
+[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
 
 func_error_exit()
 {

--- a/test-case/simultaneous-playback-capture.sh
+++ b/test-case/simultaneous-playback-capture.sh
@@ -21,16 +21,16 @@
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
-OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
 OPT_NAME['w']='wait'     OPT_DESC['w']='sleep for wait duration'
-OPT_PARM_lst['w']=1         OPT_VALUE_lst['w']=5
+OPT_HAS_ARG['w']=1         OPT_VALUE_lst['w']=5
 
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
 
 OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
-OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=1
+OPT_HAS_ARG['l']=1         OPT_VALUE_lst['l']=1
 
 func_opt_parse_option "$@"
 tplg=${OPT_VALUE_lst['t']}

--- a/test-case/test-speaker.sh
+++ b/test-case/test-speaker.sh
@@ -18,20 +18,20 @@
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
-OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VAL['t']="$TPLG"
 
 OPT_NAME['l']='loop'     OPT_DESC['l']='option of speaker-test'
-OPT_HAS_ARG['l']=1         OPT_VALUE_lst['l']=3
+OPT_HAS_ARG['l']=1         OPT_VAL['l']=3
 
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VAL['s']=1
 
 func_opt_parse_option "$@"
-tplg=${OPT_VALUE_lst['t']}
-[[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
+tplg=${OPT_VAL['t']}
+[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
 
 func_pipeline_export "$tplg" "type:playback"
-tcnt=${OPT_VALUE_lst['l']}
+tcnt=${OPT_VAL['l']}
 func_lib_setup_kernel_checkpoint
 for idx in $(seq 0 $(expr $PIPELINE_COUNT - 1))
 do

--- a/test-case/test-speaker.sh
+++ b/test-case/test-speaker.sh
@@ -18,13 +18,13 @@
 source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
-OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
 OPT_NAME['l']='loop'     OPT_DESC['l']='option of speaker-test'
-OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=3
+OPT_HAS_ARG['l']=1         OPT_VALUE_lst['l']=3
 
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
 
 func_opt_parse_option "$@"
 tplg=${OPT_VALUE_lst['t']}

--- a/test-case/verify-pcm-list.sh
+++ b/test-case/verify-pcm-list.sh
@@ -21,7 +21,7 @@ set -e
 source "$(dirname "${BASH_SOURCE[0]}")/../case-lib/lib.sh"
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $''TPLG'
-OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="${TPLG:-}"
+OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="${TPLG:-}"
 
 func_opt_parse_option "$@"
 tplg=${OPT_VALUE_lst['t']}

--- a/test-case/verify-pcm-list.sh
+++ b/test-case/verify-pcm-list.sh
@@ -21,10 +21,10 @@ set -e
 source "$(dirname "${BASH_SOURCE[0]}")/../case-lib/lib.sh"
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $''TPLG'
-OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="${TPLG:-}"
+OPT_HAS_ARG['t']=1         OPT_VAL['t']="${TPLG:-}"
 
 func_opt_parse_option "$@"
-tplg=${OPT_VALUE_lst['t']}
+tplg=${OPT_VAL['t']}
 
 tplg_path=`func_lib_get_tplg_path "$tplg"`
 [[ "$?" != "0" ]] && die "No available topology for this test case"

--- a/test-case/verify-tplg-binary.sh
+++ b/test-case/verify-tplg-binary.sh
@@ -20,10 +20,10 @@ set -e
 source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $''TPLG'
-OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VAL['t']="$TPLG"
 
 func_opt_parse_option "$@"
-tplg=${OPT_VALUE_lst['t']}
+tplg=${OPT_VAL['t']}
 
 tplg_path=`func_lib_get_tplg_path "$tplg"`
 [[ "$?" != "0" ]] && die "No available topology for this test case"

--- a/test-case/verify-tplg-binary.sh
+++ b/test-case/verify-tplg-binary.sh
@@ -20,7 +20,7 @@ set -e
 source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $''TPLG'
-OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
 func_opt_parse_option "$@"
 tplg=${OPT_VALUE_lst['t']}

--- a/test-case/volume-basic-test.sh
+++ b/test-case/volume-basic-test.sh
@@ -19,13 +19,13 @@ source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
 volume_array=("0%" "10%" "20%" "30%" "40%" "50%" "60%" "70%" "80%" "90%" "100%")
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
-OPT_PARM_lst['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
 
 OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
-OPT_PARM_lst['l']=1         OPT_VALUE_lst['l']=2
+OPT_HAS_ARG['l']=1         OPT_VALUE_lst['l']=2
 
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_PARM_lst['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
 
 func_opt_parse_option "$@"
 tplg=${OPT_VALUE_lst['t']}

--- a/test-case/volume-basic-test.sh
+++ b/test-case/volume-basic-test.sh
@@ -19,17 +19,17 @@ source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 
 volume_array=("0%" "10%" "20%" "30%" "40%" "50%" "60%" "70%" "80%" "90%" "100%")
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
-OPT_HAS_ARG['t']=1         OPT_VALUE_lst['t']="$TPLG"
+OPT_HAS_ARG['t']=1         OPT_VAL['t']="$TPLG"
 
 OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
-OPT_HAS_ARG['l']=1         OPT_VALUE_lst['l']=2
+OPT_HAS_ARG['l']=1         OPT_VAL['l']=2
 
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_HAS_ARG['s']=0             OPT_VALUE_lst['s']=1
+OPT_HAS_ARG['s']=0             OPT_VAL['s']=1
 
 func_opt_parse_option "$@"
-tplg=${OPT_VALUE_lst['t']}
-maxloop=${OPT_VALUE_lst['l']}
+tplg=${OPT_VAL['t']}
+maxloop=${OPT_VAL['l']}
 
 func_error_exit()
 {
@@ -40,7 +40,7 @@ func_error_exit()
 
 [[ -z $tplg ]] && die "Missing tplg file needed to run"
 func_pipeline_export "$tplg" "type:playback"
-[[ ${OPT_VALUE_lst['s']} -eq 1 ]] && func_lib_start_log_collect
+[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
 
 [[ $PIPELINE_COUNT -eq 0 ]] && die "Missing playback pipeline for aplay to run"
 channel=$(func_pipeline_parse_value 0 channel)


### PR DESCRIPTION
This PR renames two variable names used to define script command line options, OPT_PARM_lst to OPT_HAS_ARG, OPT_VALUE_lst to OPT_ARG

No functional change, only repo wide search and replace. check discussion https://github.com/thesofproject/sof-test/issues