### PR TITLE
sof-kernel-log-check: fix a ignore_str for usb errors

### DIFF
--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -197,7 +197,7 @@ ignore_str="$ignore_str"'|usb 2-.: .'
 # CML Helios reported usb errors in kmod test, and caused false failure
 # BugLink: https://github.com/thesofproject/sof-test/issues/567
 ignore_str="$ignore_str"'|usb .-.+: device descriptor read/.+, error'
-ignore_str="$ignore_str"'|usb .-.+.: device not accepting address .+, error'
+ignore_str="$ignore_str"'|usb .-.+: device not accepting address .+, error'
 ignore_str="$ignore_str"'|usb usb.-port.+: unable to enumerate USB device'
 
 # Test cases on some platforms fail because the boot retry message:


### PR DESCRIPTION
WHL UP Extreme has this errors while doing suspend/resume, need to fix
regular expression to ignore this.

[ 6876.560685] usb 1-8: device not accepting address 11, error -71
[ 6877.088731] usb 1-8: device not accepting address 12, error -71

This works with previous error pattern,
[ 1905.017875] kernel: usb 1-2.4: device not accepting address 4, error -71

Signed-off-by: Fred Oh <fred.oh@intel.com>

fixes: https://github.com/thesofproject/sof-test/issues/606