### PR TITLE
[DON'T MERGE] Enable DEVRES debug log for kmod test

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -105,6 +105,11 @@ function func_exit_handler()
         done
     fi
 
+    # Currently devres debug log is enabled only for kmod test.
+    # When the test case is failed, devres debug level may not be clear.
+    # So exit handler should reset log level.
+    disable_devres_debug_log
+
     # check if function already defined.
     # on exit check whether pulseaudio is disabled.
     ret=0

--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -374,3 +374,26 @@ print_module_params()
     grep -H ^ /sys/module/*sof*/parameters/*
     echo "----------------------------------------"
 }
+
+devres_debug_set()
+{
+    local new="$1"
+    local old
+    old=$(cat /sys/module/devres/parameters/log)
+    if [ "$old" -eq "$new" ]; then
+        dlogi "DEVRES log is already $new"
+        return 0
+    fi
+
+    echo "$new" | sudo tee /sys/module/devres/parameters/log > /dev/null
+}
+
+enable_devres_debug_log()
+{
+    devres_debug_set 1
+}
+
+disable_devres_debug_log()
+{
+    devres_debug_set 0
+}

--- a/test-case/check-kmod-load-unload.sh
+++ b/test-case/check-kmod-load-unload.sh
@@ -44,6 +44,10 @@ if [ ${OPT_VAL['p']} -eq 1 ];then
     func_lib_disable_pulseaudio
 fi
 
+# Enable DEVRES debug log dynamically, this is very verbose
+# it should be disabled at the end of this test
+enable_devres_debug_log
+
 for idx in $(seq 1 $loop_cnt)
 do
     dlogi "===== Starting iteration $idx of $loop_cnt ====="
@@ -110,3 +114,5 @@ do
         sleep 1
     done
 done
+
+disable_devres_debug_log

--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -365,6 +365,12 @@ ignore_str="$ignore_str"'|elan_i2c i2c-ELAN0000:.*: invalid report id data'
 # iwlwifi 0000:00:14.3: No beacon heard and the time event is over already...
 ignore_str="$ignore_str"'|iwlwifi [[:digit:].:]+: '
 
+# Ignore DEVRES debug log which is ERROR by default
+# DEVRES debug log will be enabled in kmod test
+# There are four OPs from DEVRES, ADD, REP, REM, REL
+# for example, [  182.317913] cml_rt1011_rt5682 cml_rt1011_rt5682: DEVRES REL 00000000618e4fb0 devm_card_release (8 bytes)
+# issue link: https://github.com/thesofproject/linux/issues/3008
+ignore_str="$ignore_str"'| DEVRES [A-Z]{3} '
 
 #
 # SDW related logs


### PR DESCRIPTION
Warning: this is very verbose.
Intentionally made first commit to ignore DEVRES log.