### PR TITLE
multiple-pipeline: simplify sleeps

### DIFF
--- a/test-case/multiple-pipeline.sh
+++ b/test-case/multiple-pipeline.sh
@@ -47,7 +47,7 @@ OPT_NAME['f']='first'
 OPT_DESC['f']='Fill either playback (p) or capture (c) first or any (a) for all pipelines'
 OPT_HAS_ARG['f']=1         OPT_VAL['f']='p'
 
-OPT_NAME['w']='wait'     OPT_DESC['w']='perpare wait time by sleep'
+OPT_NAME['w']='wait'     OPT_DESC['w']='duration of one (sub)test iteration'
 OPT_HAS_ARG['w']=1         OPT_VAL['w']=5
 
 OPT_NAME['r']='random'   OPT_DESC['r']='random load pipeline'
@@ -163,13 +163,10 @@ do
             die "Wrong -f argument $f_arg, see -h"
     esac
 
-    dlogi "sleep ${OPT_VAL['w']}s for sound device wakeup"
-    sleep ${OPT_VAL['w']}
-
     dlogi "checking pipeline status"
     ps_checks
 
-    dlogi "preparing sleep ${OPT_VAL['w']}"
+    dlogi "Letting playback/capture run for ${OPT_VAL['w']}s"
     sleep ${OPT_VAL['w']}
 
     # check processes again
@@ -179,6 +176,7 @@ do
     dlogc 'pkill -9 aplay arecord'
     pkill -9 arecord || true
     pkill -9 aplay   || true
+    sleep 1 # try not to pollute the next iteration
 
     # check kernel log for each iteration to catch issues
     sof-kernel-log-check.sh "$KERNEL_CHECKPOINT" || die "Caught error in kernel log"


### PR DESCRIPTION
Having the same -w parameter for two different sleeps in the same
iteration made no sense.

It was not clear what the purpose of this first sleep was, it has been in
multiple-pipeline-capture/playback.sh since the dawn of time (= commit
39cd964) For sure this first sleep was helping hide
"uninterruptible state" bug #472 by giving the DSP more time to wake up!

More recently it was found after merging and reverting an earlier
version of this (PR #543 / commit f93a3c8) that this first sleep
was (accidentally?) giving more time for processes to actually
disappeared after being killed at the end of a test round and not
pollute the next test iteration. Make that clearer by moving the first
sleep to the end of the iteration, right after the kills and hardcode to
one second.
