### PR TITLE
sof-kernel-log-check: filter i915 DRM errors

### DIFF
--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -186,6 +186,9 @@ ignore_str="$ignore_str"'|i915 0000:00:02\.0: \[drm\] \*ERROR\* TC cold unblock 
 ignore_str="$ignore_str"'|i915 0000:00:02\.0: \[drm\] \*ERROR\* TC cold block failed'
 # An error observed on ICL RVP: "[drm] *ERROR* CPU pipe A FIFO underrun"
 ignore_str="$ignore_str"'|\[drm\] \*ERROR\* CPU pipe . FIFO underrun'
+# BugLink: https://github.com/thesofproject/sof-test/issues/753
+# see also: https://github.com/thesofproject/linux/blob/57a88a71b411ff44a7568db05226ec2727bf91c1/drivers/gpu/drm/i915/display/intel_crtc.c#L580
+ignore_str="$ignore_str"'|\[drm\] \*ERROR\* Atomic update failure on pipe . \(start=[0-9]+ end=[0-9]+\) time [0-9]+ us, min [0-9]+, max [0-9]+, scanline start [0-9]+, end [0-9]+'
 
 # DRM issues with kernel v5.10-rc1 https://github.com/thesofproject/linux/pull/2538
 ignore_str="$ignore_str"'|\[drm:drm_dp_send_link_address \[drm_kms_helper\]\] \*ERROR\* Sending link address failed with -5'


### PR DESCRIPTION
Filter i915 DRM errors like:
```
[  945.548337] kernel: i915 0000:00:02.0: [drm] *ERROR* Atomic update failure on pipe A (start=184 end=185) time 149 us, min 1073, max 1079, scanline start 1071, end 1081
```

This i915 DRM errors won't affect the audio use-cases.
Need to ignore them.

see also: <https://github.com/thesofproject/linux/blob/57a88a71b411ff44a7568db05226ec2727bf91c1/drivers/gpu/drm/i915/display/intel_crtc.c#L580>

fixes #753 and #764 

Signed-off-by: Yongan Lu <yongan.lu@intel.com>