### PR TITLE
lib: pick up card ID only from the line that starts with a number

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -35,7 +35,9 @@ fi
 
 # setup SOFCARD id
 if [ ! "$SOFCARD" ]; then
-    SOFCARD=$(grep -v 'sof-probes' /proc/asound/cards | grep 'sof-[a-z]' | awk '{print $1;}')
+	# $1=$1 strips whitespaces
+	SOFCARD=$(grep -v 'sof-probes' /proc/asound/cards |
+		awk '/sof-[a-z]/ && $1 ~ /^[0-9]+$/ { $1=$1; print $1; exit 0;}')
 fi
 
 func_lib_setup_kernel_checkpoint()


### PR DESCRIPTION
If DMI info is missing and the card long name is replaced with
the card name set in the machine driver, there will be 2 lines
like this:

 0 [sofhdadsp      ]: sof-hda-dsp - sof-hda-dsp
                      sof-hda-dsp

And the test would pick up the card ID from the second line and
result in a failure.

So, ignore lines that dont start with a number to avoid this.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>