### PR TITLE
kmod: add kmod support for snd_soc_max98390

### DIFF
--- a/tools/kmod/sof_insert.sh
+++ b/tools/kmod/sof_insert.sh
@@ -54,6 +54,7 @@ insert_module snd_soc_max98090
 insert_module snd_soc_max98373
 insert_module snd_soc_max98373_i2c
 insert_module snd_soc_max98373_sdw
+insert_module snd_soc_max98390
 
 insert_module snd_soc_rt700
 insert_module snd_soc_rt711

--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -216,6 +216,7 @@ remove_module snd_soc_max98357a
 remove_module snd_soc_max98373_sdw
 remove_module snd_soc_max98373_i2c
 remove_module snd_soc_max98373
+remove_module snd_soc_max98390
 
 remove_module snd_soc_hdac_hda
 remove_module snd_soc_hdac_hdmi


### PR DESCRIPTION
This codec driver is used by one ADLP Chrome device. Fix #834.

Signed-off-by: Keqiao Zhang <keqiao.zhang@intel.com>