### PR TITLE
verify-kernel-boot-log: add boot time and very start of journalctl

### DIFF
--- a/test-case/verify-kernel-boot-log.sh
+++ b/test-case/verify-kernel-boot-log.sh
@@ -20,6 +20,9 @@ source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
 main()
 {
+    printf 'System booted at: '; uptime -s
+    journalctl -b | head -n 3
+
     func_opt_parse_option "$@"
     disable_kernel_check_point
 


### PR DESCRIPTION
Show for how long the system has been up.

Together with #825, this will show whether NTP sync or any other daemon
had enough time to start.

Sample output:
```
System booted at: 2021-12-09 18:28:32
-- Logs begin at Mon 2021-08-30 11:42:24 PDT, end at Thu 2021-12-09 18:37:18 PST. --
Dec 09 18:28:37 up2 kernel: Linux version 9.9.9-rc9softest  (gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0, GNU ld ....
Dec 09 18:28:37 up2 kernel: Command line: BOOT_IMAGE=/vmlinuz-9.9.9-rc9softest root=/dev/mapper/ubuntu--vg-root ro
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>