### PR TITLE
sof_remove.sh: Update SOF client driver names

### DIFF
--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -157,6 +157,8 @@ remove_module snd_soc_intel_sof_maxim_common
 #-------------------------------------------
 remove_module snd_sof_probes
 remove_module snd_sof_ipc_test
+remove_module snd_sof_ipc_flood_test
+remove_module snd_sof_ipc_msg_injector
 remove_module snd_sof_dma_trace
 
 # snd_sof_nocodec dependencies re-ordered


### PR DESCRIPTION
A new client is added for message injection: 'snd_sof_ipc_msg_injector'
the snd_sof_ipc_test is renamed to 'snd_sof_ipc_flood_test'

In the latest version of the SOF client series.

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>