### PR TITLE
multiple-pause-resume: rename duplicate 'loop' option

### DIFF
--- a/test-case/multiple-pause-resume.sh
+++ b/test-case/multiple-pause-resume.sh
@@ -32,7 +32,7 @@ OPT_HAS_ARG['l']=1         OPT_VAL['l']=5
 OPT_NAME['c']='count'    OPT_DESC['c']='combine test pipeline count'
 OPT_HAS_ARG['c']=1         OPT_VAL['c']=2
 
-OPT_NAME['r']='loop'     OPT_DESC['r']='pause resume repeat count'
+OPT_NAME['r']='repeat'     OPT_DESC['r']='pause resume repeat count'
 OPT_HAS_ARG['r']=1         OPT_VAL['r']=5
 
 # pause/resume interval will be a random value bounded by the min and max values below


### PR DESCRIPTION
'l' and 'r' use the same 'loop' long option:

-r parameter |  --loop parameter
	pause resume repeat count
	Default Value: 5
-l parameter |  --loop parameter
	loop count
	Default Value: 5

use '--repeat' for 'r'

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>