### PR TITLE
fake_kern_error(): downgrade priority from level 0 to level 3 (error)

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -68,7 +68,7 @@ fake_kern_error()
     boot_secs=$(awk '{ print $1 }' < /proc/uptime)
     kern_log_prefix="$d $(hostname) kernel: [$boot_secs]"
 
-    printf '<0>%s >/dev/kmsg\n' "$k_msg"  | sudo tee -a /dev/kmsg >/dev/null
+    printf '<3>%s >/dev/kmsg\n' "$k_msg"  | sudo tee -a /dev/kmsg >/dev/null
 
     # From https://www.kernel.org/doc/Documentation/ABI/testing/dev-kmsg
     # It is not possible to inject to /dev/kmesg with the facility


### PR DESCRIPTION
No need to spam all the terminals.

From "man journalctl" and syslog before that:
```
  "emerg" (0), "alert" (1), "crit" (2), "err" (3), "warning" (4),
  "notice" (5), "info" (6), "debug" (7)
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>