### PR TITLE
multiple-pipeline: add delay before ps_checks

### DIFF
--- a/test-case/multiple-pipeline.sh
+++ b/test-case/multiple-pipeline.sh
@@ -163,6 +163,10 @@ do
             die "Wrong -f argument $f_arg, see -h"
     esac
 
+    # FIXME: Last aplay or arecord process might delay to start.
+    #        Without this sleep, ps_checks returns failure in some cases
+    sleep 0.5
+
     dlogi "checking pipeline status"
     ps_checks
 


### PR DESCRIPTION
Sometimes last aplay or arecord process might delay to start. This causes
the test case to fail due to number of PIDs mistmatch. This is not 100%
reproducible but slower platform has more chance to fail.

Signed-off-by: Fred Oh <fred.oh@linux.intel.com>

fixes: https://github.com/thesofproject/sof-test/issues/672