### PR TITLE
alsa_setting: revise the model name for TGLH_RVP_NOCODEC_ZEPHYR

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -434,7 +434,7 @@ set_alsa_settings()
     local PNAME="${1%_ZEPHYR}"
     dlogi "Run alsa setting for $PNAME"
     case $PNAME in
-        APL_UP2_NOCODEC | CML_RVP_NOCODEC | JSL_RVP_NOCODEC | TGLU_RVP_NOCODEC | ADLP_RVP_NOCODEC | TGLH_RVP_NOCODEC_ZEPHYR)
+        APL_UP2_NOCODEC | CML_RVP_NOCODEC | JSL_RVP_NOCODEC | TGLU_RVP_NOCODEC | ADLP_RVP_NOCODEC | TGLH_RVP_NOCODEC)
             # common nocodec alsa settings
             "$SCRIPT_HOME"/alsa_settings/CAVS_NOCODEC.sh
         ;;


### PR DESCRIPTION
we need to revise the TGLH_RVP_NOCODEC_ZEPHYR to TGLH_RVP_NOCODEC
in PNAME case list. For zephyr platfroms, the keyword _zephyr have
been removed from the platfrom name, otherwise it will look for the
script as .sh instead of CAVS_NOCODEC.sh.

Signed-off-by: Zhang Keqiao <keqiao.zhang@intel.com>