### PR TITLE
Revert "hijack.sh: disable trace filter config "nudge" for Zephyr"

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -38,10 +38,7 @@ function func_exit_handler()
         # See DMA issue https://github.com/thesofproject/sof/issues/4333
         # We must use a component that is available everywhere: pga
         local ldcf; ldcf=$(find_ldc_file)
-
-        # Zephyr does not support trace configuration, see
-        # https://github.com/thesofproject/sof/issues/5032
-        is_zephyr || for i in 1 2; do
+        for i in 1 2; do
             # Running this twice makes it very easy to observe the stuck
             # lines bug: the "ipc" logs corresponding to this -F command
             # will appear _only once_ at the end of the slogger.txt DMA


### PR DESCRIPTION
This reverts commit 905bd1f33044c86db0d30123a6d4a9930179ff76.

https://github.com/thesofproject/sof/issues/5032 should be fixed now;
let's see that.