### PR TITLE
hijack.sh: print FAIL on missing logfile to avoid long CI timeout

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -62,16 +62,25 @@ function func_exit_handler()
             sudo pkill -KILL "$loggerBin"
             exit_status=1
         fi
-        # logfile is set in a different file: lib.sh
+
+        # $logfile is defined in a different file (lib.sh)
         # shellcheck disable=SC2154
-        wcLog=$(wc -l "$logfile")
-        dlogi "nlines=$wcLog"
-        local nlines; nlines=$(wc -l < "$logfile")
-        # Line 1 is the header
-        if [ "$nlines" -le 1 ]; then
-            dloge "Empty logger trace"
+        if test -e "$logfile"; then
+
+            wcLog=$(wc -l "$logfile") # show both line count and filename
+            dlogi "nlines=$wcLog"
+
+            local nlines; nlines=$(wc -l < "$logfile") # line count only
+            # The first line is the sof-logger header
+            if [ "$nlines" -le 1 ]; then
+                dloge "Empty logger trace"
+                exit_status=1
+            fi
+        else
+            dloge "Log file not found: $logfile"
             exit_status=1
         fi
+
     fi
 
     if [[ "$KERNEL_CHECKPOINT" =~ ^[0-9]{10} ]]; then


### PR DESCRIPTION
For reasons beyond the scope of this commit, our Jenkins CI does not
know when a test script has finished to run. Instead of checking the
exit status like a normal test runner it waits for a "FAIL" or "PASS" or
"N/A" string to be printed. When the test aborts without printing one of
these, Jenkins falls back on a fairly long timeout - per test.

This unusual approach has been causing issues with `set -e` (#312)

In some relatively rare but possible failures the DSP or the drivers do
not load at all, examples:

https://sof-ci.01.org/sofpr/PR4782/build10387/devicetest/
https://sof-ci.01.org/sofpr/PR4766/build10353/devicetest/
https://sof-ci.01.org/sofpr/PR4768/build10348/devicetest/

In that case the $logFile is not found and many tests abort without
printing FAIL.

This commit prints FAIL when $logfile is missing and avoids the many
per-test Jenkins timeouts.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>