### PR TITLE
sof_remove.sh: Update SOF client driver names

### DIFF
--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -151,10 +151,13 @@ remove_module snd_soc_sof_sdw
 remove_module snd_soc_ehl_rt5660
 remove_module snd_soc_intel_hda_dsp_common
 remove_module snd_soc_intel_sof_maxim_common
-remove_module snd_sof_ipc_test
+
+#-------------------------------------------
+# SOF client drivers
+#-------------------------------------------
 remove_module snd_sof_probes
-remove_module snd_sof_intel_client
-remove_module snd_sof_client
+remove_module snd_sof_ipc_test
+remove_module snd_sof_dma_trace
 
 # snd_sof_nocodec dependencies re-ordered
 # in https://github.com/thesofproject/linux/pull/2800

--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -167,6 +167,7 @@ remove_module snd_sof_nocodec || true
 
 remove_module snd_sof
 remove_module snd_sof_nocodec
+remove_module snd_sof_utils
 
 #-------------------------------------------
 # Codec drivers


### PR DESCRIPTION
Add a section for the SOF client drivers and update the names to match
with the known names.

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>