### PR TITLE
check-sof-logger: fail on empty logs

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -33,10 +33,6 @@ jobs:
       # :-( https://github.community/t/support-for-yaml-anchors/16128
       - {uses: actions/checkout@v2, with: {fetch-depth: 0}}
       - uses: actions/setup-python@v2
-      - name: temporary python3-pil HACK because github is out of date
-        run: sudo apt-get -y install libimagequant0 libwebpdemux2 &&
-           wget http://security.ubuntu.com/ubuntu/ubuntu/pool/main/p/pillow/python3-pil_7.0.0-4ubuntu0.2_amd64.deb &&
-           sudo dpkg -i python3-pil_*.deb
       - name: get python libs
         # FIXME: apt-get succeeds but 'import numpy' still fails!?
         run: sudo apt-get -y install python3-numpy python3-scipy pylint

--- a/test-case/check-sof-logger.sh
+++ b/test-case/check-sof-logger.sh
@@ -65,7 +65,7 @@ func_logger_exit()
 }
 
 # check if we get any sof-logger errors
-logger_err=`grep -i "error" $error_file`
+logger_err=$(grep -i 'error' "$error_file")
 if [[ $logger_err ]]; then
     dloge "No available log to export due to sof-logger errors."
     func_logger_exit 1 'error'
@@ -73,15 +73,16 @@ fi
 
 # '\.c\:[1-9]' to filter like '.c:6' this type keyword like:
 # [3017136.770833]  (11.302083) c0 SA  src/lib/agent.c:65  ERROR validate(), ll drift detected, delta = 25549
-fw_log_err=`grep -i "error" $data_file | grep -v '\.c\:[1-9]'`
+fw_log_err=$(grep -i 'error' "$data_file" | grep -v '\.c\:[1-9]')
+
 # '[[:blank:]]TIMESTAMP.*CONTENT$' to filter the log header:
 # TIMESTAMP  DELTA C# COMPONENT  LOCATION  CONTENT
-if [[ ! $(sed -n '/[[:blank:]]TIMESTAMP.*CONTENT$/p' $data_file) ]]; then
-    dloge "No available log to export."
+if [[ ! $(sed -n '/[[:blank:]]TIMESTAMP.*CONTENT$/p' "${data_file}") ]]; then
+    dloge "Log header not found in ${data_file}"
     func_logger_exit 1
 # we catch error from fw log
 elif [[ $fw_log_err ]]; then
-    dloge "Errors in firmware log:"
+    dloge "Error(s) found in firmware log ${data_file}"
     func_logger_exit 1
 fi
 

--- a/test-case/check-sof-logger.sh
+++ b/test-case/check-sof-logger.sh
@@ -74,11 +74,15 @@ fi
 # '\.c\:[1-9]' to filter like '.c:6' this type keyword like:
 # [3017136.770833]  (11.302083) c0 SA  src/lib/agent.c:65  ERROR validate(), ll drift detected, delta = 25549
 fw_log_err=$(grep -i 'error' "$data_file" | grep -v '\.c\:[1-9]')
+data_len=$(wc -l < "${data_file}")
 
 # '[[:blank:]]TIMESTAMP.*CONTENT$' to filter the log header:
 # TIMESTAMP  DELTA C# COMPONENT  LOCATION  CONTENT
 if [[ ! $(sed -n '/[[:blank:]]TIMESTAMP.*CONTENT$/p' "${data_file}") ]]; then
     dloge "Log header not found in ${data_file}"
+    func_logger_exit 1
+elif [[ "${data_len}" -lt 2 ]]; then
+    dloge "Nothing but the header in ${data_file}"
     func_logger_exit 1
 # we catch error from fw log
 elif [[ $fw_log_err ]]; then


### PR DESCRIPTION
1st commit:
```
fix some quoting and rephrase some errors
Get the number of shellcheck warnings down a bit.
```
2nd commit:
```
fail when there's only the header
Found by chance while testing Zephyr.
```