### PR TITLE
check-sof-logger: disable dma_nudge() workaround for stuck DMA issue 4333

### DIFF
--- a/test-case/check-sof-logger.sh
+++ b/test-case/check-sof-logger.sh
@@ -188,7 +188,8 @@ main()
 
             # Workaround for DMA trace bug
             # https://github.com/thesofproject/sof/issues/4333
-            if [ "$f" = data ]; then
+#            if [ "$f" = data ]; then
+            if false; then # let's check whether #4333 was finally fixed by #4763
                 dloge "Empty or stuck DMA trace? Let's try to nudge it."
                 dloge '  vv  Workaround for SOF issue 4333  vv'
                 local second_chance="$LOG_ROOT/logger.dma_trace_bug_4333.txt"


### PR DESCRIPTION
Looks like https://github.com/thesofproject/sof/pull/4763 might have
fixed it.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>