### PR TITLE
lib.sh: fix sudo "$loggerCmd" quoting

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -140,10 +140,10 @@ func_lib_start_log_collect()
         return 3
     fi
 
-    local loggerCmd="$SOFLOGGER $logopt -l $ldcFile -o $logfile"
-    dlogi "Starting $loggerCmd"
+    local loggerCmd=("$SOFLOGGER" "$logopt" -l "$ldcFile" -o "$logfile")
+    dlogi "Starting ${loggerCmd[*]}"
     # Cleaned up by func_exit_handler() in hijack.sh
-    sudo "$loggerCmd" &
+    sudo "${loggerCmd[@]}" &
 }
 
 # Calling this function is often a mistake because the error message


### PR DESCRIPTION
sudo "$loggerCmd" works only with our redefined sudo function. Replace
it with an array-based and properly quoted sudo "${loggerCmd[@]}" that
works with any sudo.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>