### PR TITLE
lib.sh: fix etrace collection on failure (recent regression)

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -142,7 +142,9 @@ func_lib_start_log_collect()
         return 3
     fi
 
-    local loggerCmd=("$SOFLOGGER" "$logopt" -l "$ldcFile" -o "$logfile")
+    # The logger does not like empty '' arguments and $logopt can be
+    # shellcheck disable=SC2206
+    local loggerCmd=("$SOFLOGGER" $logopt -l "$ldcFile" -o "$logfile")
     dlogi "Starting ${loggerCmd[*]}"
     # Cleaned up by func_exit_handler() in hijack.sh
     sudo "${loggerCmd[@]}" &


### PR DESCRIPTION
Fixes failures to collect etrace on failure. It goes like this:
```
UTC [INFO] Starting sof-logger '' -l /lib/firmware/intel/sof/sof-apl.ldc
 -o sof-test/logs/check-runtime-pm-status/2021-12-02-23:49:42-22493/etrace.txt
error: Unused parameter ''
Usage sof-logger <option(s)> <file(s)>
```
This happens when $logopt is empty.

Fixes recent regression introduced by commit 814b904acfca6 ("lib.sh: fix
sudo "$loggerCmd" quoting")

Signed-off-by: Marc Herbert <marc.herbert@intel.com>