### PR TITLE
[SKIP CI] .github: unhardcode from "master" branch that does not exist anymore

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,9 +10,7 @@
 name: Pull Requests
 
 # yamllint disable-line rule:truthy
-on:
-  pull_request:
-    branches: [master]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
 


### PR DESCRIPTION
Funny how no one missed shellcheck and pylint...

Signed-off-by: Marc Herbert <marc.herbert@intel.com>