### PR TITLE
sof-kernel-log-check: use RE to filter asix errors

### DIFF
--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -256,8 +256,10 @@ ignore_str="$ignore_str"'|asix .-.+:.\.. en.+: asix_rx_fixup\(\) Bad Header Leng
 
 # asix error in TGLH_0A5E_SDW
 # kernel: asix 3-3.1:1.0 enx000ec65356e1: Failed to enable software MII access
+# kernel: asix 3-3.1:1.0 enx000ec65356e1: Failed to enable hardware MII access
 # buglink: https://github.com/thesofproject/sof-test/issues/565
-ignore_str="$ignore_str"'|asix .-.+\..:.\.. en.+: Failed to enable software MII access'
+# buglink: https://github.com/thesofproject/sof-test/issues/664
+ignore_str="$ignore_str"'|asix .-.+\..:.\.. en.+: Failed to .+'
 
 case "$platform" in
     # Audio PCI ID on CML Mantis is [8086:9dc8], which is defined as CNL in linux kernel.


### PR DESCRIPTION
Updated ignore_str to filter more asix errors

[Logs that needed to be filtered out ]

```
[ 7430.598174] kernel: asix 3-3.1:1.0 enx000ec65356e1: Failed to enable hardware MII access
[ 7430.599294] kernel: asix 3-3.1:1.0 enx000ec65356e1: Failed to enable hardware MII access
[ 7430.600408] kernel: asix 3-3.1:1.0 enx000ec65356e1: Failed to enable hardware MII access
[ 7430.600411] kernel: asix 3-3.1:1.0 enx000ec65356e1: Failed to write Medium Mode mode to 0x0134: ffffff8f
```
```
kernel: [ 7321.220312] asix 3-12.1:1.0 enx000ec668ad2a: Failed to read reg index 0x0000: -113
kernel: [ 7321.220314] asix 3-12.1:1.0 enx000ec668ad2a: Failed to write reg index 0x0000: -113
kernel: [ 7321.220315] asix 3-12.1:1.0 enx000ec668ad2a: Failed to enable software MII access
```


Since the common string part is always " asix ....... : Failed to " , I refined it to  **ignore_str="$ignore_str"'|asix .-.+\..:.\.. en.+: Failed to .+'**

Signed-off-by: Iris Wu <xiaoyun.wu@intel.com>