### PR TITLE
check-suspend-resume: sleep 1s before rtcwake iteration

### DIFF
--- a/test-case/check-suspend-resume.sh
+++ b/test-case/check-suspend-resume.sh
@@ -70,6 +70,11 @@ else
     done
 fi
 
+# This is used to workaround https://github.com/thesofproject/sof-test/issues/650,
+# which may be caused by kernel issue or unstable network connection.
+# TODO: remove this after issue fixed.
+sleep 1
+
 for i in $(seq 1 $loop_count)
 do
     dlogi "===== Round($i/$loop_count) ====="


### PR DESCRIPTION
After some kernel update, we start to observe a timeout
issue on several JF devices. As we are not going to fix
the kernel, this workaround is applied.

Accroding to the solution in this patch, the device may
get into sleep before netcat can send out messages, this
maybe related to network issue in the kernel, or network
route is too long between JF and SH, etc. In this patch,
we add a 1-second sleep to wait a stable connection before
running rtcwake.

Workaround: #650

Signed-off-by: Chao Song <chao.song@linux.intel.com>