### PR TITLE
test-case: improve Chrome OS compatibility

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -335,7 +335,7 @@ is_sof_used()
 # a wrapper to journalctl with required style
 journalctl_cmd()
 {
-   journalctl -k -q --no-pager --utc --output=short-monotonic \
+   sudo journalctl -k -q --no-pager --utc --output=short-monotonic \
      --no-hostname "$@"
 }
 

--- a/test-case/check-capture.sh
+++ b/test-case/check-capture.sh
@@ -78,8 +78,7 @@ do
         if [ ${OPT_VAL['F']} = '1' ]; then
             fmt=$(func_pipeline_parse_value $idx fmts)
         fi
-        # clean up dmesg
-        sudo dmesg -C
+
         for fmt_elem in $(echo $fmt)
         do
             for i in $(seq 1 $loop_cnt)

--- a/test-case/check-playback.sh
+++ b/test-case/check-playback.sh
@@ -86,8 +86,7 @@ do
         if [ ${OPT_VAL['F']} = '1' ]; then
             fmts=$(func_pipeline_parse_value "$idx" fmts)
         fi
-        # clean up dmesg
-        sudo dmesg -C
+
         for fmt_elem in $fmts
         do
             for i in $(seq 1 $loop_cnt)

--- a/tools/pactlinfo.py
+++ b/tools/pactlinfo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 ''' This is a helper tool to analysis pactl cmd '''
 

--- a/tools/sof-combinatoric.py
+++ b/tools/sof-combinatoric.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import itertools
 import argparse

--- a/tools/sof-dump-status.py
+++ b/tools/sof-dump-status.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import subprocess
 import os

--- a/tools/sof-dump-status.py
+++ b/tools/sof-dump-status.py
@@ -79,14 +79,14 @@ class clsSYSCardInfo():
 
     def loadPCI(self):
         self.pci_lst.clear()
-        exit_code, output=subprocess.getstatusoutput("lspci -D |grep audio -i|grep intel -i")
+        exit_code, output=subprocess.getstatusoutput("sudo lspci -D |grep audio -i|grep intel -i")
         # grep exit 1 means nothing matched
         if exit_code != 0:
             return
         for line in output.splitlines():
             pci_info = {}
             pci_info['pci_id'] = line.split(' ')[0]
-            tmp_output = subprocess.getoutput("lspci -s %s -kx" % (pci_info['pci_id'])).splitlines()
+            tmp_output = subprocess.getoutput("sudo lspci -s %s -kx" % (pci_info['pci_id'])).splitlines()
             pci_info['name'] = tmp_output[1].split(':')[-1].strip()
             for i in range(2, len(tmp_output)):
                 if tmp_output[i].split()[1].strip() == 'modules:' :

--- a/tools/sof-tplgreader.py
+++ b/tools/sof-tplgreader.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import subprocess
 import os

--- a/tools/tplgtool.py
+++ b/tools/tplgtool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/tools/wavetool.py
+++ b/tools/wavetool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright(c) 2020 Intel Corporation. All rights reserved.
 


### PR DESCRIPTION
These two patches make check-playback/capture test cases can run on Chrome smoothly. suppose sof-test is downloaded to /usr/local, and other dependencies are installed with [chromebrew](http://skycocker.github.io/chromebrew)