### PR TITLE
tplgtool2: Hide core info when unspecified in topology

### DIFF
--- a/tools/tplgtool2.py
+++ b/tools/tplgtool2.py
@@ -774,8 +774,9 @@ class TplgGraph:
 
     def _display_node_label(self, name: str, widget: Container):
         sublabel = ""
-        if self.show_core == 'always' or (self.show_core == 'auto' and self._tplg.is_multicore):
-            sublabel += f'<BR ALIGN="CENTER"/><SUB>core:{GroupedTplg.get_core_id(widget, default=0)}</SUB>'
+        core = GroupedTplg.get_core_id(widget)
+        if core is not None and (self.show_core == 'always' or (self.show_core == 'auto' and self._tplg.is_multicore)):
+            sublabel += f'<BR ALIGN="CENTER"/><SUB>core:{core}</SUB>'
         return f'<{name}{sublabel}>'
 
     def draw(self, outfile: str, outdir: str = '.', file_format: str = "png", live_view: bool = False):


### PR DESCRIPTION
Hide core info instead of fallback to "core:0" when it is unspecified in
topology, because the default "0" could be misleading for some
components like Buffer which are under the pipeline with the non-0 core.

example for `sof-tgl-nocodec-ci`:
![sof-tgl-nocodec-ci](https://user-images.githubusercontent.com/87001168/139028116-0d2600d3-d7b3-4f31-befc-a407923e029f.png)


Signed-off-by: Yongan Lu <yongan.lu@intel.com>