### PR TITLE
kmod: sof-remove.sh: change ACPI dependency orders

### DIFF
--- a/tools/kmod/sof_insert.sh
+++ b/tools/kmod/sof_insert.sh
@@ -48,8 +48,15 @@ insert_module snd_soc_rt1011
 insert_module snd_sof_acpi_intel_byt
 insert_module snd_sof_acpi_intel_bdw
 
+insert_module snd_sof_pci_intel_tng
+insert_module snd_sof_pci_intel_apl
+insert_module snd_sof_pci_intel_cnl
+insert_module snd_sof_pci_intel_icl
+insert_module snd_sof_pci_intel_tgl
+
 insert_module snd_sof_acpi
 insert_module snd_sof_pci
+
 insert_module snd_usb_audio
 
 # without the status check force quit

--- a/tools/kmod/sof_insert.sh
+++ b/tools/kmod/sof_insert.sh
@@ -45,6 +45,9 @@ insert_module snd_soc_rt1308_sdw
 insert_module snd_soc_rt715
 insert_module snd_soc_rt1011
 
+insert_module snd_sof_acpi_intel_byt
+insert_module snd_sof_acpi_intel_bdw
+
 insert_module snd_sof_acpi
 insert_module snd_sof_pci
 insert_module snd_usb_audio

--- a/tools/kmod/sof_insert.sh
+++ b/tools/kmod/sof_insert.sh
@@ -45,9 +45,6 @@ insert_module snd_soc_rt1308_sdw
 insert_module snd_soc_rt715
 insert_module snd_soc_rt1011
 
-insert_module sof_acpi_dev
-insert_module sof_pci_dev
-
 insert_module snd_sof_acpi
 insert_module snd_sof_pci
 insert_module snd_usb_audio

--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -22,6 +22,12 @@ remove_module snd_usb_audio
 #-------------------------------------------
 remove_module snd_hda_intel
 remove_module snd_sof_pci
+remove_module snd_sof_acpi_intel_byt
+remove_module snd_sof_acpi_intel_bdw
+
+#-------------------------------------------
+# Helpers
+#-------------------------------------------
 remove_module snd_sof_acpi
 
 #-------------------------------------------
@@ -33,17 +39,24 @@ remove_module snd_intel_sst_core
 remove_module snd_soc_sst_atom_hifi2_platform
 remove_module snd_soc_skl
 
-#-------------------------------------------
-# Machine drivers
-#-------------------------------------------
+#------------------------------------------------------
+# obsolete platform drivers - kept to avoid breaking CI
+#------------------------------------------------------
 remove_module snd_sof_intel_byt
 remove_module snd_sof_intel_bdw
+
+#-------------------------------------------
+# platform drivers
+#-------------------------------------------
 remove_module snd_sof_intel_hda_common
 remove_module snd_sof_intel_hda
 remove_module snd_sof_intel_ipc
 remove_module snd_sof_xtensa_dsp
 remove_module snd_soc_acpi_intel_match
 
+#-------------------------------------------
+# Machine drivers
+#-------------------------------------------
 remove_module snd_soc_sof_rt5682
 remove_module snd_soc_sof_da7219_max98373
 remove_module snd_soc_sst_bdw_rt5677_mach

--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -21,8 +21,6 @@ remove_module snd_usb_audio
 # Top level devices
 #-------------------------------------------
 remove_module snd_hda_intel
-remove_module sof_pci_dev
-remove_module sof_acpi_dev
 remove_module snd_sof_pci
 remove_module snd_sof_acpi
 

--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -19,9 +19,14 @@ remove_module snd_usb_audio
 
 #-------------------------------------------
 # Top level devices
+# ACPI is after PCI due to TNG dependencies
 #-------------------------------------------
 remove_module snd_hda_intel
-remove_module snd_sof_pci
+remove_module snd_sof_pci_intel_tng
+remove_module snd_sof_pci_intel_apl
+remove_module snd_sof_pci_intel_cnl
+remove_module snd_sof_pci_intel_icl
+remove_module snd_sof_pci_intel_tgl
 remove_module snd_sof_acpi_intel_byt
 remove_module snd_sof_acpi_intel_bdw
 
@@ -29,6 +34,7 @@ remove_module snd_sof_acpi_intel_bdw
 # Helpers
 #-------------------------------------------
 remove_module snd_sof_acpi
+remove_module snd_sof_pci
 
 #-------------------------------------------
 # legacy drivers (not used but loaded)


### PR DESCRIPTION
ACPI drivers were reworked, sof-acpi-dev is now a helper and no longer
the top-level. The modules were renamed, but old names kept for now,
so this change should have no functional impact.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>