### PR TITLE
run-all-tests.sh: print partial results when interrupted with Ctrl-C

### DIFF
--- a/test-case/run-all-tests.sh
+++ b/test-case/run-all-tests.sh
@@ -87,6 +87,9 @@ main()
 	local failures=()
 	local passed=()
 
+	# On Ctrl-C
+	trap interrupted_results INT
+
 	local tests_length=10 time_delay=3
 
 	while getopts "l:T:h" OPTION; do
@@ -133,6 +136,20 @@ print_results()
 	fi
 
 	printf "\n\n\033[40;32m test end with %d failed tests\033[0m\n\n" "${#failures[@]}"
+}
+
+interrupted_results()
+{
+	# Users often hit Ctrl-C multiple times which would interrupt
+	# this function too.
+	trap '' INT
+
+	# Give subprocesses some time to avoid mixed up output
+	sleep 3
+
+	print_results
+	printf 'Testing was INTERRUPTED, results are incomplete!\n'
+	exit 1
 }
 
 test_firmware-presence()

--- a/test-case/run-all-tests.sh
+++ b/test-case/run-all-tests.sh
@@ -121,13 +121,18 @@ main()
 		sleep "$time_delay"
 	done
 
+	print_results
+	exit "${#failures[@]}"
+}
+
+print_results()
+{
 	printf "\n\nPASS:"; printf ' %s;' "${passed[@]}"
 	if [ "${#failures[@]}" -gt 0 ]; then
 	    printf "\nFAIL:"; printf ' %s;' "${failures[@]}"
 	fi
 
 	printf "\n\n\033[40;32m test end with %d failed tests\033[0m\n\n" "${#failures[@]}"
-	exit "${#failures[@]}"
 }
 
 test_firmware-presence()


### PR DESCRIPTION
Convenient when seeing a failure. Sample output:

```
2021-09-10 22:27:37 UTC Sub-Test: [INFO] Test Result: PASS!
^C

PASS: firmware-presence; speaker; firmware-load;
FAIL: sof-logger;

 test end with 1 failed tests

Testing was INTERRUPTED, results are incomplete!
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>