### PR TITLE
multiple-pipeline: wait 0.5s for aplay_opts()

### DIFF
--- a/test-case/multiple-pipeline.sh
+++ b/test-case/multiple-pipeline.sh
@@ -163,6 +163,10 @@ do
             die "Wrong -f argument $f_arg, see -h"
     esac
 
+    # Give the aplay_opts and arecord_opts subshells some time to start
+    # their aplay processes.
+    dlogi "wait 0.5s for aplay_opts()"
+    sleep 0.5
     dlogi "checking pipeline status"
     ps_checks
 


### PR DESCRIPTION
Give the aplay_opts and arecord_opts subshells some time to start
their aplay processes.

Fixes a726dc19d648 ("multiple-pipeline: simplify sleeps")

Signed-off-by: Marc Herbert <marc.herbert@intel.com>