### PR TITLE
tools: sof-kernel-log-check: filter out iwlwifi related error logs

### DIFF
--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -166,20 +166,10 @@ ignore_str="$ignore_str"'|cfg80211: failed to load regulatory\.db'
 ignore_str="$ignore_str"'|EXT4-fs \(nvme0n1p6\): re-mounted\. Opts: errors=remount-ro'
 ignore_str="$ignore_str"'|usb 2-3: Enable of device-initiated U1 failed\.'
 ignore_str="$ignore_str"'|usb 2-3: Enable of device-initiated U2 failed\.'
-ignore_str="$ignore_str"'|iwlwifi 0000:00:14\.3: Direct firmware load for iwlwifi-QuZ-a0-hr-b0-56\.ucode failed with error -2'
-ignore_str="$ignore_str"'|iwlwifi 0000:00:14\.3: Direct firmware load for iwlwifi-QuZ-a0-hr-b0-55\.ucode failed with error -2'
-ignore_str="$ignore_str"'|iwlwifi 0000:00:14\.3: Direct firmware load for iwlwifi-QuZ-a0-hr-b0-54\.ucode failed with error -2'
-ignore_str="$ignore_str"'|iwlwifi 0000:00:14\.3: Direct firmware load for iwlwifi-QuZ-a0-hr-b0-53\.ucode failed with error -2'
-ignore_str="$ignore_str"'|iwlwifi 0000:00:14\.3: Direct firmware load for iwlwifi-QuZ-a0-hr-b0-52\.ucode failed with error -2'
-ignore_str="$ignore_str"'|iwlwifi 0000:00:14\.3: Direct firmware load for iwlwifi-QuZ-a0-hr-b0-51\.ucode failed with error -2'
-ignore_str="$ignore_str"'|iwlwifi 0000:00:14\.3: Direct firmware load for iwlwifi-QuZ-a0-hr-b0-50\.ucode failed with error -2'
-ignore_str="$ignore_str"'|iwlwifi 0000:00:14\.3: Direct firmware load for iwlwifi-QuZ-a0-hr-b0-49\.ucode failed with error -2'
-ignore_str="$ignore_str"'|iwlwifi 0000:00:14\.3: Direct firmware load for iwl-debug-yoyo\.bin failed with error -2'
 ignore_str="$ignore_str"'|thermal thermal_zone.*: failed to read out thermal zone \(-61\)'
 
 # Dell CML-U laptop with SoundWire, issues reported by sof-test
 # BugLink: https://github.com/thesofproject/sof-test/issues/307
-ignore_str="$ignore_str"'|iwlwifi 0000:00:14\.3: Microcode SW error detected\. Restarting 0x0\.'
 ignore_str="$ignore_str"'|: authentication with ..:..:..:..:..:.. timed out'
 
 # Dell TGL laptop with SoundWire, issues reported by sof-test
@@ -309,6 +299,16 @@ ignore_str="$ignore_str"'|proc_thermal 0000:00:..\..: No auxiliary DTSs enabled'
 # origin logs seen on GLK platforms
 # elan_i2c i2c-ELAN0000:00: invalid report id data (ff)
 ignore_str="$ignore_str"'|elan_i2c i2c-ELAN0000:.*: invalid report id data'
+
+# iwlwifi net adaptor logs can be ignored
+# origin logs seen on CML platforms
+# iwlwifi 0000:00:14.3: Direct firmware load for iwlwifi-QuZ-a0-hr-b0-56.ucode failed with error -2
+# iwlwifi 0000:00:14.3: Direct firmware load for iwl-debug-yoyo.bin failed with error -2
+# BugLink: https://github.com/thesofproject/sof-test/issues/307
+# iwlwifi 0000:00:14.3: Microcode SW error detected. Restarting 0x0.'
+# BugLink: https://github.com/thesofproject/sof-test/issues/578
+# iwlwifi 0000:00:14.3: No beacon heard and the time event is over already...
+ignore_str="$ignore_str"'|iwlwifi [[:digit:].:]+: '
 
 #
 # SDW related logs


### PR DESCRIPTION
move all iwlwifi related filter rules history into one place
and filter out all iwlwifi releated error kernel logs

Signed-off-by: Marc Herbert <marc.herbert@intel.com>
Signed-off-by: Pan Xiuli <xiuli.pan@linux.intel.com>