### PR TITLE
check-pm: set the kernel check point before runtime PM support check

### DIFF
--- a/test-case/check-runtime-pm-status.sh
+++ b/test-case/check-runtime-pm-status.sh
@@ -50,6 +50,8 @@ func_check_dsp_status()
 }
 
 func_opt_parse_option "$@"
+setup_kernel_check_point
+
 tplg=${OPT_VAL['t']}
 loop_count=${OPT_VAL['l']}
 [[ -z $tplg ]] && die "Miss tplg file to run"


### PR DESCRIPTION
runtime PM is not supported on BDW and BYT platforms, so we need
to set the kernel check point before the runtime PM support check
or the kernel check point will not be properly set up and cause
runtime PM check TIMEOUT on unsupported platforms.

Signed-off-by: Zhang Keqiao <keqiao.zhang@intel.com>