### PR TITLE
hijack.sh: disable trace filter config "nudge" for Zephyr 

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -37,12 +37,13 @@ function func_exit_handler()
         # logs relevant to the current test.
         # See DMA issue https://github.com/thesofproject/sof/issues/4333
         # We must use a component that is available everywhere: pga
+        local ldcf; ldcf=$(find_ldc_file)
         for i in 1 2; do
             # Running this twice makes it very easy to observe the stuck
             # lines bug: the "ipc" logs corresponding to this -F command
             # will appear _only once_ at the end of the slogger.txt DMA
             # trace!
-            sudo "$SOFLOGGER" -l "$(find_ldc_file)" -F info=pga > /dev/null ||
+            sudo "$SOFLOGGER" -l "${ldcf}" -F info=pga > /dev/null ||
                 test "$exit_status" -ne 0 || exit_status=1
         done
         # We _also_ need to wait for the trace_work() thread to run;

--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -38,7 +38,10 @@ function func_exit_handler()
         # See DMA issue https://github.com/thesofproject/sof/issues/4333
         # We must use a component that is available everywhere: pga
         local ldcf; ldcf=$(find_ldc_file)
-        for i in 1 2; do
+
+        # Zephyr does not support trace configuration, see
+        # https://github.com/thesofproject/sof/issues/5032
+        is_zephyr || for i in 1 2; do
             # Running this twice makes it very easy to observe the stuck
             # lines bug: the "ipc" logs corresponding to this -F command
             # will appear _only once_ at the end of the slogger.txt DMA


### PR DESCRIPTION
Zephyr does not support trace configuration, see
thesofproject/sof#5032

5032 is not closed as "wontfix" yet but we need to urgently stop
polluting many Zephyr test results only because some relatively minor
feature is missing.

Moreover the test failures are very confusing because they happen only
when two tests are run immediately one after the other; quickly enough
for the kernel error 'error: fail in sof_ipc_trace_update_filter -22' to
appear in the results of the _next_ test. Tests are not affected by
their own errors because the filter update happens in the "tearDown"
phase, _after_ the PASS/FAIL decision has been made.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>