### PR TITLE
sof_remove.sh: remove snd_soc_rt5682s module

### DIFF
--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -202,6 +202,7 @@ remove_module snd_soc_rt5677_spi
 remove_module snd_soc_rt5682_sdw
 remove_module snd_soc_rt5682_i2c
 remove_module snd_soc_rt5682
+remove_module snd_soc_rt5682s
 remove_module snd_soc_rl6231
 remove_module snd_soc_rl6347a
 


### PR DESCRIPTION
Found module removing error in TGL Debin/Voxel with I2S RT5682 codec.

RMMOD	snd_soc_core
rmmod: ERROR: Module snd_soc_core is in use by: snd_soc_rt5682s

snd_soc_rt5682s is used by snd_soc_rt5682, so remove it
after snd_soc_rt5682.

Module                  Size  Used by
snd_soc_rt5682s        98304  1 snd_soc_sof_rt5682

Signed-off-by: Fred Oh <fred.oh@linux.intel.com>