### PR TITLE
Revert "multiple-pipeline: remove initial sleep and clarify second sleep

### DIFF
--- a/test-case/multiple-pipeline.sh
+++ b/test-case/multiple-pipeline.sh
@@ -47,7 +47,7 @@ OPT_NAME['f']='first'
 OPT_DESC['f']='Fill either playback (p) or capture (c) first or any (a) for all pipelines'
 OPT_HAS_ARG['f']=1         OPT_VAL['f']='p'
 
-OPT_NAME['w']='wait'     OPT_DESC['w']='duration of one (sub)test iteration'
+OPT_NAME['w']='wait'     OPT_DESC['w']='perpare wait time by sleep'
 OPT_HAS_ARG['w']=1         OPT_VAL['w']=5
 
 OPT_NAME['r']='random'   OPT_DESC['r']='random load pipeline'
@@ -163,10 +163,13 @@ do
             die "Wrong -f argument $f_arg, see -h"
     esac
 
+    dlogi "sleep ${OPT_VAL['w']}s for sound device wakeup"
+    sleep ${OPT_VAL['w']}
+
     dlogi "checking pipeline status"
     ps_checks
 
-    dlogi "Letting playback/capture run for ${OPT_VAL['w']}s"
+    dlogi "preparing sleep ${OPT_VAL['w']}"
     sleep ${OPT_VAL['w']}
 
     # check processes again


### PR DESCRIPTION
This reverts commit f93a3c807b2fedbbcdbc876984137e8fca7b2cdb.

This broke multiple-pipeline-playback-50 on sh-tglu-sku0a3e-sdw-01 and
jf-cml-sku0983-sdw-2, see below. Almost all other platforms ran
fine.

Found by Keqiao in daily test run 3577 (thx)

It's not clear what exactly the issue/race is yet (let's discuss in
original PR #543 or in a new bug linked from there) but the top
priority is to fix the tests.

```
2021-04-27 22:35:17 UTC [REMOTE_COMMAND] aplay   -D hw:0,0 -c 2 -r 48000 -f S16_LE /dev/zero -q
2021-04-27 22:35:17 UTC [REMOTE_INFO] Testing: Speaker [hw:0,2]
2021-04-27 22:35:17 UTC [REMOTE_COMMAND] aplay   -D hw:0,2 -c 2 -r 48000 -f S16_LE /dev/zero -q
2021-04-27 22:35:17 UTC [REMOTE_INFO] Testing: HDMI 1 [hw:0,5]
2021-04-27 22:35:17 UTC [REMOTE_COMMAND] aplay   -D hw:0,5 -c 2 -r 48000 -f S16_LE /dev/zero -q
2021-04-27 22:35:17 UTC [REMOTE_INFO] Testing: HDMI 2 [hw:0,6]
2021-04-27 22:35:17 UTC [REMOTE_INFO] checking pipeline status
2021-04-27 22:35:17 UTC [REMOTE_COMMAND] aplay   -D hw:0,6 -c 2 -r 48000 -f S16_LE /dev/zero -q
2021-04-27 22:35:17 UTC [REMOTE_INFO] Letting playback/capture run for 5s
2021-04-27 22:35:22 UTC [REMOTE_INFO] checking pipeline status again
2021-04-27 22:35:22 UTC [REMOTE_COMMAND] pkill -9 aplay arecord
/home/ubuntu/sof-test/test-case/../case-lib/lib.sh: line 312: 59208 Killed                  aplay $SOF_ALSA_OPTS $SOF_APLAY_OPTS "$@"
/home/ubuntu/sof-test/test-case/../case-lib/lib.sh: line 312: 59216 Killed                  aplay $SOF_ALSA_OPTS $SOF_APLAY_OPTS "$@"
/home/ubuntu/sof-test/test-case/../case-lib/lib.sh: line 312: 59190 Killed                  aplay $SOF_ALSA_OPTS $SOF_APLAY_OPTS "$@"
declare -- cmd="journalctl_cmd --since=@1619562912"

2021-04-27 22:35:22 UTC [REMOTE_INFO] ===== Testing: (Loop: 2/50) =====

2021-04-27 22:35:22 UTC [REMOTE_INFO] /home/ubuntu/sof-test/test-case/multiple-pipeline.sh will use topology /lib/firmware/intel/sof-tplg/sof-tgl-rt715-rt711-rt1308-mono.tplg to run the test case
2021-04-27 22:35:22 UTC [REMOTE_INFO] Pipeline list to ignore is specified, will ignore 'pcm=HDA Digital' in test case
2021-04-27 22:35:22 UTC [REMOTE_INFO] Run command to get pipeline parameters
2021-04-27 22:35:22 UTC [REMOTE_COMMAND] sof-tplgreader.py /lib/firmware/intel/sof-tplg/sof-tgl-rt715-rt711-rt1308-mono.tplg -f 'type:playback' -b ' pcm:HDA Digital' -s 0 -e
2021-04-27 22:35:22 UTC [REMOTE_INFO] Testing: Jack Out [hw:0,0]
2021-04-27 22:35:22 UTC [REMOTE_COMMAND] aplay   -D hw:0,0 -c 2 -r 48000 -f S16_LE /dev/zero -q
2021-04-27 22:35:22 UTC [REMOTE_INFO] Testing: Speaker [hw:0,2]
2021-04-27 22:35:22 UTC [REMOTE_COMMAND] aplay   -D hw:0,2 -c 2 -r 48000 -f S16_LE /dev/zero -q
2021-04-27 22:35:22 UTC [REMOTE_INFO] Testing: HDMI 1 [hw:0,5]
2021-04-27 22:35:22 UTC [REMOTE_COMMAND] aplay   -D hw:0,5 -c 2 -r 48000 -f S16_LE /dev/zero -q
2021-04-27 22:35:22 UTC [REMOTE_INFO] Testing: HDMI 2 [hw:0,6]
2021-04-27 22:35:22 UTC [REMOTE_COMMAND] aplay   -D hw:0,6 -c 2 -r 48000 -f S16_LE /dev/zero -q
2021-04-27 22:35:22 UTC [REMOTE_INFO] checking pipeline status
2021-04-27 22:35:22 UTC [REMOTE_ERROR] Running process count is 5, but 4 is expected
```