### PR TITLE
sof-dump-status : Add ADL platform info  ;  verify-pcm-list : fix 'set -e' incompatibility   

### DIFF
--- a/test-case/verify-pcm-list.sh
+++ b/test-case/verify-pcm-list.sh
@@ -26,8 +26,8 @@ OPT_HAS_ARG['t']=1         OPT_VAL['t']="${TPLG:-}"
 func_opt_parse_option "$@"
 tplg=${OPT_VAL['t']}
 
-tplg_path=`func_lib_get_tplg_path "$tplg"`
-[[ "$?" != "0" ]] && die "No available topology for this test case"
+tplg_path=$(func_lib_get_tplg_path "$tplg") ||
+       	die "No available topology for this test case"
 
 # hijack DMESG_LOG_START_LINE which refer dump kernel log in exit function
 DMESG_LOG_START_LINE=$(sof-get-kernel-line.sh|tail -n 1 |awk '{print $1;}')
@@ -35,7 +35,7 @@ DMESG_LOG_START_LINE=$(sof-get-kernel-line.sh|tail -n 1 |awk '{print $1;}')
 tplg_str="$(sof-tplgreader.py $tplg_path -d id pcm type -o)"
 pcm_str="$(sof-dump-status.py -i ${SOFCARD:-0})"
 
-dlogc "sof-tplgreader.py $tplg_file -d id pcm type -o"
+dlogc "sof-tplgreader.py $tplg_path -d id pcm type -o"
 dlogi "Pipeline(s) from topology file:"
 echo "$tplg_str"
 dlogc "sof-dump-status.py -i ${SOFCARD:-0}"

--- a/tools/sof-dump-status.py
+++ b/tools/sof-dump-status.py
@@ -10,14 +10,22 @@ class clsSYSCardInfo():
         self.pci_lst=[]
         self.acpi_lst=[]
         self.proc_card={}
-        # https://github.com/thesofproject/linux/blob/topic/sof-dev/sound/soc/sof/sof-pci-dev.c
-        self._pci_ids={"0x119a":"tng","0x5a98":"apl", "0x1a98":"apl", "0x3198":"glk",
-            "0x9dc8":"cnl", "0xa348":"cfl", "0x9d71":"kbl", "0x9d70":"skl", "0x34c8":"icl", "0x38c8":"jsl", "0x4dc8":"jsl",
-            "0x02c8":"cml", "0x06c8":"cml", "0xa0c8":"tgl", "0x43c8":"tgl-h", "0x4b55":"ehl", "0x4b58":"ehl", "0x7ad0": "adl-s",
-            # https://github.com/thesofproject/linux/blob/topic/sof-dev/sound/soc/sof/sof-acpi-dev.c
-            "0x3438":"bdw", "0x33c8":"hsw", "0x0f04":"byt", "0x2284":"cht",
-            # https://github.com/thesofproject/linux/blob/topic/sof-dev/sound/pci/hda/hda_intel.c
-            "0x160c":"bdw" }
+        # https://github.com/thesofproject/linux/tree/topic/sof-dev/sound/soc/sof/intel/
+        self._pci_ids = {
+            # pci-tng.c
+            "0x119a":"tng",
+            # pci-apl.c
+            "0x5a98":"apl", "0x1a98":"apl", "0x3198":"glk",
+            # pci-cnl.c
+            "0x9dc8":"cnl", "0xa348":"cfl", "0x02c8":"cml", "0x06c8":"cml",
+            # pci-icl.c
+            "0x34c8":"icl", "0x38c8":"jsl", "0x4dc8":"jsl",
+            # pci-tgl.c
+            "0xa0c8":"tgl", "0x43c8":"tgl-h", "0x4b55":"ehl", "0x4b58":"ehl", "0x7ad0": "adl-s", "0x51c8":"adl",
+            # Other PCI IDs
+            "0x9d71":"kbl", "0x9d70":"skl", "0x33c8":"hsw", 
+            "0x3438":"bdw", "0x160c":"bdw", "0x0f04":"byt", "0x2284":"cht"
+        }
         # self.sys_card=[]
         # some device use acpi-dev instead of pci-dev
         # https://github.com/thesofproject/linux/blob/topic/sof-dev/sound/soc/sof/sof-acpi-dev.c


### PR DESCRIPTION
Add support for ADL-P in tools/sof-dump-status.py since it is a new platform.

Also fix some 'set -e incompatibilities' in test-cases/verify-pcm-list.sh to avoid silent exit.