### PR TITLE
kmod: sof_remove.sh: add snd_sof_intel_atom

### DIFF
--- a/tools/kmod/sof_insert.sh
+++ b/tools/kmod/sof_insert.sh
@@ -17,9 +17,10 @@ insert_module() {
 # Test sudo first, not after dozens of SKIP
 sudo true
 
+# Insert codec drivers first, they are required to register ASoC components
+
 insert_module snd_soc_da7213
 insert_module snd_soc_da7219
-
 insert_module snd_soc_rt274
 insert_module snd_soc_rt286
 insert_module snd_soc_rt298
@@ -48,6 +49,9 @@ insert_module snd_soc_rt1308_sdw
 insert_module snd_soc_rt715
 insert_module snd_soc_rt1011
 
+# insert top-level ACPI/PCI SOF drivers. They will register SOF components and
+# load machine drivers as needed. Do not insert any other sort of audio module,
+# code dependencies will be used to load the relevant modules.
 insert_module snd_sof_acpi_intel_byt
 insert_module snd_sof_acpi_intel_bdw
 
@@ -60,6 +64,7 @@ insert_module snd_sof_pci_intel_tgl
 insert_module snd_sof_acpi
 insert_module snd_sof_pci
 
+# USB
 insert_module snd_usb_audio
 
 # without the status check force quit

--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -65,6 +65,7 @@ remove_module snd_sof_intel_hda_common || true
 #-------------------------------------------
 remove_module snd_sof_acpi
 remove_module snd_sof_pci
+remove_module snd_sof_intel_atom
 
 #-------------------------------------------
 # legacy drivers (not used but loaded)


### PR DESCRIPTION
All CI tests fail because of the introduction of a new module:
https://sof-ci.01.org/linuxpr/PR2874/build5690/devicetest/

Add it to sof_remove.sh

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>