### PR TITLE
lib.sh: don't quietly override the user-provided TPLG dirname

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -261,10 +261,10 @@ func_lib_get_tplg_path()
     local tplg=$1
     if [[ -z "$tplg" ]]; then   # tplg given is empty
         return 1
-    elif [[ -f "$TPLG_ROOT/$(basename "$tplg")" ]]; then
-        echo "$TPLG_ROOT/$(basename "$tplg")"
     elif [[ -f "$tplg" ]]; then
         realpath "$tplg"
+    elif [[ -f "$TPLG_ROOT/$tplg" ]]; then
+        echo "$TPLG_ROOT/$tplg"
     else
         return 1
     fi


### PR DESCRIPTION
Fixes commit 1494965e7f that added support for both relative and
absolute paths.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>