### PR TITLE
sof-kernel-log-check: ignore ACPI _ADR workaround

### DIFF
--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -310,6 +310,11 @@ ignore_str="$ignore_str"'|proc_thermal 0000:00:..\..: No auxiliary DTSs enabled'
 # elan_i2c i2c-ELAN0000:00: invalid report id data (ff)
 ignore_str="$ignore_str"'|elan_i2c i2c-ELAN0000:.*: invalid report id data'
 
+# SoundWire workaround using RT701
+# https://github.com/thesofproject/linux/pull/2701
+ignore_str="$ignore_str"'|rt711 sdw:[0-3]:25d:701:0: Probe of rt711 failed: -19'
+ignore_str="$ignore_str"'|rt1308 sdw:[0-3]:25d:701:0: Probe of rt1308 failed: -19'
+
 #
 # SDW related logs
 #


### PR DESCRIPTION
PR https://github.com/thesofproject/linux/pull/2701 introduces a
workaround which leads to errors being thrown when the DSDT contains a
device with the 0x701 part_id.

Ignore the error since it's a normal error flow.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>