### PR TITLE
lib.sh: add TGLH_RVP_NOCODEC_ZEPHYR to CAVS_NOCODEC group

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -434,7 +434,7 @@ set_alsa_settings()
     local PNAME="${1%_ZEPHYR}"
     dlogi "Run alsa setting for $PNAME"
     case $PNAME in
-        APL_UP2_NOCODEC | CML_RVP_NOCODEC | JSL_RVP_NOCODEC | TGLU_RVP_NOCODEC | ADLP_RVP_NOCODEC)
+        APL_UP2_NOCODEC | CML_RVP_NOCODEC | JSL_RVP_NOCODEC | TGLU_RVP_NOCODEC | ADLP_RVP_NOCODEC | TGLH_RVP_NOCODEC_ZEPHYR)
             # common nocodec alsa settings
             "$SCRIPT_HOME"/alsa_settings/CAVS_NOCODEC.sh
         ;;


### PR DESCRIPTION
TGLH_RVP_NOCODEC_ZEPHYR shares same alsa settings with CAVS_NOCODEC.sh.

Signed-off-by: Fred Oh <fred.oh@linux.intel.com>

Found a missed platform, TGLH_RVP_NOCODEC_ZEPHYR, to run alsa setting before alsabat testing.
Internal daily test 7618.