### PR TITLE
check-sof-logger: fix bug that did not kill/clean sof-logger -t

### DIFF
--- a/test-case/check-sof-logger.sh
+++ b/test-case/check-sof-logger.sh
@@ -111,9 +111,9 @@ print_logs_exit()
     for ftype in data etrace error etrace_stderr; do
         printf '\n\n'
         bname="logger.$ftype.txt"
-        dlogi "Log $ftype BEG::"
+        dlogi "Log file $bname BEG::"
         cat "$LOG_ROOT/$bname" || true # we already checked these
-        dlogi "::END $ftype"
+        dlogi "::END log file $bname"
     done
     test -z "$errmsg" || dloge "$errmsg"
     exit "$exit_code"
@@ -132,6 +132,8 @@ main()
         if test -s "$stderr_file"; then
             print_logs_exit 1 "stderr $stderr_file is not empty"
         fi
+        printf 'GOOD: %s was empty, no stderr output from that sof-logger instance\n' \
+               logger."$f".txt > "$stderr_file"
     done
 
     # Search for the log header, should be something like this:


### PR DESCRIPTION
2 commits. Main fix:

Killing sudo does NOT kill the sof-logger child! Use timeout as root
instead.

We probably got away with it because of the various "pkill sof-logger"
out there.

Fixes 8732f67 ("check-sof-logger: rewrite most of it so it can
actually find bugs ")

Signed-off-by: Marc Herbert <marc.herbert@intel.com>