### PR TITLE
kmod: work-around dependency changes

### DIFF
--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -14,6 +14,14 @@ remove_module() {
     fi
 }
 
+try_remove_module() {
+    set +e
+
+    remove_module $1
+
+    set -e
+ }
+
 # SOF CI has a dependency on usb audio
 remove_module snd_usb_audio
 
@@ -29,6 +37,11 @@ remove_module snd_sof_pci_intel_icl
 remove_module snd_sof_pci_intel_tgl
 remove_module snd_sof_acpi_intel_byt
 remove_module snd_sof_acpi_intel_bdw
+
+#-------------------------------------------
+# temporary dependency
+#-------------------------------------------
+try_remove_module snd_sof_intel_hda_common
 
 #-------------------------------------------
 # Helpers


### PR DESCRIPTION
PR https://github.com/thesofproject/linux/pull/2683 introduces a
dependency change. There is still one case there a module is used
differently before and after this PR, and renaming isn't really an
option.

This patch suggests a temporary workaround where we try to remove a
module (with errors disabled), and if it doesn't work we keep going.
In practice the snd_sof_hda_common module is made mostly of helper
routines and tables, without any PCI stuff, so there is a limited risk
of issues.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>