### PR TITLE
check-sof-logger: print stderr output when etrace fails to start

### DIFF
--- a/test-case/check-sof-logger.sh
+++ b/test-case/check-sof-logger.sh
@@ -100,8 +100,10 @@ run_loggers()
     dlogi "Trying to get the etrace mailbox ..."
     dlogc \
     "sudo $loggerBin    -f 3 -l  $ldcFile  2>  $etrace_stderr_file  -o  $etrace_file"
-    sudo "$loggerBin"   -f 3 -l "$ldcFile" 2> "$etrace_stderr_file" -o "$etrace_file" ||
+    sudo "$loggerBin"   -f 3 -l "$ldcFile" 2> "$etrace_stderr_file" -o "$etrace_file" || {
         etrace_exit=$?
+        cat "$etrace_stderr_file" >&2
+    }
 
     printf '\n'
 


### PR DESCRIPTION
We can't even start we want to provide feedback right away (thanks to
set -e) and not rely on distant and elusive output post-processing.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>