### PR TITLE
func_exit_handler: don't die when KERNEL_CHECKPOINT is missing

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -54,7 +54,9 @@ function func_exit_handler()
     if [[ "$KERNEL_CHECKPOINT" =~ ^[0-9]{10} ]]; then
         journalctl_cmd --since=@"$KERNEL_CHECKPOINT" > "$LOG_ROOT/dmesg.txt"
     else
-        die 'Kernel check point "KERNEL_CHECKPOINT" is not properly set'
+       dloge 'Kernel check point "KERNEL_CHECKPOINT" is not properly set'
+       dloge "KERNEL_CHECKPOINT=$KERNEL_CHECKPOINT"
+       test "$exit_status" -ne 0 || exit_status=1
     fi
     # After log collected, KERNEL_CHECKPOINT will not be used any more
     unset KERNEL_CHECKPOINT


### PR DESCRIPTION
One should never die in the "die handler", this means the final status
is not printed and causes a Jenkins timeout.

Fixes commit 18c7e6155053 ("sof-test: use journalctl for log
collection")