### PR TITLE
kernel-log-check: add adl-s to ignore i915 AUX errors

### DIFF
--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -276,8 +276,8 @@ case "$platform" in
         # https://unix.stackexchange.com/questions/109294/mei-00000016-0-init-hw-failure
         ignore_str="$ignore_str"'|mei_me 0000:00:16\..: wait hw ready failed'
         ;;
-    adl)
-	# i915 AUX logs can be ignored
+    adl|adl-s)
+        # i915 AUX logs can be ignored
         # origin logs seen on ADLS platforms
         # i915 0000:00:02.0: [drm] *ERROR* AUX A/DDI A/PHY A: did not complete or timeout within 10ms (status 0xad4003ff)
         # i915 0000:00:02.0: [drm] *ERROR* AUX A/DDI A/PHY A: not done (status 0xad4003ff)


### PR DESCRIPTION
i915 AUX errors are happening in not only adl but also adl-s.
related PR: https://github.com/thesofproject/sof-test/pull/705

Signed-off-by: Fred Oh <fred.oh@linux.intel.com>

Found in internal Dailiy test 4960?model=ADLS_RVP_HDA&testcase=verify-kernel-boot-log