### PR TITLE
kmod: sof_remove.sh: fix SKL/KBL tests

### DIFF
--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -79,6 +79,7 @@ remove_module snd_usb_audio
 #-------------------------------------------
 remove_module snd_hda_intel
 remove_module snd_sof_pci_intel_tng
+remove_module snd_sof_pci_intel_skl
 remove_module snd_sof_pci_intel_apl
 remove_module snd_sof_pci_intel_cnl
 remove_module snd_sof_pci_intel_icl


### PR DESCRIPTION
Missing dependency causing errors

RMMOD	snd_sof_intel_hda_common
rmmod: ERROR: Module snd_sof_intel_hda_common is in use by:
snd_sof_pci_intel_skl

SKIP	snd_sof_acpi  	not loaded
RMMOD	snd_sof_pci
rmmod: ERROR: Module snd_sof_pci is in use by:
snd_sof_intel_hda_common snd_sof_pci_intel_skl

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>