### PR TITLE
kernel-log-check: filter i915 supsending crtc logs

### DIFF
--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -283,6 +283,11 @@ case "$platform" in
         # i915 0000:00:02.0: [drm] *ERROR* AUX A/DDI A/PHY A: not done (status 0xad4003ff)
         ignore_str="$ignore_str"'|i915 [[:digit:].:]+: \[drm\] \*ERROR\* AUX .+'
         ;;
+    ehl)
+	# i915 crtc logs can be ignored
+	# origin logs seen on EHL_RVP_I2S platforms
+	# i915 0000:00:02.0: [drm] *ERROR* Suspending crtc's failed with -22
+	ignore_str="$ignore_str""|i915 [[:digit:].:]+: \[drm\] \*ERROR\* Suspending crtc's failed with -[[:digit:]]+"
 esac
 
 # below are new error level kernel logs from journalctl --priority=err


### PR DESCRIPTION
on EHL platforms , when check suspend resume , 'kernel: i915 0000:00:02.0: [drm] *ERROR* Suspending crtc's failed with -22' error happens and leads testcase to fail .
Since this is irrelevant to audio , filter it so that the testcase can run successfully 

Signed-off-by: Iris Wu <xiaoyun.wu@intel.com>