### PR TITLE
hijack.sh: read from -i /dev/null when changing the log level

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -46,7 +46,7 @@ function func_exit_handler()
             # lines bug: the "ipc" logs corresponding to this -F command
             # will appear _only once_ at the end of the slogger.txt DMA
             # trace!
-            sudo "$SOFLOGGER" -l "${ldcf}" -F info=pga > /dev/null ||
+            sudo "$SOFLOGGER" -l "${ldcf}" -F info=pga -i /dev/null -o /dev/null ||
                 test "$exit_status" -ne 0 || exit_status=1
         done
         # We _also_ need to wait for the trace_work() thread to run;


### PR DESCRIPTION
sof-logger inconveniently does not allow changing the log level without
reading some logs at the same time. We've always redirected these logs
to /dev/null but Zephyr uses a different etrace format that can cause
errors on stderr and we don't want to discard stderr because we never
want to ignore ALL errors in test code. We can't switch to the DMA trace
either because reading the DMA trace never stops.

So, read the trace from neither the DMA nor the shared memory but from
/dev/null instead.

Keep redirecting output to /dev/null too because we still don't want to
see the banner either.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>