### PR TITLE
[SKIP CI] GitHub Actions: Use builtin Python and move dependencies to python-deps.txt

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -42,8 +42,7 @@ jobs:
         run: sudo apt-get -y update
 
       - name: get python libs
-        # FIXME: apt-get succeeds but 'import numpy' still fails!?
-        run: sudo apt-get -y install python3-numpy python3-scipy pylint
+        run: sudo apt-get -y install $(cat python-deps.txt)
 
       - name: pylint
         env:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       # :-( https://github.community/t/support-for-yaml-anchors/16128
       - {uses: actions/checkout@v2, with: {fetch-depth: 0}}
-      - uses: actions/setup-python@v2
+      - run: python --version
 
       # Package index is "out of date by design"
       # https://github.com/actions/virtual-environments/issues/1757

--- a/python-deps.txt
+++ b/python-deps.txt
@@ -1,0 +1,3 @@
+python3-numpy
+python3-scipy
+pylint


### PR DESCRIPTION
* Use builtin Python instead of [setup-python](https://github.com/marketplace/actions/setup-python) since we use apt to install packages.
* Move the dependencies data to python-deps.txt, so if someone wants to set up a system, they don't need to look at GitHub Actions to find dependencies. 

See also: <https://github.com/thesofproject/sof-test/pull/755#discussion_r700766961> and <https://github.com/thesofproject/sof-test/pull/755#discussion_r700421012>

Signed-off-by: Yongan Lu <yongan.lu@intel.com>