### PR TITLE
check-sof-logger: change BEG>> to BEG:: to avoid HTML conflict

### DIFF
--- a/test-case/check-sof-logger.sh
+++ b/test-case/check-sof-logger.sh
@@ -76,7 +76,7 @@ fw_log_err=$(grep -i 'error' "$data_file" | grep -v '\.c\:[1-9]')
 
 # '[[:blank:]]TIMESTAMP.*CONTENT$' to filter the log header:
 # TIMESTAMP  DELTA C# COMPONENT  LOCATION  CONTENT
-if [[ ! $(sed -n '/[[:blank:]]TIMESTAMP.*CONTENT$/p' "${data_file}") ]]; then
+if [[ ! $(sed -n '/TIMESTAMP.*CONTENT/p' "${data_file}") ]]; then
     dloge "Log header not found in ${data_file}"
     func_logger_exit 1
 # we catch error from fw log

--- a/test-case/check-sof-logger.sh
+++ b/test-case/check-sof-logger.sh
@@ -56,10 +56,14 @@ sudo pkill -9 "$(basename "$loggerBin")" 2> /dev/null
 
 func_logger_exit()
 {
-    local code=$1 type=${2:-data}
-    dlogi "Log $type BEG>>"
-    cat "$LOG_ROOT/logger.$type.log"
-    dlogi "<<END $type data"
+    local code=$1
+
+    for ftype in data error; do
+        printf '\n'
+        dlogi "Log $ftype BEG::"
+        cat "$LOG_ROOT/logger.$ftype.log"
+        dlogi "::END $ftype"
+    done
     exit "$code"
 }
 
@@ -67,7 +71,7 @@ func_logger_exit()
 logger_err=$(grep -i 'error' "$error_file")
 if [[ $logger_err ]]; then
     dloge "No available log to export due to sof-logger errors."
-    func_logger_exit 1 'error'
+    func_logger_exit 1
 fi
 
 # '\.c\:[1-9]' to filter like '.c:6' this type keyword like:


### PR DESCRIPTION
Also change <<END to ::END and print both files always.

<< and >> seem to corrupt the generated HTML and I could not find
anything parsing these anyway as of now.

See discussion in (much larger) PR #666 for more details.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>