### PR TITLE
kmod: sof_remove: reorder dependencies with nocodec

### DIFF
--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -120,6 +120,7 @@ remove_module snd_sof_ipc_test
 remove_module snd_sof_probes
 remove_module snd_sof_intel_client
 remove_module snd_sof_client
+remove_module snd_sof_nocodec || true
 
 remove_module snd_sof
 remove_module snd_sof_nocodec


### PR DESCRIPTION
nocodec is a card, should be removed before sof core.

FIXME: This may break on previous versions, let's see.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>