### PR TITLE
test-speaker: add argument for loop count

### DIFF
--- a/test-case/test-speaker.sh
+++ b/test-case/test-speaker.sh
@@ -20,8 +20,11 @@ source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $TPLG'
 OPT_HAS_ARG['t']=1         OPT_VAL['t']="$TPLG"
 
-OPT_NAME['l']='loop'     OPT_DESC['l']='option of speaker-test'
-OPT_HAS_ARG['l']=1         OPT_VAL['l']=3
+OPT_NAME['l']='loop'     OPT_DESC['l']='stress loops count'
+OPT_HAS_ARG['l']=1         OPT_VAL['l']=1
+
+OPT_NAME['L']='nloops'     OPT_DESC['L']='option of speaker-test, loop number of .wav files, 0 = infinite'
+OPT_HAS_ARG['L']=1         OPT_VAL['L']=3
 
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_HAS_ARG['s']=0             OPT_VAL['s']=1
@@ -31,27 +34,32 @@ tplg=${OPT_VAL['t']}
 [[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
 
 func_pipeline_export "$tplg" "type:playback"
-tcnt=${OPT_VAL['l']}
+tcnt=${OPT_VAL['L']}
+tloop=${OPT_VAL['l']}
 setup_kernel_check_point
-for idx in $(seq 0 $(expr $PIPELINE_COUNT - 1))
+for loop in $(seq 1 $tloop)
 do
-    channel=$(func_pipeline_parse_value $idx channel)
-    rate=$(func_pipeline_parse_value $idx rate)
-    fmt=$(func_pipeline_parse_value $idx fmt)
-    dev=$(func_pipeline_parse_value $idx dev)
-    snd=$(func_pipeline_parse_value $idx snd)
+    dlogi "===== Starting iteration $loop of $tloop ====="
+    for idx in $(seq 0 $(expr $PIPELINE_COUNT - 1))
+    do
+        channel=$(func_pipeline_parse_value $idx channel)
+        rate=$(func_pipeline_parse_value $idx rate)
+        fmt=$(func_pipeline_parse_value $idx fmt)
+        dev=$(func_pipeline_parse_value $idx dev)
+        snd=$(func_pipeline_parse_value $idx snd)
 
-    dlogc "speaker-test -D $dev -r $rate -c $channel -f $fmt -l $tcnt -t wav -P 8"
-    speaker-test -D $dev -r $rate -c $channel -f $fmt -l $tcnt -t wav -P 8 2>&1 |tee $LOG_ROOT/result_$idx.txt
-    resultRet=$?
+        dlogc "speaker-test -D $dev -r $rate -c $channel -f $fmt -l $tcnt -t wav -P 8"
+        speaker-test -D $dev -r $rate -c $channel -f $fmt -l $tcnt -t wav -P 8 2>&1 |tee $LOG_ROOT/result_$loop_$idx.txt
+        resultRet=$?
 
-    if [[ $resultRet -eq 0 ]]; then
-        grep -nr -E "error|failed" $LOG_ROOT/result_$idx.txt
-        if [[ $? -eq 0 ]]; then
-            func_lib_lsof_error_dump $snd
-            die "speaker test failed"
+        if [[ $resultRet -eq 0 ]]; then
+            grep -nr -E "error|failed" $LOG_ROOT/result_$idx.txt
+            if [[ $? -eq 0 ]]; then
+                func_lib_lsof_error_dump $snd
+                die "speaker test failed"
+            fi
         fi
-    fi
+    done
 done
 
 sof-kernel-log-check.sh "$KERNEL_CHECKPOINT"


### PR DESCRIPTION
The existed '-l' is for nloops of speaker-test, which is used to
configure the loop number of left/right .wav files in each playback, it
is not suitable for the loop count for the speaker-test stress.

Change the old speaker-test one to '-L' and add new '-l' for stress test
purpose, to make it consistent with stress test of other cases.

Signed-off-by: Keyon Jie <yang.jie@linux.intel.com>