### PR TITLE
New systemctl_show_pulseaudio() that catches the sneaky 'gdm' user 

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # get test-case information
-SCRIPT_HOME="$(dirname "$0")"
+SCRIPT_HOME="$(dirname "${BASH_SOURCE[0]}")"
 # get test-case parent folder name
 SCRIPT_HOME=$(cd "$SCRIPT_HOME/.." && pwd)
 # shellcheck disable=SC2034 # external script can use it

--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -2,6 +2,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright(c) 2018 Intel Corporation. All rights reserved.
 
+
+TOPDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+
+# shellcheck source=case-lib/lib.sh
+source "$TOPDIR"/case-lib/lib.sh
+
 remove_module() {
 
     local MODULE="$1"
@@ -22,9 +28,7 @@ exit_handler()
     # warn about any running pulseaudio because it could make us fail
     # the next time.
     if pgrep -a pulseaudio; then
-        >&2 printf 'ERROR: %s fails semi-randomly when pulseaudio is running\n' \
-               "$(basename "$0")"
-        systemctl --user list-units --all '*pulse*' || true
+        systemctl_show_pulseaudio
     fi
 
     if test "$exit_status" -ne 0; then


### PR DESCRIPTION
Trying to stop the unstoppable thanks to the --global option

Sample ~/SOF/sof-test/tools/kmod/sof_remove.sh output:
```
SKIP	snd_compress  	not loaded
SKIP	snd_pcm  	not loaded
529 /usr/bin/pulseaudio --daemonize=no --log-target=journal

+ systemctl --system list-unit-files --all '*pulse*'
UNIT FILE                           STATE  VENDOR PRESET
pulseaudio-enable-autospawn.service masked enabled

1 unit files listed.

+ systemctl --global list-unit-files --all '*pulse*'
UNIT FILE          STATE   VENDOR PRESET
pulseaudio.service enabled enabled
pulseaudio.socket  enabled enabled

2 unit files listed.

+ systemctl --user list-unit-files --all '*pulse*'
UNIT FILE          STATE  VENDOR PRESET
pulseaudio.service masked enabled
pulseaudio.socket  masked enabled

2 unit files listed.

For joe ONLY:
+ systemctl --user list-units --all '*pulse*'
  UNIT               LOAD   ACTIVE   SUB  DESCRIPTION
● pulseaudio.service masked inactive dead pulseaudio.service
● pulseaudio.socket  masked inactive dead pulseaudio.socket

LOAD   = Reflects whether the unit definition was properly loaded.
ACTIVE = The high-level unit activation state, i.e. generalization of SUB.
SUB    = The low-level unit activation state, values depend on unit type.

2 loaded units listed.
To show all installed unit files use 'systemctl list-unit-files'.
gdm          529  0.0  0.3 804512 13960 ?        S<sl 13:46   0:00 /usr/bin/pulseaudio --daemonize=no --log-target=journal

ERROR: sof_remove.sh fails semi-randomly when pulseaudio is running

Try: sudo systemctl --global mask pulseaudio.{socket,service} and reboot.
    --global is required for session managers like "gdm"
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>