### PR TITLE
CI: run pull_request.yml action only on PR

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,8 +11,6 @@ name: Pull Requests
 
 # yamllint disable-line rule:truthy
 on:
-  push:
-    branches: [master]
   pull_request:
     branches: [master]
 


### PR DESCRIPTION
This GitHub action is designed for PR only.
It could not run on push.

Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>

Fix strange GitHub action on PR merge push
https://github.com/thesofproject/sof-test/runs/1774851099?check_suite_focus=true