### PR TITLE
Add volume_levels into run-all-tests.sh

### DIFF
--- a/test-case/run-all-tests.sh
+++ b/test-case/run-all-tests.sh
@@ -65,7 +65,7 @@ sof-logger
 '
 
 # Requires Octave
-# testlist="$testlist volume_levels"
+testlist="$testlist volume_levels"
 
 main()
 {


### PR DESCRIPTION
This test step checks with audio level measurement that the
correct volume gain and mute commands are applied to each
audio channel. The test script requires Octave.

Signed-off-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>