### PR TITLE
kmod/sof_remove: show systemctl units when pulseaudio is running

### DIFF
--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -22,13 +22,19 @@ exit_handler()
     # warn about any running pulseaudio because it could make us fail
     # the next time.
     if pgrep -a pulseaudio; then
-        printf 'ERROR: %s fails semi-randomly when pulseaudio is running\n' \
+        >&2 printf 'ERROR: %s fails semi-randomly when pulseaudio is running\n' \
                "$(basename "$0")"
+        systemctl --user list-units --all '*pulse*' || true
     fi
     return "$exit_status"
 }
 
 trap 'exit_handler $?' EXIT
+
+# Breaks systemctl --user and "double sudo" is not great
+test "$(id -u)" -ne 0 ||
+    >&2 printf '\nWARNING: running as root is not supported\n\n'
+
 
 # SOF CI has a dependency on usb audio
 remove_module snd_usb_audio
@@ -192,5 +198,3 @@ remove_module snd_hwdep
 remove_module snd_compress
 remove_module snd_pcm
 
-# without the status check force quit
-builtin exit 0


### PR DESCRIPTION
When pulseaudio is running display not just the warning but this too:
```
skipping snd_compress, not loaded
skipping snd_pcm, not loaded
553 /usr/bin/pulseaudio --daemonize=no --log-target=journal
ERROR: sof_remove.sh fails semi-randomly when pulseaudio is running
  UNIT               LOAD   ACTIVE   SUB     DESCRIPTION
  pulseaudio.service loaded active   running Sound Service
  pulseaudio.socket  masked inactive dead    pulseaudio.socket
```
This points the user towards a root-cause.

Also remove obsolete `builtin exit`

Signed-off-by: Marc Herbert <marc.herbert@intel.com>