### PR TITLE
sof-get-default-tplg: use faster grep feature provided by journalctl

### DIFF
--- a/tools/sof-get-default-tplg.sh
+++ b/tools/sof-get-default-tplg.sh
@@ -8,5 +8,5 @@
 # sof-apl-pcm512x.tplg will be returned
 #
 
-tplg_file=$(sudo journalctl -k |grep -i topology |awk -F ':' '/tplg/ {print $NF;}'|tail -n 1)
+tplg_file=$(sudo journalctl -k -g topology |awk -F ':' '/tplg/ {print $NF;}'|tail -n 1)
 [[ "$tplg_file" ]] && basename "$tplg_file" || echo ""


### PR DESCRIPTION
Much faster than piping the entire logs to an external grep process;
down from 2+ seconds to 0.5s on my system.

Also makes test duration less variable, which among others makes
SOF_TEST_INTERVAL more deterministic.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>