### PR TITLE
lib.sh: re-enable sof-logger for Zephyr

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -397,7 +397,7 @@ is_zephyr()
 
 logger_disabled()
 {
-    [[ ${OPT_VAL['s']} -eq 0 ]] || is_zephyr
+    [[ ${OPT_VAL['s']} -eq 0 ]]
 }
 
 print_module_params()


### PR DESCRIPTION
check-sof-logger was re-enabled for Zephyr in commit 56db25953967 and it
passed the daily tests. Re-enable logging for all tests when using
Zephyr.

Partial revert of 325e57244e2 ("logger: disable sof-logger for zephyr")

Signed-off-by: Marc Herbert <marc.herbert@intel.com>