### PR TITLE
verify-kernel-boot-log: check if the device's time is in sync

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -409,3 +409,19 @@ print_module_params()
     grep -H ^ /sys/module/*sof*/parameters/*
     echo "----------------------------------------"
 }
+
+# check if NTP Synchronized, if so return 0 otherwise return 1
+check_ntp_sync()
+{
+    # Check this device time is NTP Synchronized.
+    timedatectl show | grep -q "NTPSynchronized=yes"
+}
+
+re_enable_ntp_sync()
+{
+    # disable synchronization first
+    sudo timedatectl set-ntp false
+
+    # enable ntp sync. This will trigger initial synchronization to time server
+    sudo timedatectl set-ntp true
+}

--- a/test-case/verify-kernel-boot-log.sh
+++ b/test-case/verify-kernel-boot-log.sh
@@ -23,4 +23,21 @@ disable_kernel_check_point
 
 print_module_params
 
+# Check this device time is NTP Synchronized
+if check_ntp_sync; then
+    printf '\nTime Check: NTP Synchronized\n'
+else
+    timedatectl show
+    # try to disable/enable NTP once, this will trigger ntp sync twice,
+    # before stopping ntp and after enabling ntp.
+    re_enable_ntp_sync
+
+    if check_ntp_sync; then
+        printf '\nTime Check: NTP Synchronized after re-enabling ntp sync\n'
+    else
+        # If NTP is not synchronized, let this test fail
+        die "Time Check: NTP NOT Synchronized"
+    fi
+fi
+
 sof-kernel-log-check.sh


### PR DESCRIPTION
If device time is not accurate, let this test fail.
All of test devices are supposed to be NTP Synchronized. Power cycling
a device with no internal battery and old coin battery may cause
time out of sync.

Signed-off-by: Fred Oh <fred.oh@linux.intel.com>