### PR TITLE
[SKIP CI] lib.sh: remove temporary jq installation

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -389,10 +389,6 @@ disable_kernel_check_point()
 
 is_zephyr()
 {
-    # check if jq is installed, will remove this part
-    # after all DUTs have jq installed.
-    type -p jq || sudo apt install jq -y
-
     local manifest=/etc/sof/manifest.txt
     test -e "$manifest" || return 1
     jq '.version.firmwareType' "$manifest" | grep "zephyr"

--- a/env-check.sh
+++ b/env-check.sh
@@ -50,6 +50,8 @@ printf "Checking for some OS packages:\t\t"
 func_check_pkg expect
 func_check_pkg aplay
 func_check_pkg python3
+# jq is command-line json parser
+func_check_pkg jq
 func_check_python_pkg graphviz
 func_check_python_pkg numpy
 func_check_python_pkg scipy


### PR DESCRIPTION
jq package will be installed with device setup script. env-check.sh will
provide a warning if jq is not installed.

Signed-off-by: Fred Oh <fred.oh@linux.intel.com>