### PR TITLE
[SKIP CI] .github: don't run git range checks on mere pushes

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,10 +7,14 @@
 # yaml merge-expand pull_request.yml exp.yml &&
 #    diff -b -u pull_request.yml exp.yml
 
+
+# TODO: see if https://github.com/trilom/file-changes-action/ or similar
+# can replace check-gitrange.bash
+
 name: Pull Requests
 
 # yamllint disable-line rule:truthy
-on: [push, pull_request, workflow_dispatch]
+on: [pull_request, workflow_dispatch]
 
 jobs:
 
@@ -47,11 +51,3 @@ jobs:
         # let's re-enable 'C'onventions once we got the other numbers down
         run: ./tools/CI/check-gitrange.bash origin/${BASE_REF}...HEAD
                text/x-python pylint --disable=C
-
-
-  yamllint:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - name: yamllint ourselves
-        run: yamllint .github/workflows/pull_request.yml

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -1,0 +1,15 @@
+---
+
+name: yamllint
+
+# yamllint disable-line rule:truthy
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+
+  yamllint:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: yamllint github actions
+        run: yamllint .github/workflows/*.yml


### PR DESCRIPTION
... because there's no ${BASE_REF} and no range to check.

Stops spurious failures like:

 https://github.com/marc-hb/sof-test/runs/2414768508

Signed-off-by: Marc Herbert <marc.herbert@intel.com>