### PR TITLE
lib.sh: don't use $ in KERNEL_CHECKPOINT arithmetic

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -44,7 +44,7 @@ setup_kernel_check_point()
 {
     # Make the check point $SOF_TEST_INTERVAL second(s) earlier to avoid log loss.
     # Note this may lead to an error caused by one test appear in the next one.
-    KERNEL_CHECKPOINT=$(($(date +%s) - $SOF_TEST_INTERVAL))
+    KERNEL_CHECKPOINT=$(($(date +%s) - SOF_TEST_INTERVAL))
 }
 
 # This function adds a fake error to dmesg (which is always saved by


### PR DESCRIPTION
Fixes:
```
In case-lib/lib.sh line 69:
  KERNEL_CHECKPOINT=$(($(date +%s)
    - $SOF_TEST_INTERVAL))
      ^----------------^ SC2004: $/${} is unnecessary on arithmetic variables.
```
This new warning was introduced in commit b4716c9fab29 where it was
drowned in other warnings in other files.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>