### PR TITLE
hijack.sh: fail if the logger trace is empty

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -48,6 +48,12 @@ function func_exit_handler()
         # shellcheck disable=SC2154
         wcLog=$(wc -l "$logfile")
         dlogi "nlines=$wcLog"
+        local nlines; nlines=$(wc -l < "$logfile")
+        # Line 1 is the header
+        if [ "$nlines" -le 1 ]; then
+            dloge "Empty logger trace"
+            exit_status=1
+        fi
     fi
     # when case ends, store kernel log
     # /var/log/kern.log format:


### PR DESCRIPTION
_Resubmit #383 to new `main` branch_

Does not completely fixes #297 but goes a long way.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>