### PR TITLE
userspace: add verify-ucm-bootsequence

### DIFF
--- a/case-lib/user.sh
+++ b/case-lib/user.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# function dpkg_version_ge uses dpkg to get the package version
+# and compares it with the specified version. If the package version
+# is less than the specified version, it means the version dependency
+# is not met and return 1.
+# Args: $1: package name
+#       $2: specified version
+dpkg_version_ge()
+{
+    local ver
+    ver=$(dpkg -l "$1" |grep "$1" | awk '{print $3}')
+    [[ -z "$ver" ]] && die "failed to get $1 version"
+    dlogi "find $1 version  $ver"
+    version_ge "$ver" "$2"
+}
+
+# function version_ge compares the 2 versions specified in the parameters.
+version_ge()
+{
+    printf '%s\n' "$2" "$1" | sort -V -C
+}

--- a/test-case/verify-bootsequence.sh
+++ b/test-case/verify-bootsequence.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+##
+## Case Name: verify-bootsequence.sh
+## Preconditions:
+##    UCMv2 is installed in /usr/share/alsa/ucm2 folder
+## Description:
+##    Run alsactl init to test the initialization settings are correct or not
+## Case step:
+##    1. check the alsa-lib, alsa-utils version
+##    2. save the original amixer settings
+##    3. run alsactl init
+##    4. restore the original amixer settings
+## Expect result:
+##    alsactl init runs successfully
+##
+
+set -e
+
+# shellcheck source=case-lib/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
+# shellcheck source=case-lib/user.sh
+source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/user.sh
+
+# BootSequence is introduced in alsa-utils 1.2.2-16
+ALSAUTILS_VER=1.2.2-16
+# BootSequence is introduced in alsa-lib 1.2.2-44
+ALSALIB_VER=1.2.2-44
+# BootSequence is introduced in alsa-ucm-conf 1.2.3-15
+ALSAUCM_VER=1.2.3-15
+
+func_opt_parse_option "$@"
+
+main()
+{
+    local tmp
+
+    dpkg_version_ge "libasound2" "$ALSALIB_VER"
+    dpkg_version_ge "alsa-utils" "$ALSAUTILS_VER"
+    dpkg_version_ge "alsa-ucm-conf" "$ALSAUCM_VER" || dlogi "alsa-ucm-conf version is too low"
+
+    # alsactl init only applies to SOF card
+    [[ -n "$SOFCARD" ]] || die "No SOF card"
+    cardname=$(sof-dump-status.py -s "$SOFCARD") || exit 1
+    [[ -n "$cardname" ]] || die "Failed to get card $SOFCARD short name"
+
+    tmp=$(mktemp -d) || die "Failed to create tmp folder."
+    cd "$tmp"
+    dlogi "Indirectly checking the card $cardname UCM2 initial settings (if any) with alsactl init"
+    alsactl store -f tmp.conf || die "Failed to save the amixer setting"
+    dlogc "alsactl init $SOFCARD"
+    alsactl init "$SOFCARD" || die "Failed to run alsactl init"
+    alsactl restore -f tmp.conf || die "Failed to restore the amixer setting"
+}
+
+main "$@"


### PR DESCRIPTION
This test case will check the UCM2 codec initialization setting
on the tested cards.

Signed-off-by: Libin Yang <libin.yang@intel.com>