### PR TITLE
[skip ci] .github/ actions: temporary python3-pil installation hack

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,6 +9,7 @@
 
 name: Pull Requests
 
+# yamllint disable-line rule:truthy
 on:
   push:
     branches: [master]
@@ -34,6 +35,10 @@ jobs:
       # :-( https://github.community/t/support-for-yaml-anchors/16128
       - {uses: actions/checkout@v2, with: {fetch-depth: 0}}
       - uses: actions/setup-python@v2
+      - name: temporary python3-pil HACK because github is out of date
+        run: sudo apt-get -y install libimagequant0 libwebpdemux2 &&
+           wget http://security.ubuntu.com/ubuntu/ubuntu/pool/main/p/pillow/python3-pil_7.0.0-4ubuntu0.2_amd64.deb &&
+           sudo dpkg -i python3-pil_*.deb
       - name: get python libs
         # FIXME: apt-get succeeds but 'import numpy' still fails!?
         run: sudo apt-get -y install python3-numpy python3-scipy pylint


### PR DESCRIPTION
Because the Ubuntu package index is out of date on github
https://github.com/actions/virtual-environments/issues/1757#issuecomment-765238242

Should be much faster than apt-update

Signed-off-by: Marc Herbert <marc.herbert@intel.com>