### PR TITLE
print module parameter values

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -364,3 +364,13 @@ logger_disabled()
         return 1
     fi
 }
+
+print_module_params()
+{
+    echo "--------- Printing module parameters ----------"
+    grep -H ^ /sys/module/snd_intel_dspcfg/parameters/*
+
+    # for all the *sof* modules
+    grep -H ^ /sys/module/*sof*/parameters/*
+    echo "----------------------------------------"
+}

--- a/test-case/verify-kernel-boot-log.sh
+++ b/test-case/verify-kernel-boot-log.sh
@@ -21,4 +21,6 @@ source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 func_opt_parse_option "$@"
 disable_kernel_check_point
 
+print_module_params
+
 sof-kernel-log-check.sh


### PR DESCRIPTION
Collect module parameters when kernel boot log is saved. Some of
parameters are very useful to debug potential issue.

Signed-off-by: Fred Oh <fred.oh@linux.intel.com>

This is a output example from CML Helios,
```
---------> Printing module parameters <----------
/sys/module/snd_intel_dspcfg/parameters/dsp_driver = 3
/sys/module/snd_sof/parameters/disable_pause = N
/sys/module/snd_sof/parameters/sof_debug = 0
/sys/module/snd_sof_acpi/parameters/fw_path = (null)
/sys/module/snd_sof_acpi/parameters/sof_acpi_debug = 0
/sys/module/snd_sof_acpi/parameters/tplg_path = (null)
/sys/module/snd_sof_intel_hda_common/parameters/always_enable_dmi_l1 = N
/sys/module/snd_sof_intel_hda_common/parameters/codec_mask = -1
/sys/module/snd_sof_intel_hda_common/parameters/disable_rewinds = N
/sys/module/snd_sof_intel_hda_common/parameters/dmic_num = -1
/sys/module/snd_sof_intel_hda_common/parameters/enable_trace_D0I3_S0 = N
/sys/module/snd_sof_intel_hda_common/parameters/hda_model = (null)
/sys/module/snd_sof_intel_hda_common/parameters/sdw_clock_stop_quirks = 8
/sys/module/snd_sof_intel_hda_common/parameters/use_common_hdmi = Y
/sys/module/snd_sof_intel_hda_common/parameters/use_msi = Y
/sys/module/snd_sof_pci/parameters/fw_path = (null)
/sys/module/snd_sof_pci/parameters/sof_pci_debug = 0
/sys/module/snd_sof_pci/parameters/tplg_path = (null)
----------------------------------------
```