### PR TITLE
[skip ci] .github: apt-get -y update

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -33,13 +33,16 @@ jobs:
       # :-( https://github.community/t/support-for-yaml-anchors/16128
       - {uses: actions/checkout@v2, with: {fetch-depth: 0}}
       - uses: actions/setup-python@v2
-      - name: temporary python3-pil HACK because github is out of date
-        run: sudo apt-get -y install libimagequant0 libwebpdemux2 &&
-           wget http://security.ubuntu.com/ubuntu/ubuntu/pool/main/p/pillow/python3-pil_7.0.0-4ubuntu0.2_amd64.deb &&
-           sudo dpkg -i python3-pil_*.deb
+
+      # Package index is "out of date by design"
+      # https://github.com/actions/virtual-environments/issues/1757
+      - name: apt-get -y update
+        run: sudo apt-get -y update
+
       - name: get python libs
         # FIXME: apt-get succeeds but 'import numpy' still fails!?
         run: sudo apt-get -y install python3-numpy python3-scipy pylint
+
       - name: pylint
         env:
           BASE_REF: ${{ github.base_ref }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -46,3 +46,11 @@ jobs:
         # let's re-enable 'C'onventions once we got the other numbers down
         run: ./tools/CI/check-gitrange.bash origin/${BASE_REF}...HEAD
                text/x-python pylint --disable=C
+
+
+  yamllint:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: yamllint ourselves
+        run: yamllint .github/workflows/pull_request.yml


### PR DESCRIPTION
Because Ubuntu VMs on github have a package index that is out of date by
design:

https://github.com/actions/virtual-environments/issues/ 1757

Signed-off-by: Marc Herbert <marc.herbert@intel.com>