### PR TITLE
sof-test: include test interval in kernel check point

### DIFF
--- a/case-lib/config.sh
+++ b/case-lib/config.sh
@@ -56,3 +56,8 @@ SUDO_LEVEL=${SUDO_LEVEL:-}
 # pipelines will be filtered out. Example:
 #
 # NO_HDMI_MODE=true
+
+# Test interval between two test cases, the default value is 5 seconds
+# in CI, which is controlled by sof-framework. In manual run, user can
+# override the default value.
+SOF_TEST_INTERVAL=${SOF_TEST_INTERVAL:-5}

--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -40,10 +40,11 @@ if [ ! "$SOFCARD" ]; then
 		awk '/sof-[a-z]/ && $1 ~ /^[0-9]+$/ { $1=$1; print $1; exit 0;}')
 fi
 
-func_lib_setup_kernel_checkpoint()
+setup_kernel_check_point()
 {
-    # shellcheck disable=SC2034 # external script will use it
-    KERNEL_CHECKPOINT=$(date +%s)
+    # Make the check point $SOF_TEST_INTERVAL second(s) earlier to avoid log loss.
+    # Note this may lead to an error caused by one test appear in the next one.
+    KERNEL_CHECKPOINT=$(($(date +%s) - $SOF_TEST_INTERVAL))
 }
 
 # This function adds a fake error to dmesg (which is always saved by
@@ -342,5 +343,5 @@ is_sof_used()
 journalctl_cmd()
 {
    journalctl -k -q --no-pager --utc --output=short-monotonic \
-     --no-hostname  "$@"
+     --no-hostname "$@"
 }

