### PR TITLE
logging: add new SOF_LOGS_BASE feature 

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,3 +178,7 @@ Note PAM security configuration is complex and
 distribution-specific. This was tested only on Ubuntu 20.04. See `man
 pam.d` or one of the PAM guides available on the Internet. Be careful
 not to make your system vulnerable.
+
+On systems using auditd, sof-test will also generate a huge amount of
+log. If you need to keep `audit`, check `man auditctl` to find how to
+filter out sudo noise.

--- a/case-lib/logging_ctl.sh
+++ b/case-lib/logging_ctl.sh
@@ -44,15 +44,20 @@ _func_log_cmd()
 # without setting up the LOG_ROOT keyword, now create the log directory for it
 _func_log_directory()
 {
-    if [ "$LOG_ROOT" ]; then
+    # LOG_ROOT is the top of a single test run. SOF_LOGS_BASE is higher
+    # up and for all tests and all runs.
+    if [ -n "$LOG_ROOT" ]; then
         mkdir -p "$LOG_ROOT"
         return
     fi
 
+    # default value
+    : "${SOF_LOGS_BASE:=${SCRIPT_HOME}}"
+
     local case_name log_dir timetag
     case_name=$(basename "$SCRIPT_NAME")
     case_name=${case_name%.*}
-    log_dir="$SCRIPT_HOME/logs/$case_name"
+    log_dir="${SOF_LOGS_BASE}/logs/$case_name"
     timetag=$(date +%F"-"%T)"-$RANDOM"
     mkdir -p "$log_dir/$timetag"
     # now using the last link for the time tag

--- a/tools/sof-get-default-tplg.sh
+++ b/tools/sof-get-default-tplg.sh
@@ -8,5 +8,5 @@
 # sof-apl-pcm512x.tplg will be returned
 #
 
-tplg_file=$(journalctl -k |grep -i topology |awk -F ':' '/tplg/ {print $NF;}'|tail -n 1)
+tplg_file=$(sudo journalctl -k |grep -i topology |awk -F ':' '/tplg/ {print $NF;}'|tail -n 1)
 [[ "$tplg_file" ]] && basename "$tplg_file" || echo ""


### PR DESCRIPTION
\+ 2 other minor fixes

Using root to write inside a regular user directory (sof-test) is not
great. It creates files difficult to remove and it does not work across
network filesystems. Don't change the default location but add a new
SOF_LOGS_BASE feature.