### PR TITLE
tools: kmod: sof_remove.sh: Remove snd_intel_sdw_acpi

### DIFF
--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -207,6 +207,7 @@ remove_module soundwire_generic_allocation
 remove_module regmap_sdw
 remove_module regmap_sdw_mbq
 remove_module soundwire_bus
+remove_module snd_intel_sdw_acpi
 
 remove_module snd_soc_core
 remove_module snd_hda_codec


### PR DESCRIPTION
Remove the snd_intel_dsw_acpi module as well which remained loaded after
a run (tested on tgl-h platform).

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>