### PR TITLE
tools/kmod/remove: more specific regex, remove &> /dev/null

### DIFF
--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -6,7 +6,7 @@ remove_module() {
 
     local MODULE="$1"
 
-    if lsmod | grep -w "$MODULE" &> /dev/null ; then
+    if lsmod | grep -q "^${MODULE}[[:blank:]]"; then
         echo "Removing $MODULE"
         sudo rmmod "$MODULE"
     else


### PR DESCRIPTION
Remove unnecessary &>/dev/null redirection, replace with grep -q.

grep lsmod output with a more specific regex

Signed-off-by: Marc Herbert <marc.herbert@intel.com>