### PR TITLE
lib.sh: switch is_zephyr() to look for zephyr strings in .ldc

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -390,9 +390,15 @@ disable_kernel_check_point()
 
 is_zephyr()
 {
-    local manifest=/etc/sof/manifest.txt
-    test -e "$manifest" || return 1
-    jq '.version.firmwareType' "$manifest" | grep "zephyr"
+    local ldcFile
+    ldcFile=$(find_ldc_file) || {
+        dloge '.ldc file not found, assuming XTOS firmware'
+        return 1
+    }
+    local znum
+    znum=$(strings "$ldcFile" | grep -c -i zephyr)
+    # As of Nov. 2021, znum ~= 30 for Zephyr and 0 for XTOS
+    test "$znum" -gt 10
 }
 
 logger_disabled()


### PR DESCRIPTION
Now that the sof-logger is well tested with Zephyr, change the
is_zephyr() test to count the number of "zephyr" strings in the .ldc
dictionary file. The previous test was based on /etc/sof/manifest.txt
which is a CI-only file. This probably removes a dependency on 'jq' too.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>