### PR TITLE
case-lib: add support for no logger mode

### DIFF
--- a/case-lib/config.sh
+++ b/case-lib/config.sh
@@ -67,3 +67,7 @@ SUDO_LEVEL=${SUDO_LEVEL:-}
 # in CI, which is controlled by sof-framework. In manual run, user can
 # override the default value.
 SOF_TEST_INTERVAL=${SOF_TEST_INTERVAL:-5}
+
+# Logger is not always supported, we want sof-test to run even
+# without logger.
+LOGGER_MODE=${LOGGER_MODE:-true}

--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -397,7 +397,7 @@ is_zephyr()
 
 logger_disabled()
 {
-    [[ ${OPT_VAL['s']} -eq 0 ]]
+    [[ ${OPT_VAL['s']} -eq 0 ]] || [[  "$LOGGER_MODE" == "false" ]]
 }
 
 print_module_params()


### PR DESCRIPTION
Logger is not supported for firmware without
ldc file, add a new mode to test without
sof-logger.

Signed-off-by: Chao Song <chao.song@linux.intel.com>