--- a/test-case/check-capture.sh
+++ b/test-case/check-capture.sh
@@ -59,7 +59,7 @@ file_prefix=${OPT_VAL['f']}
 
 [[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
 
-func_lib_setup_kernel_checkpoint
+setup_kernel_check_point
 func_lib_check_sudo
 func_pipeline_export "$tplg" "type:capture & ${OPT_VAL['S']}"
 

--- a/test-case/check-fw-echo-reference.sh
+++ b/test-case/check-fw-echo-reference.sh
@@ -44,7 +44,7 @@ frequency=${OPT_VAL['f']}
 [[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
 
 func_pipeline_export "$tplg" "echo:any"
-func_lib_setup_kernel_checkpoint
+setup_kernel_check_point
 
 if [ "$PIPELINE_COUNT" != "2" ]; then
     die "Only detect $PIPELINE_COUNT pipeline(s) from topology, but two are needed"

--- a/test-case/check-ipc-flood.sh
+++ b/test-case/check-ipc-flood.sh
@@ -44,7 +44,7 @@ do
     # cleanup dmesg buffer for each iteration
     sudo dmesg -c > /dev/null
     # set up timestamp for each iteration
-    func_lib_setup_kernel_checkpoint
+    setup_kernel_check_point
     dlogi "===== [$i/$loop_cnt] loop Begin ====="
     dlogc "sudo bash -c 'echo $lpc_loop_cnt > $ipc_flood_dfs'"
     sudo bash -c "'echo $lpc_loop_cnt > $ipc_flood_dfs'"

--- a/test-case/check-keyword-detection.sh
+++ b/test-case/check-keyword-detection.sh
@@ -55,7 +55,7 @@ duration=${OPT_VAL['d']}
 [[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
 
 func_pipeline_export "$tplg" "kpbm:any"
-func_lib_setup_kernel_checkpoint
+setup_kernel_check_point
 
 if test "$PIPELINE_COUNT" != "1"; then
     die "detected $PIPELINE_COUNT wov pipeline(s) from topology, but 1 is needed"

--- a/test-case/check-kmod-load-unload.sh
+++ b/test-case/check-kmod-load-unload.sh
@@ -33,7 +33,7 @@ OPT_NAME['p']='pulseaudio'   OPT_DESC['p']='disable pulseaudio on the test proce
 OPT_HAS_ARG['p']=0             OPT_VAL['p']=1
 
 func_opt_parse_option "$@"
-func_lib_setup_kernel_checkpoint
+setup_kernel_check_point
 
 loop_cnt=${OPT_VAL['l']}
 
@@ -48,7 +48,7 @@ for idx in $(seq 1 $loop_cnt)
 do
     dlogi "===== Starting iteration $idx of $loop_cnt ====="
     ## - 1: remove module section
-    func_lib_setup_kernel_checkpoint
+    setup_kernel_check_point
 
     # After module removal, it takes about 10s for "aplay -l" to show
     # device list, within this 10s, it shows "no soundcard found". Here
@@ -78,7 +78,7 @@ do
     sof-kernel-log-check.sh "$KERNEL_CHECKPOINT" ||
         die "error found after kmod unload is real error, failing"
 
-    func_lib_setup_kernel_checkpoint
+    setup_kernel_check_point
     dlogi "run kmod/sof_insert.sh"
     sudo sof_insert.sh || {
         # FIXME: don't exit the status of dloge(). Use die()

--- a/test-case/check-pause-release-suspend-resume.sh
+++ b/test-case/check-pause-release-suspend-resume.sh
@@ -110,7 +110,7 @@ esac
 
 [[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
 
-func_lib_setup_kernel_checkpoint
+setup_kernel_check_point
 
 dlogi "Entering audio stream expect script with: $cmd -D $pcm -r $rate -c $channel -f $fmt -vv -i $dummy_file -q"
 dlogi "Will enter suspend-resume cycle during paused period of audio stream process"

--- a/test-case/check-pause-resume.sh
+++ b/test-case/check-pause-resume.sh
@@ -81,7 +81,7 @@ func_pipeline_export "$tplg" "type:$test_mode & ${OPT_VAL['S']}"
 for idx in $(seq 0 $((PIPELINE_COUNT - 1)))
 do
     # set up checkpoint for each iteration
-    func_lib_setup_kernel_checkpoint
+    setup_kernel_check_point
     channel=$(func_pipeline_parse_value "$idx" channel)
     rate=$(func_pipeline_parse_value "$idx" rate)
     fmt=$(func_pipeline_parse_value "$idx" fmt)

--- a/test-case/check-playback.sh
+++ b/test-case/check-playback.sh
@@ -67,7 +67,7 @@ else
     dlogi "using $file as playback source"
 fi
 
-func_lib_setup_kernel_checkpoint
+setup_kernel_check_point
 func_lib_check_sudo
 func_pipeline_export "$tplg" "type:playback & ${OPT_VAL['S']}"
 

--- a/test-case/check-runtime-pm-double-active.sh
+++ b/test-case/check-runtime-pm-double-active.sh
@@ -89,7 +89,7 @@ do
     for i in $(seq 1 $loop_count)
     do
         # set up checkpoint for each iteration
-        func_lib_setup_kernel_checkpoint
+        setup_kernel_check_point
         dlogi "===== Iteration $i of $loop_count for $pcm ====="
         # playback or capture device - check status
         dlogc "$cmd -D $dev -r $rate -c $channel -f $fmt $dummy_file -q"

--- a/test-case/check-runtime-pm-status.sh
+++ b/test-case/check-runtime-pm-status.sh
@@ -83,7 +83,7 @@ do
     for i in $(seq 1 $loop_count)
     do
         # set up checkpoint for each iteration
-        func_lib_setup_kernel_checkpoint
+        setup_kernel_check_point
         dlogi "===== Iteration $i of $loop_count for $pcm ====="
         # playback or capture device - check status
         dlogc "$cmd -D $dev -r $rate -c $channel -f $fmt $dummy_file -q"

--- a/test-case/check-signal-stop-start.sh
+++ b/test-case/check-signal-stop-start.sh
@@ -56,7 +56,7 @@ case $test_mode in
     ;;
 esac
 
-func_lib_setup_kernel_checkpoint
+setup_kernel_check_point
 
 func_stop_start_pipeline()
 {

--- a/test-case/check-smart-amplifier.sh
+++ b/test-case/check-smart-amplifier.sh
@@ -59,7 +59,7 @@ tplg=${OPT_VAL['t']}
 [[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
 
 func_pipeline_export "$tplg" "smart_amp:any"
-func_lib_setup_kernel_checkpoint
+setup_kernel_check_point
 
 [ "$PIPELINE_COUNT" == "2" ] || die "Only detect $PIPELINE_COUNT pipeline(s) from topology, but two are needed"
 

--- a/test-case/check-suspend-resume-with-audio.sh
+++ b/test-case/check-suspend-resume-with-audio.sh
@@ -91,7 +91,7 @@ fi
 for idx in $(seq 0 $(expr $PIPELINE_COUNT - 1))
 do
     # set up checkpoint for each iteration
-    func_lib_setup_kernel_checkpoint
+    setup_kernel_check_point
     # store local checkpoint as we have sub-test
     LOCAL_CHECK_POINT="$KERNEL_CHECKPOINT"
     channel=$(func_pipeline_parse_value $idx channel)

--- a/test-case/check-suspend-resume.sh
+++ b/test-case/check-suspend-resume.sh
@@ -74,7 +74,7 @@ for i in $(seq 1 $loop_count)
 do
     dlogi "===== Round($i/$loop_count) ====="
     # set up checkpoint for each iteration
-    func_lib_setup_kernel_checkpoint
+    setup_kernel_check_point
     sleep_count=$(cat /sys/power/wakeup_count)
     dlogc "Run the command: rtcwake -m mem -s ${sleep_lst[$i]}"
     sudo rtcwake -m mem -s ${sleep_lst[$i]}

--- a/test-case/check-xrun-injection.sh
+++ b/test-case/check-xrun-injection.sh
@@ -43,7 +43,7 @@ interval=${OPT_VAL['i']}
 
 [[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
 
-func_lib_setup_kernel_checkpoint
+setup_kernel_check_point
 func_lib_check_sudo
 
 case $test_mode in

--- a/test-case/multiple-pause-resume.sh
+++ b/test-case/multiple-pause-resume.sh
@@ -145,7 +145,7 @@ for i in $(seq 1 $loop_count)
 do
     dlogi "===== Loop count( $i / $loop_count ) ====="
     # set up checkpoint for each iteration
-    func_lib_setup_kernel_checkpoint
+    setup_kernel_check_point
     for pipeline_combine_str in "${pipeline_combine_lst[@]}"
     do
         unset pid_lst

--- a/test-case/multiple-pipeline.sh
+++ b/test-case/multiple-pipeline.sh
@@ -144,7 +144,7 @@ ps_checks()
 for i in $(seq 1 $loop_cnt)
 do
     # set up checkpoint for each iteration
-    func_lib_setup_kernel_checkpoint
+    setup_kernel_check_point
     dlogi "===== Testing: (Loop: $i/$loop_cnt) ====="
 
     # start playback or capture:

--- a/test-case/simultaneous-playback-capture.sh
+++ b/test-case/simultaneous-playback-capture.sh
@@ -69,7 +69,7 @@ func_error_exit()
 for i in $(seq 1 $loop_cnt)
 do
     # set up checkpoint for each iteration
-    func_lib_setup_kernel_checkpoint
+    setup_kernel_check_point
     dlogi "===== Testing: (Loop: $i/$loop_cnt) ====="
     # following sof-tplgreader, split 'both' pipelines into separate playback & capture pipelines, with playback occurring first
     for order in $(seq 0 2 $(expr $PIPELINE_COUNT - 1))

--- a/test-case/test-speaker.sh
+++ b/test-case/test-speaker.sh
@@ -32,7 +32,7 @@ tplg=${OPT_VAL['t']}
 
 func_pipeline_export "$tplg" "type:playback"
 tcnt=${OPT_VAL['l']}
-func_lib_setup_kernel_checkpoint
+setup_kernel_check_point
 for idx in $(seq 0 $(expr $PIPELINE_COUNT - 1))
 do
     channel=$(func_pipeline_parse_value $idx channel)

--- a/test-case/volume-basic-test.sh
+++ b/test-case/volume-basic-test.sh
@@ -62,7 +62,7 @@ dlogi "pgalist number = ${#pgalist[@]}"
 
 for i in $(seq 1 $maxloop)
 do
-    func_lib_setup_kernel_checkpoint
+    setup_kernel_check_point
     dlogi "===== Round($i/$maxloop) ====="
     # TODO: need to check command effect
     for i in "${pgalist[@]}"


### PR DESCRIPTION
The sof-framework will add a 5-second test interval
between two test cases. This patch makes the kernel
check point include this test interval to avoid log loss.

And also rename func_lib_setup_kernel_check_point
to setup_kernel_check_point, because the prefix
doesn't provide much information.

Signed-off-by: Chao Song <chao.song@linux.intel.com>

As PR #639 makes very big change, I am going to split it to several relatively small PRs, this is the first one.