### PR TITLE
sof-dump-status.py: make -s, -i and -l fail on wrong card numbers

### DIFF
--- a/tools/sof-dump-status.py
+++ b/tools/sof-dump-status.py
@@ -484,25 +484,19 @@ if __name__ == "__main__":
 
     if ret_args.get('id') is not None:
         sysinfo.loadProcSound()
-        card_info = sysinfo.proc_card.get(str(ret_args['id']))
-        if card_info is None:
-            exit(0)
+        card_info = sysinfo.proc_card[str(ret_args['id'])]
         dump_cardinfo_pcm(card_info)
         exit(0)
 
     if ret_args.get('short') is not None:
         sysinfo.loadProcSound()
-        card_info = sysinfo.proc_card.get(str(ret_args['short']))
-        if card_info is None:
-            exit(0)
+        card_info = sysinfo.proc_card[str(ret_args['short'])]
         print(card_info['short'])
         exit(0)
 
     if ret_args.get('longname') is not None:
         sysinfo.loadProcSound()
-        card_info = sysinfo.proc_card.get(str(ret_args['longname']))
-        if card_info is None:
-            exit(0)
+        card_info = sysinfo.proc_card[str(ret_args['longname'])]
         print(card_info['longname'])
         exit(0)
 


### PR DESCRIPTION
Yet another green failure. Passing a wrong card number now fails as
expected:
```shell
./tools/sof-dump-status.py  -i 42 >/dev/null

Traceback (most recent call last):
  File "./tools/sof-dump-status.py", line 487, in <module>
    card_info = sysinfo.proc_card[str(ret_args['id'])]
KeyError: '42'
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>