### PR TITLE
kmod: unload snd_sof_intel_hda_common early, work around dep. changes

### DIFF
--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -30,6 +30,12 @@ remove_module snd_sof_pci_intel_tgl
 remove_module snd_sof_acpi_intel_byt
 remove_module snd_sof_acpi_intel_bdw
 
+#--------------------------------------------------
+# With older kernels this is in use by snd_sof_pci,
+# see https://github.com/thesofproject/linux/pull/2683
+#--------------------------------------------------
+remove_module snd_sof_intel_hda_common || true
+
 #-------------------------------------------
 # Helpers
 #-------------------------------------------


### PR DESCRIPTION
From pierre-louis.bossart@linux.intel.com in PR #589

PR https://github.com/thesofproject/linux/pull/2683 introduces a
dependency change. There is still one case there a module is used
differently before and after this PR, and renaming isn't really an
option.

This patch suggests a temporary workaround where we try to remove a
module (with errors disabled), and if it doesn't work we keep going.
In practice the snd_sof_hda_common module is made mostly of helper
routines and tables, without any PCI stuff, so there is a limited risk
of issues.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>