### PR TITLE
volume-basic-test.sh: search PGA name without case sensitive

### DIFF
--- a/test-case/volume-basic-test.sh
+++ b/test-case/volume-basic-test.sh
@@ -56,7 +56,7 @@ sleep 1
 [[ ! $(pidof aplay) ]] && die "$pid process is terminated too early"
 
 sofcard=${SOFCARD:-0}
-pgalist=($(amixer -c$sofcard controls | grep PGA | sed 's/ /_/g;' | awk -Fname= '{print $2}'))
+pgalist=($(amixer -c$sofcard controls | grep -i PGA | sed 's/ /_/g;' | awk -Fname= '{print $2}'))
 dlogi "pgalist number = ${#pgalist[@]}"
 [[ ${#pgalist[@]} -eq 0 ]] && func_error_exit "No PGA control is available"
 


### PR DESCRIPTION
PGA name could be in uppercase or lowercase. Especially topology2 change
makes pga name in lowercase.