### PR TITLE
check-kwd: set up kernel check point earlier

### DIFF
--- a/test-case/check-keyword-detection.sh
+++ b/test-case/check-keyword-detection.sh
@@ -44,6 +44,7 @@ OPT_NAME['d']='duration'          OPT_DESC['d']='interrupt kwd pipeline in # sec
 OPT_HAS_ARG['d']=1                  OPT_VAL['d']=10
 
 func_opt_parse_option "$@"
+setup_kernel_check_point
 
 tplg=${OPT_VAL['t']}
 loop_cnt=${OPT_VAL['l']}
@@ -55,7 +56,6 @@ duration=${OPT_VAL['d']}
 [[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
 
 func_pipeline_export "$tplg" "kpbm:any"
-setup_kernel_check_point
 
 if test "$PIPELINE_COUNT" != "1"; then
     die "detected $PIPELINE_COUNT wov pipeline(s) from topology, but 1 is needed"


### PR DESCRIPTION
Previously, the call of func_pipeline_export is
earlier than setup_kernel_check_point, if we have
failure in export pipeline, the kernel check point
will not be properly set up. So bring kernel check
point set up earlier.

Signed-off-by: Chao Song <chao.song@linux.intel.com>