### PR TITLE
sof-tplgreader: don't use RE for pipeline filtering

### DIFF
--- a/tools/sof-tplgreader.py
+++ b/tools/sof-tplgreader.py
@@ -172,8 +172,11 @@ class clsTPLGReader:
                 if 'any' in value or value == ['']:
                     check = True if key in line.keys() else False
                 else:
-                    # match for 'keyword'/'keyword [0-9]' target line
-                    check = len ([em for em in value if re.match(em + '$|' + em + '[^a-zA-Z]', str(line[key]), re.I)]) > 0
+                    # check if current pipeline is the one we want
+                    if type(value) == list:
+                        check = str(line[key]) in value
+                    else:
+                        check = str(line[key]) == value
                 if check is bIn:
                     break
             else:


### PR DESCRIPTION
If we have two pipelines with id=1 and id=10, current
RE is not able to filter these two pipelines from each
other.

This patch deprecates RE and use string comparison for
pipeline filtering.

Signed-off-by: Chao Song <chao.song@linux.intel.com>