### PR TITLE
print_modules_params: don't SKIP the test when driver is not loaded

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -436,10 +436,10 @@ logger_disabled()
 print_module_params()
 {
     echo "--------- Printing module parameters ----------"
-    grep -H ^ /sys/module/snd_intel_dspcfg/parameters/*
+    grep -H ^ /sys/module/snd_intel_dspcfg/parameters/* || true
 
     # for all the *sof* modules
-    grep -H ^ /sys/module/*sof*/parameters/*
+    grep -H ^ /sys/module/*sof*/parameters/* || true
     echo "----------------------------------------"
 }
 


### PR DESCRIPTION
grep return code is '2' when files are missing. '2' is also the sof-test
convention for skipping tests.
When using print_modules_params in a test with set -e, this causes the
test to be SKIPped when the driver is not loaded.

Simply ignore all grep errors in this function; it's not the job of a
"print_" function to fail. Missing audio is already caught in many other
places.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>