### PR TITLE
test: disable the test for Bluetooth pipelines

### DIFF
--- a/case-lib/config.sh
+++ b/case-lib/config.sh
@@ -57,6 +57,12 @@ SUDO_LEVEL=${SUDO_LEVEL:-}
 #
 # NO_HDMI_MODE=true
 
+# Bluetooth connection is not set up on our Linux device.
+# The I2S is in slave and there will be no WS/FSYNC from
+# the BT side, so audio side will get -EIO.
+#
+# NO_BT_MODE=true
+
 # Test interval between two test cases, the default value is 5 seconds
 # in CI, which is controlled by sof-framework. In manual run, user can
 # override the default value.

--- a/case-lib/pipeline.sh
+++ b/case-lib/pipeline.sh
@@ -48,6 +48,8 @@ func_pipeline_export()
     local opt="$2"
     # In no HDMI mode, exclude HDMI pipelines
     [ -z "$NO_HDMI_MODE" ] || opt="$opt & ~pcm:HDMI"
+    # In no Bluetooth mode, exclude BT pipelines
+    [ -z "$NO_BT_MODE" ] || opt="$opt & ~pcm:Bluetooth"
     opt="-f '${opt}'"
 
     [[ "$ignore" ]] && opt="$opt -b '$ignore'"


### PR DESCRIPTION
Bluetooth is not supported on our linux device and
will cause -EIO when testing BT pipelines.

This patch adds an option to disable the BT test.
Once NO_BT_MODE is true, all BT pipelines will be
filtered out and skip the test.

Signed-off-by: Zhang Keqiao <keqiao.zhang@intel.com>