### PR TITLE
lib: remove the fake kernel device prefix

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -54,12 +54,13 @@ func_lib_setup_kernel_checkpoint()
 # more critical for testing changes to the test framework and especially
 # error handling code.
 #
-# Sample usage: fake_kern_error "FAKE error $0 PID $$ $round"
+# Sample usage: fake_kern_error "DRIVER ID: FAKE error $0 PID $$ $round"
+#               fake_kern_error "asix 3-12.1:1.0 enx000ec668ad2a: Failed to write reg index 0x0000: -11"
 fake_kern_error()
 {
     local k_msg d boot_secs kern_log_prefix
 
-    k_msg="sof-audio-pci 0000:66:66.6: $1"
+    k_msg="$1"
     d=$(date '+%b %d %R:%S') # TODO: is this locale dependent?
     boot_secs=$(awk '{ print $1 }' < /proc/uptime)
     kern_log_prefix="$d $(hostname) kernel: [$boot_secs]"


### PR DESCRIPTION
The fake_kern_error need to test with not only sof related issues.
before fix:
[683402.712924] sof-audio-pci 0000:66:66.6: asix 3-12.1:1.0 enx000ec668ad2a: Failed to read reg index 0x0000: -113 >/dev/kmsg
after fix:
[683541.396907] asix 3-12.1:1.0 enx000ec668ad2a: Failed to write reg index 0x0000: -113 >/dev/kmsg

Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>