### PR TITLE
sof_remove.sh: print FAILED and run lsmod when rmmod fails silently

### DIFF
--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -6,7 +6,7 @@ remove_module() {
 
     local MODULE="$1"
 
-    if lsmod | grep -q "^${MODULE}[[:blank:]]"; then
+    if grep -q "^${MODULE}[[:blank:]]" /proc/modules; then
         printf 'RMMOD\t%s\n' "$MODULE"
         sudo rmmod "$MODULE"
     else

--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -26,6 +26,13 @@ exit_handler()
                "$(basename "$0")"
         systemctl --user list-units --all '*pulse*' || true
     fi
+
+    if test "$exit_status" -ne 0; then
+        lsmod | grep -e sof -e snd -e sound -e drm
+        # rmmod can fail silently, for instance when "Used by" is -1
+        printf "%s FAILED\n" "$0"
+    fi
+
     return "$exit_status"
 }
 


### PR DESCRIPTION
In my example this changes the output from a totally quiet and cryptic:
```
SKIP	snd_usb_audio  	not loaded
SKIP	snd_hda_intel  	not loaded
SKIP	snd_sof_pci_intel_tng  	not loaded
RMMOD	snd_sof_pci_intel_apl
```
to this instead:
```
SKIP	snd_usb_audio  	not loaded
SKIP	snd_hda_intel  	not loaded
SKIP	snd_sof_pci_intel_tng  	not loaded
RMMOD	snd_sof_pci_intel_apl
snd_sof_pci_intel_apl    16384  -1
snd_sof_intel_hda_common    77824  1 snd_sof_pci_intel_apl
snd_sof_pci            20480  2 snd_sof_intel_hda_common,snd_sof_pci_intel_apl
snd_soc_acpi_intel_match    40960  1 snd_sof_pci_intel_apl
snd_soc_acpi           16384  2 snd_soc_acpi_intel_match,snd_sof_intel_hda_common
snd_sof               126976  2 snd_sof_pci,snd_sof_intel_hda_common
snd_soc_core          253952  1 snd_sof
snd_sof_xtensa_dsp     16384  1 snd_sof_intel_hda_common
snd_intel_dspcfg       28672  1 snd_sof_intel_hda_common
snd_pcm               118784  3 snd_sof,snd_sof_intel_hda_common,snd_soc_core
snd_usbmidi_lib        36864  0
ledtrig_audio          16384  1 snd_sof
snd_seq_midi           20480  0
snd_seq_midi_event     16384  1 snd_seq_midi
snd_rawmidi            36864  2 snd_seq_midi,snd_usbmidi_lib
snd_seq                81920  2 snd_seq_midi,snd_seq_midi_event
snd_seq_device         16384  3 snd_seq,snd_seq_midi,snd_rawmidi
snd_timer              36864  2 snd_seq,snd_pcm
snd                    86016  7 snd_seq,snd_seq_device,snd_usbmidi_lib,snd_timer,snd_soc_core,snd_pcm,snd_rawmidi
soundcore              16384  1 snd
drm_kms_helper        200704  1 i915
syscopyarea            16384  1 drm_kms_helper
sysfillrect            16384  1 drm_kms_helper
sysimgblt              16384  1 drm_kms_helper
fb_sys_fops            16384  1 drm_kms_helper
drm                   434176  3 drm_kms_helper,i915
./sof-test/tools/kmod/sof_remove.sh FAILED
```
Another "rmmod snd_sof_pci_intel_apl" instance was stuck when this happened.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>