### PR TITLE
logger: disable sof-logger for zephyr

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -343,3 +343,24 @@ disable_kernel_check_point()
 {
     KERNEL_CHECKPOINT="disabled"
 }
+
+is_zephyr()
+{
+    # check if jq is installed, will remove this part
+    # after all DUTs have jq installed.
+    type -p jq || sudo apt install jq -y
+
+    local manifest=/etc/sof/manifest.txt
+    test -e "$manifest" || return 1
+    jq '.version.firmwareType' "$manifest" | grep "zephyr"
+}
+
+logger_disabled()
+{
+    # disable logger when firmware type is zephyr or -s is set to 0
+    if is_zephyr || [[ ${OPT_VAL['s']} -ne 1 ]]; then
+        return 0
+    else
+        return 1
+    fi
+}

--- a/test-case/check-alsabat.sh
+++ b/test-case/check-alsabat.sh
@@ -58,7 +58,7 @@ then
 	exit 2
 fi
 
-[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
+logger_disabled || func_lib_start_log_collect
 
 function __upload_wav_file
 {

--- a/test-case/check-capture.sh
+++ b/test-case/check-capture.sh
@@ -57,7 +57,7 @@ loop_cnt=${OPT_VAL['l']}
 out_dir=${OPT_VAL['o']}
 file_prefix=${OPT_VAL['f']}
 
-[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
+logger_disabled || func_lib_start_log_collect
 
 setup_kernel_check_point
 func_lib_check_sudo

--- a/test-case/check-fw-echo-reference.sh
+++ b/test-case/check-fw-echo-reference.sh
@@ -41,7 +41,7 @@ loop_cnt=${OPT_VAL['l']}
 frames=${OPT_VAL['n']}
 frequency=${OPT_VAL['f']}
 
-[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
+logger_disabled || func_lib_start_log_collect
 
 func_pipeline_export "$tplg" "echo:any"
 setup_kernel_check_point

--- a/test-case/check-keyword-detection.sh
+++ b/test-case/check-keyword-detection.sh
@@ -53,7 +53,7 @@ history_depth=${OPT_VAL['s']}
 preamble_time=${OPT_VAL['p']}
 duration=${OPT_VAL['d']}
 
-[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
+logger_disabled || func_lib_start_log_collect
 
 func_pipeline_export "$tplg" "kpbm:any"
 

--- a/test-case/check-pause-release-suspend-resume.sh
+++ b/test-case/check-pause-release-suspend-resume.sh
@@ -108,7 +108,7 @@ esac
 [[ -z $file_name ]] && file_name=$dummy_file
 
 
-[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
+logger_disabled || func_lib_start_log_collect
 
 setup_kernel_check_point
 

--- a/test-case/check-pause-resume.sh
+++ b/test-case/check-pause-resume.sh
@@ -74,7 +74,7 @@ case $test_mode in
     ;;
 esac
 
-[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
+logger_disabled || func_lib_start_log_collect
 
 [[ -z $file_name ]] && file_name=$dummy_file
 

--- a/test-case/check-playback.sh
+++ b/test-case/check-playback.sh
@@ -54,7 +54,7 @@ loop_cnt=${OPT_VAL['l']}
 file=${OPT_VAL['f']}
 
 
-[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
+logger_disabled || func_lib_start_log_collect
 
 # checking if source file exists
 if [[ -z $file ]]; then

--- a/test-case/check-runtime-pm-double-active.sh
+++ b/test-case/check-runtime-pm-double-active.sh
@@ -69,7 +69,7 @@ DEV_LST['playback']='/dev/zero'
 APP_LST['capture']='arecord'
 DEV_LST['capture']='/dev/null'
 
-[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
+logger_disabled || func_lib_start_log_collect
 func_pipeline_export "$tplg" "type:any"
 
 for idx in $(seq 0 $(expr $PIPELINE_COUNT - 1))

--- a/test-case/check-runtime-pm-status.sh
+++ b/test-case/check-runtime-pm-status.sh
@@ -65,7 +65,7 @@ DEV_LST['playback']='/dev/zero'
 APP_LST['capture']='arecord'
 DEV_LST['capture']='/dev/null'
 
-[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
+logger_disabled || func_lib_start_log_collect
 func_pipeline_export "$tplg" "type:any"
 
 for idx in $(seq 0 $(expr $PIPELINE_COUNT - 1))

--- a/test-case/check-signal-stop-start.sh
+++ b/test-case/check-signal-stop-start.sh
@@ -40,7 +40,7 @@ count=${OPT_VAL['c']}
 interval=${OPT_VAL['i']}
 test_mode=${OPT_VAL['m']}
 
-[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
+logger_disabled || func_lib_start_log_collect
 
 case $test_mode in
     "playback")

--- a/test-case/check-smart-amplifier.sh
+++ b/test-case/check-smart-amplifier.sh
@@ -56,7 +56,7 @@ duration=${OPT_VAL['d']}
 loop_cnt=${OPT_VAL['l']}
 tplg=${OPT_VAL['t']}
 
-[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
+logger_disabled || func_lib_start_log_collect
 
 func_pipeline_export "$tplg" "smart_amp:any"
 setup_kernel_check_point

--- a/test-case/check-suspend-resume-with-audio.sh
+++ b/test-case/check-suspend-resume-with-audio.sh
@@ -59,7 +59,7 @@ setup_kernel_check_point
 func_lib_check_sudo
 
 tplg=${OPT_VAL['t']}
-[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
+logger_disabled || func_lib_start_log_collect
 
 # overwrite the subscript: test-case LOG_ROOT environment
 # so when load the test-case in current script

--- a/test-case/check-xrun-injection.sh
+++ b/test-case/check-xrun-injection.sh
@@ -41,7 +41,7 @@ test_mode=${OPT_VAL['m']}
 count=${OPT_VAL['c']}
 interval=${OPT_VAL['i']}
 
-[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
+logger_disabled || func_lib_start_log_collect
 
 setup_kernel_check_point
 func_lib_check_sudo

--- a/test-case/multiple-pause-resume.sh
+++ b/test-case/multiple-pause-resume.sh
@@ -57,7 +57,7 @@ rnd_range=$[ $rnd_max - $rnd_min ]
 tplg=${OPT_VAL['t']}
 func_pipeline_export "$tplg" "type:any"
 
-[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
+logger_disabled || func_lib_start_log_collect
 
 declare -a pipeline_idx_lst
 declare -a cmd_idx_lst

--- a/test-case/multiple-pipeline.sh
+++ b/test-case/multiple-pipeline.sh
@@ -63,7 +63,7 @@ func_opt_parse_option "$@"
 loop_cnt=${OPT_VAL['l']}
 tplg=${OPT_VAL['t']}
 f_arg=${OPT_VAL['f']}
-[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
+logger_disabled || func_lib_start_log_collect
 
 max_count=0
 # this line will help to get $PIPELINE_COUNT

--- a/test-case/simultaneous-playback-capture.sh
+++ b/test-case/simultaneous-playback-capture.sh
@@ -58,7 +58,7 @@ unset tmp_id_lst tplg_path
 id_lst_str=${id_lst_str/,/} # remove 1st, which is not used
 [[ ${#id_lst_str} -eq 0 ]] && dlogw "no pipeline with both playback and capture capabilities found in $tplg" && exit 2
 func_pipeline_export "$tplg" "id:$id_lst_str"
-[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
+logger_disabled || func_lib_start_log_collect
 
 func_error_exit()
 {

--- a/test-case/test-speaker.sh
+++ b/test-case/test-speaker.sh
@@ -28,7 +28,7 @@ OPT_HAS_ARG['s']=0             OPT_VAL['s']=1
 
 func_opt_parse_option "$@"
 tplg=${OPT_VAL['t']}
-[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
+logger_disabled || func_lib_start_log_collect
 
 func_pipeline_export "$tplg" "type:playback"
 tcnt=${OPT_VAL['l']}

--- a/test-case/volume-basic-test.sh
+++ b/test-case/volume-basic-test.sh
@@ -41,7 +41,7 @@ func_error_exit()
 
 [[ -z $tplg ]] && die "Missing tplg file needed to run"
 func_pipeline_export "$tplg" "type:playback"
-[[ ${OPT_VAL['s']} -eq 1 ]] && func_lib_start_log_collect
+logger_disabled || func_lib_start_log_collect
 
 [[ $PIPELINE_COUNT -eq 0 ]] && die "Missing playback pipeline for aplay to run"
 channel=$(func_pipeline_parse_value 0 channel)


### PR DESCRIPTION
since zephyr doesnot support sof-logger, so add a function
to disable logger trace for zephyr during the test.

Signed-off-by: Zhang Keqiao <keqiao.zhang@intel.com>