### PR TITLE
hijack.sh: don't return error when test case is already skip

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -72,7 +72,8 @@ function func_exit_handler()
 
             local nlines; nlines=$(wc -l < "$logfile") # line count only
             # The first line is the sof-logger header
-            if [ "$nlines" -le 1 ]; then
+            # Don't override exit_status if already SKIPped test case
+            if ([ "$nlines" -le 1 ] && [ $exit_status -ne 2 ]); then
                 dloge "Empty logger trace"
                 exit_status=1
             fi


### PR DESCRIPTION
Empty logger in skipped test is expected. Don't return error
because sof-logger is empty in skipped test.

Signed-off-by: Fred Oh <fred.oh@linux.intel.com>