### PR TITLE
kmod/tools: tabulate log output, stricter lsmod | grep

### DIFF
--- a/tools/kmod/sof_insert.sh
+++ b/tools/kmod/sof_insert.sh
@@ -14,6 +14,9 @@ insert_module() {
     fi
 }
 
+# Test sudo first, not after dozens of SKIP
+sudo true
+
 insert_module snd_soc_da7213
 insert_module snd_soc_da7219
 

--- a/tools/kmod/sof_insert.sh
+++ b/tools/kmod/sof_insert.sh
@@ -7,10 +7,10 @@ insert_module() {
     local MODULE="$1"
 
     if modinfo "$MODULE" &> /dev/null ; then
-        echo "Inserting $MODULE"
+        printf 'MODPROBE\t%s\n' "$MODULE"
         sudo modprobe "$MODULE"
     else
-        echo "skipping $MODULE, not in tree"
+        printf 'SKIP    \t%s \tnot in tree\n' "$MODULE"
     fi
 }
 

--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -6,7 +6,7 @@ remove_module() {
 
     local MODULE="$1"
 
-    if lsmod | grep -w "$MODULE" &> /dev/null ; then
+    if lsmod | grep -q "^${MODULE}[[:blank:]]"; then
         printf 'RMMOD\t%s\n' "$MODULE"
         sudo rmmod "$MODULE"
     else

--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -35,6 +35,8 @@ trap 'exit_handler $?' EXIT
 test "$(id -u)" -ne 0 ||
     >&2 printf '\nWARNING: running as root is not supported\n\n'
 
+# Make sure sudo works first, not after dozens of SKIP
+sudo true
 
 # SOF CI has a dependency on usb audio
 remove_module snd_usb_audio

--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -7,10 +7,10 @@ remove_module() {
     local MODULE="$1"
 
     if lsmod | grep -w "$MODULE" &> /dev/null ; then
-        echo "Removing $MODULE"
+        printf 'RMMOD\t%s\n' "$MODULE"
         sudo rmmod "$MODULE"
     else
-        echo "skipping $MODULE, not loaded"
+        printf 'SKIP\t%s  \tnot loaded\n' "$MODULE"
     fi
 }
 


### PR DESCRIPTION
3 commits, most visible one: kmod/tools: tabulate log output

Sample new output:
```
SKIP	snd_hda_codec_realtek  	not loaded
SKIP	snd_hda_codec_generic  	not loaded
RMMOD	snd_soc_acpi
SKIP	snd_hda_ext_core  	not loaded
RMMOD	snd_intel_dspcfg
SKIP	soundwire_intel_init  	not loaded
SKIP	soundwire_intel  	not loaded
SKIP	soundwire_cadence  	not loaded
SKIP	soundwire_generic_allocation  	not loaded
SKIP	regmap_sdw  	not loaded
SKIP	regmap_sdw_mbq  	not loaded
SKIP	soundwire_bus  	not loaded
RMMOD	snd_soc_core
SKIP	snd_hda_codec  	not loaded
SKIP	snd_hda_core  	not loaded
RMMOD	snd_hwdep
SKIP	snd_compress  	not loaded
RMMOD	snd_pcm

SKIP    	snd_sof_pci_intel_tng 	not in tree
SKIP    	snd_sof_pci_intel_apl 	not in tree
SKIP    	snd_sof_pci_intel_cnl 	not in tree
SKIP    	snd_sof_pci_intel_icl 	not in tree
SKIP    	snd_sof_pci_intel_tgl 	not in tree
MODPROBE	snd_sof_acpi
MODPROBE	snd_sof_pci
MODPROBE	snd_usb_audio
```