### PR TITLE
multiple-pause-resume: change default values and fix serious loop index bug

### DIFF
--- a/test-case/multiple-pause-resume.sh
+++ b/test-case/multiple-pause-resume.sh
@@ -157,10 +157,10 @@ do
         done
         # wait for expect script finished
         dlogi "wait for expect process finished"
-        i=$max_wait_time
-        while [ $i -gt 0 ]
+        iwait=$max_wait_time
+        while [ $iwait -gt 0 ]
         do
-            i=$[ $i - 1 ]
+            iwait=$((iwait - 1))
             sleep 1s
             [[ ! "$(pidof expect)" ]] && break
         done


### PR DESCRIPTION
@ranj063 reported this problem. Occasionally it timeout too early.
```
2021-06-30 17:20:20 UTC Sub-Test: [INFO] pipeline: Port1 with aplay
2021-06-30 17:20:20 UTC Sub-Test: [INFO] pipeline: Port2 with aplay
2021-06-30 17:20:20 UTC Sub-Test: [INFO] Check expect exit status
2021-06-30 17:20:20 UTC Sub-Test: [INFO] Port1 to command: aplay -D hw:0,1 -r 48000 -c 2 -f S16_LE -vv -i /dev/zero -q
spawn aplay -D hw:0,1 -r 48000 -c 2 -f S16_LE -vv -i /dev/zero -q^M
2021-06-30 17:20:20 UTC Sub-Test: [INFO] Port2 to command: arecord -D hw:0,2 -r 48000 -c 2 -f S16_LE -vv -i /dev/null -q
2021-06-30 17:20:20 UTC Sub-Test: [INFO] wait for expect process finished
===> Fred: only after 5 second, it timeout for 250 second!
2021-06-30 17:20:25 UTC Sub-Test: [ERROR] Still have expect process not finished after wait for 250
root        7937    7931 34 17:20 pts/1    00:00:01 aplay -D hw:0,1 -r 48000 -c 2 -f S16_LE -vv -i /dev/zero -q
root        7946    7942 36 17:20 pts/2    00:00:01 arecord -D hw:0,2 -r 48000 -c 2 -f S16_LE -vv -i /dev/null -q
root        7962    6577  0 17:20 pts/0    00:00:00 grep -E aplay|arecord
2021-06-30 17:20:25 UTC Sub-Test: [ERROR] Starting func_exit_handler(), exit status=1, FUNCNAME stack:
2021-06-30 17:20:25 UTC Sub-Test: [ERROR]  main()  @  /home/ubuntu/sof-test/test-case/multiple-pause-resume.sh
```