### PR TITLE
sof_remove.sh: Add snd_pcm_dmaengine to the list of modules to be rem…

### DIFF
--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -245,5 +245,6 @@ remove_module snd_hda_codec
 remove_module snd_hda_core
 remove_module snd_hwdep
 remove_module snd_compress
+remove_module snd_pcm_dmaengine
 remove_module snd_pcm
 


### PR DESCRIPTION
…oved

Recently I have encountered that on distro kernel (5.14.10-artix1-1)
the sof_remove.sh fails:
RMMOD   snd_pcm
rmmod: ERROR: Module snd_pcm is in use by: snd_pcm_dmaengine
snd_ctl_led            24576  0
ledtrig_audio          16384  3 snd_ctl_led,dell_wmi,dell_laptop
snd_pcm_dmaengine      16384  0
snd_pcm               151552  1 snd_pcm_dmaengine
snd_timer              45056  1 snd_pcm
snd                   114688  3 snd_ctl_led,snd_timer,snd_pcm
soundcore              16384  2 snd_ctl_led,snd
drm_kms_helper        303104  1 i915
cec                    73728  2 drm_kms_helper,i915
drm                   589824  9 drm_kms_helper,i915,ttm
syscopyarea            16384  1 drm_kms_helper
sysfillrect            16384  1 drm_kms_helper
sysimgblt              16384  1 drm_kms_helper
fb_sys_fops            16384  1 drm_kms_helper
/home/sof/work/SOF/sof-test/tools/kmod/sof_remove.sh FAILED

Remove the snd_pcm_dmaengine before snd_pcm to fix this.

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>