### PR TITLE
[SKIP CI] lib.sh: remove _ZEPHYR postfix

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -434,7 +434,7 @@ set_alsa_settings()
     local PNAME="${1%_ZEPHYR}"
     dlogi "Run alsa setting for $PNAME"
     case $PNAME in
-        APL_UP2_NOCODEC | CML_RVP_NOCODEC | JSL_RVP_NOCODEC | TGLU_RVP_NOCODEC | ADLP_RVP_NOCODEC | TGLH_RVP_NOCODEC_ZEPHYR)
+        APL_UP2_NOCODEC | CML_RVP_NOCODEC | JSL_RVP_NOCODEC | TGLU_RVP_NOCODEC | ADLP_RVP_NOCODEC | TGLH_RVP_NOCODEC)
             # common nocodec alsa settings
             "$SCRIPT_HOME"/alsa_settings/CAVS_NOCODEC.sh
         ;;


### PR DESCRIPTION
In the beginning of the function, _ZEPHYR is removed from PNAME.
ZEPHYR and non-ZEPHYR platform share same alsa settings. _ZEPHYR postfix
is not required.

Signed-off-by: Fred Oh <fred.oh@linux.intel.com>

This is completely my bad, I failed to read my own code.