### PR TITLE
opt.sh: refine option definition and overriding

### DIFF
--- a/case-lib/opt.sh
+++ b/case-lib/opt.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright(c) 2021 Intel Corporation. All rights reserved.
+
 # These four arrays are used to define script options, and they should be
 # indexed by a character [a-zA-Z], which is the option short name.
 # OPT_NAME: option long name

--- a/case-lib/opt.sh
+++ b/case-lib/opt.sh
@@ -28,7 +28,7 @@ func_opt_parse_option()
 
     _func_case_dump_description()
     {
-         grep '^##' "$SCRIPT_NAME" | sed 's/^## //g'
+        grep '^##' "$SCRIPT_NAME" | sed 's/^## //g'
     }
 
     # Asks getopt to validate command line input and generate $_op_temp_script
@@ -75,36 +75,36 @@ func_opt_parse_option()
         printf 'Usage: %s [OPTION]\n' "$0"
         for i in ${!OPT_DESC[*]}
         do
-                [ "X$i" = "Xh" ] && continue
-                # display short option
-                [ "$i" ] && printf '    -%s' "$i"
-                # if option requires extra argument
+            [ "X$i" = "Xh" ] && continue
+            # display short option
+            [ "$i" ] && printf '    -%s' "$i"
+            # if option requires extra argument
+            [ "X${OPT_HAS_ARG[$i]}" == "X1" ] && printf ' parameter'
+            # display long option
+            if [ "${OPT_NAME[$i]}" ]; then
+                # whether display short option
+                [ "$i" ] && printf ' |  ' || printf '    '
+                printf '%s' "--${OPT_NAME[$i]}"
                 [ "X${OPT_HAS_ARG[$i]}" == "X1" ] && printf ' parameter'
-                # display long option
-                if [ "${OPT_NAME[$i]}" ]; then
-                    # whether display short option
-                    [ "$i" ] && printf ' |  ' || printf '    '
-                    printf '%s' "--${OPT_NAME[$i]}"
-                    [ "X${OPT_HAS_ARG[$i]}" == "X1" ] && printf ' parameter'
+            fi
+            printf '\n\t%s\n' "${OPT_DESC[$i]}"
+            if [ "${OPT_VAL[$i]}" ]; then
+                if [ "${OPT_HAS_ARG[$i]}" -eq 1 ]; then
+                    printf '\tDefault Value: %s\n' "${OPT_VAL[$i]}"
+                elif [ "${OPT_VAL[$i]}" -eq 0 ]; then
+                    printf '\tDefault Value: Off\n'
+                else
+                    printf '\tDefault Value: On\n'
                 fi
-                printf '\n\t%s\n' "${OPT_DESC[$i]}"
-                if [ "${OPT_VAL[$i]}" ]; then
-                    if [ "${OPT_HAS_ARG[$i]}" -eq 1 ]; then
-                        printf '\tDefault Value: %s\n' "${OPT_VAL[$i]}"
-                    elif [ "${OPT_VAL[$i]}" -eq 0 ]; then
-                        printf '\tDefault Value: Off\n'
-                    else
-                        printf '\tDefault Value: On\n'
-                    fi
-                fi
-            done
+            fi
+        done
 
-            printf '    -h |  --help\n'
-            printf '\tthis message\n'
-            _func_case_dump_description
-            trap - EXIT
-            exit 2
-        }
+        printf '    -h |  --help\n'
+        printf '\tthis message\n'
+        _func_case_dump_description
+        trap - EXIT
+        exit 2
+    }
 
     add_common_options
 

--- a/case-lib/opt.sh
+++ b/case-lib/opt.sh
@@ -10,15 +10,19 @@
 # OPT_DESC: description for this option
 declare -A OPT_NAME OPT_HAS_ARG OPT_VAL OPT_DESC
 
-# option setup && parse function
-func_opt_parse_option()
+# Define common options among test scripts.
+add_common_options()
 {
     # The help option
     OPT_NAME['h']='help'
     OPT_HAS_ARG['h']=0
     OPT_VAL['h']=0
     OPT_DESC['h']='show help information'
+}
 
+# option setup && parse function
+func_opt_parse_option()
+{
     local _op_temp_script
     local -A _op_short_lst _op_long_lst
 
@@ -101,6 +105,8 @@ func_opt_parse_option()
             trap - EXIT
             exit 2
         }
+
+    add_common_options
 
     # Asks getopt to validate input and generate _op_temp_script.
     # Initialize reverse maps _op_short_lst and _opt_long_lst used next.

--- a/case-lib/opt.sh
+++ b/case-lib/opt.sh
@@ -30,11 +30,11 @@ add_common_options()
 # and dump help
 func_opt_parse_option()
 {
-    # lines that start with '##' will be regarded as documentation.
-    # this function dumps these lines after removing the leading '## '
+    # Lines that start with '##' will be regarded as documentation,
+    # removing the leading '##' or '## ' from documentation.
     _dump_case_description()
     {
-        grep '^##' "$SCRIPT_NAME" | sed 's/^## //g'
+        grep '^##' "$SCRIPT_NAME" | sed 's/^##//g' | sed 's/^ //g'
     }
 
     # This function helps to fill below four variables


### PR DESCRIPTION
1. move common option definition to a function, common options can be define here(eg, help, and tplg). TODO, call this in script explicitly(rather than in opt.sh), or some options may be hidden.
2. split  function in_func_create_tmpbash to _fill_opt_vars and _validate_and_format_cmd_line for better code structure.
3. fix unclear comments and add more comments
