### PR TITLE
Add support for topologies and .ldc files in /lib/firmware/updates …

### DIFF
--- a/case-lib/config.sh
+++ b/case-lib/config.sh
@@ -7,7 +7,13 @@
 SUDO_PASSWD=${SUDO_PASSWD:-}
 
 # global define
-TPLG_ROOT=${TPLG_ROOT:-/lib/firmware/intel/sof-tplg}
+if [ -z "$TPLG_ROOT" ]; then
+    if test -e /lib/firmware/updates/intel/sof-tplg; then
+        TPLG_ROOT=/lib/firmware/updates/intel/sof-tplg
+    else
+        TPLG_ROOT=/lib/firmware/intel/sof-tplg
+    fi
+fi
 
 # ignore the target keyword for tplg
 # example: ignore 'pipeline ids equal to 2'

--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -260,10 +260,10 @@ func_lib_get_tplg_path()
     local tplg=$1
     if [[ -z "$tplg" ]]; then   # tplg given is empty
         return 1
-    elif [[ -f "$TPLG_ROOT/$(basename "$tplg")" ]]; then
-        echo "$TPLG_ROOT/$(basename "$tplg")"
     elif [[ -f "$tplg" ]]; then
         realpath "$tplg"
+    elif [[ -f "$TPLG_ROOT/$tplg" ]]; then
+        echo "$TPLG_ROOT/$tplg"
     else
         return 1
     fi

--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -92,8 +92,14 @@ find_ldc_file()
             return 1
         }
         ldcFile=/etc/sof/sof-"$platf".ldc
-        [ -e "$ldcFile" ] ||
-            ldcFile=/lib/firmware/intel/sof/sof-"$platf".ldc
+        [ -e "$ldcFile" ] || {
+            # Fall back on standard /lib/firmware location
+            if test -e /lib/firmware/updates/intel/sof; then
+                ldcFile=/lib/firmware/updates/intel/sof/sof-"$platf".ldc
+            else
+                ldcFile=/lib/firmware/intel/sof/sof-"$platf".ldc
+            fi
+        }
     fi
 
     [[ -e "$ldcFile" ]] || {

--- a/case-lib/pipeline.sh
+++ b/case-lib/pipeline.sh
@@ -35,6 +35,11 @@ func_pipeline_export()
     }
     dlogi "$SCRIPT_NAME will use topology $tplg_path to run the test case"
 
+    if test -d /lib/firmware/updates &&
+            [[ $tplg_path = /lib/firmware/intel/* ]]; then
+        dlogw "/lib/firmware/updates/ exists but topology is in /lib/firmware/intel/"
+    fi
+
     # create block option string
     local ignore=""
     if [ ${#TPLG_IGNORE_LST[@]} -ne 0 ]; then

--- a/tools/sof-dump-status.py
+++ b/tools/sof-dump-status.py
@@ -554,7 +554,11 @@ if __name__ == "__main__":
                 }
             }
         ]
-        fw_path = "/lib/firmware/intel/sof"
+        SOF_UPDATES = "/lib/firmware/updates/intel/sof"
+        fw_path = (
+            SOF_UPDATES if os.path.exists(SOF_UPDATES)
+            else "/lib/firmware/intel/sof"
+        )
         sysinfo.loadDMI()
         board = {
                     "ident": sysinfo.dmi["board_name"],


### PR DESCRIPTION
2 commits. 1 bug fix, 1 main feature

Required by SOF install commit 65ade5a4f973 ("installer: change default
destination to /lib/firmware/updates"), see
thesofproject/sof#4020

Signed-off-by: Marc Herbert <marc.herbert@intel.com>