### PR TITLE
check-kmod-load-unload: use TOPDIR, don't rely on PATH 

### DIFF
--- a/test-case/check-kmod-load-unload.sh
+++ b/test-case/check-kmod-load-unload.sh
@@ -22,8 +22,11 @@ set -e
 ##    check kernel log and find no errors
 ##
 
+TOPDIR="$(dirname "${BASH_SOURCE[0]}")"/..
+TOPDIR=$(cd "$TOPDIR" && pwd)
+
 # shellcheck source=case-lib/lib.sh
-source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
+source "${TOPDIR}"/case-lib/lib.sh
 
 OPT_NAME['l']='loop_cnt'
 OPT_DESC['l']='remove / insert module loop count -- per device'

--- a/test-case/check-kmod-load-unload.sh
+++ b/test-case/check-kmod-load-unload.sh
@@ -74,7 +74,7 @@ do
     done
 
     dlogi "run kmod/sof-kmod-remove.sh"
-    sudo sof_remove.sh || die "remove modules error"
+    "$TOPDIR"/tools/kmod/sof_remove.sh || die "remove modules error"
 
     ## - 1a: check for errors after removal
     dlogi "checking for general errors after kmod unload with sof-kernel-log-check tool"
@@ -83,7 +83,7 @@ do
 
     setup_kernel_check_point
     dlogi "run kmod/sof_insert.sh"
-    sudo sof_insert.sh || die "insert modules error"
+    "$TOPDIR"/tools/kmod/sof_insert.sh || die "insert modules error"
 
     ## - 2a: check for errors after insertion
     dlogi "checking for general errors after kmod insert with sof-kernel-log-check tool"

--- a/tools/kmod/sof_insert.sh
+++ b/tools/kmod/sof_insert.sh
@@ -10,6 +10,9 @@ insert_module() {
         printf 'MODPROBE\t%s\t\t' "$MODULE"
         printf '%s ' "$@"
         printf '\n'
+        # If sudo is slow, it's probably because the 'account' service
+        # of the pam_unix.so module. Its version 1.5.1-7.fc34 tries to
+        # close() all file descriptors from 65535 to 0.
         sudo modprobe "$MODULE" "$@"
     else
         printf 'SKIP    \t%s \t(not in tree)\n' "$MODULE"


### PR DESCRIPTION
This was apparently the only test in run-all-tests.sh that required a PATH change.
