### PR TITLE
verify-kernel-kernel-log: skip ADL platforms 

### DIFF
--- a/test-case/verify-kernel-boot-log.sh
+++ b/test-case/verify-kernel-boot-log.sh
@@ -27,6 +27,13 @@ main()
 
     ntp_check
 
+    platform=$(sof-dump-status.py -p)
+    case "$platform" in
+        adl)
+            skip_test "$platform is under active development"
+            ;;
+    esac
+
     sof-kernel-log-check.sh
 }
 


### PR DESCRIPTION
2 commits:
- move all the code to functions. Zero functional change
- Don't inspect kernel boot logs on ADL.

You _really_ want to review the commits separately