### PR TITLE
[SKIP CI] check-alsabat: dump amixer contents when fails

### DIFF
--- a/test-case/check-alsabat.sh
+++ b/test-case/check-alsabat.sh
@@ -92,6 +92,8 @@ dlogc "alsabat -C$pcm_c -c $channel_c -r $rate -F $frequency"
 alsabat -C$pcm_c -c $channel_c -r $rate -F $frequency || {
         # upload failed wav file
         __upload_wav_file
+        # dump amixer contents for more debugging
+        amixer contents > "$LOG_ROOT"/amixer_settings.txt
         exit 1
 }
 


### PR DESCRIPTION
Most of alsabat test failures are due to wrong alsa settings. To debug
the failure, amixer contents dumps are very useful.

Signed-off-by: Fred Oh <fred.oh@linux.intel.com>

One of example, recently TGLH_0A5E_SDW failed on alsabat test. By the captured wav, it had overflow problem.
5685?model=TGLH_0A5E_SDW&testcase=check-alsabat-headset-playback

After I sshed to the device and checked the settings, there is no alsa setting issue. It might be changed after that. We need the alsa contents dump when it fails.