### PR TITLE
case-lib: add support for no HDMI mode

### DIFF
--- a/case-lib/config.sh
+++ b/case-lib/config.sh
@@ -49,3 +49,10 @@ SOFCARD=${SOFCARD:-}
 # 2: run cmd with sudo, but needs sudo password
 # example: echo $SUDO_PASSWD | sudo -S ls /sys/kernel/debug/
 SUDO_LEVEL=${SUDO_LEVEL:-}
+
+# The i915 driver sometimes is not ready on a new platform, sof-test
+# will fail because broken HDMI pipelines are present.
+# The NO_HDMI_MODE option controls the pipeline filter, if true, HDMI
+# pipelines will be filtered out. Example:
+#
+# NO_HDMI_MODE=true

--- a/case-lib/pipeline.sh
+++ b/case-lib/pipeline.sh
@@ -45,9 +45,11 @@ func_pipeline_export()
         done
     fi
 
-    local opt=""
-    # acquire filter option
-    [[ "$2" ]] && opt="-f '$2'"
+    local opt="$2"
+    # In no HDMI mode, exclude HDMI pipelines
+    [ -z "$NO_HDMI_MODE" ] || opt="$opt & ~pcm:HDMI"
+    opt="-f '${opt}'"
+
     [[ "$ignore" ]] && opt="$opt -b '$ignore'"
     [[ "$SOFCARD" ]] && opt="$opt -s $SOFCARD"
 


### PR DESCRIPTION
The i915 driver sometimes is not ready on a new platform,
sof-test will fail because broken HDMI pipelines are
present.

This patch adds support for no HDMI mode, once we are
under no HDMI mode, HDMI pipelines will be filtered
out, thus sof-test can run normally.

Signed-off-by: Chao Song <chao.song@linux.intel.com>

This patch has to be used with the change here: https://github.com/thesofproject/sof-test/pull/642