### PR TITLE
env-check.sh: fix check for octave packages 

### DIFF
--- a/env-check.sh
+++ b/env-check.sh
@@ -4,6 +4,16 @@ set -e
 
 mydir=$(cd "$(dirname "$0")"; pwd)
 
+ubuntu_warning()
+{
+cat <<EOF
+
+    Disclaimer: this script is tested only on a somewhat recent Ubuntu version.
+    On other distributions your mileage may vary.
+
+EOF
+}
+
 # enable dynamic debug logs for SOF modules
 DYNDBG="/etc/modprobe.d/sof-dyndbg.conf"
 
@@ -44,6 +54,16 @@ func_check_exec_binary() {
         check_res=1
     fi
 }
+
+main()
+{
+    ubuntu_warning
+}
+
+main "$@"
+
+# All code should be moved to a function eventually:
+# https://github.com/thesofproject/sof-test/issues/740
 
 out_str="" check_res=0
 printf "Checking for some OS packages:\t\t"

--- a/env-check.sh
+++ b/env-check.sh
@@ -17,7 +17,7 @@ EOF
 # enable dynamic debug logs for SOF modules
 DYNDBG="/etc/modprobe.d/sof-dyndbg.conf"
 
-# check for the system package
+# This works only for packages that have an executable of the same name.
 func_check_pkg(){
     if command -v "$1" >/dev/null; then
         return
@@ -26,6 +26,20 @@ func_check_pkg(){
         check_res=1
     fi
 }
+
+func_check_dpkg()
+{
+    command -v dpkg >/dev/null || {
+        out_str="${out_str}\tNot a dpkg-based OS, cannot check \e[31m $1 \e[0m package\n"
+        check_res=1; return
+    }
+
+    dpkg -s "$1" >& /dev/null || {
+        out_str="${out_str}\tPlease install the \e[31m $1 \e[0m package\n"
+        check_res=1
+    }
+}
+
 
 func_check_python_pkg(){
     if command -v python3 >/dev/null; then
@@ -92,9 +106,9 @@ fi
 # octave packages are required only for check-volume-levels.sh
 # Good to check upfront but this can be optional requirement
 out_str="" check_res=0
-func_check_pkg octave
-func_check_pkg octave-signal
-func_check_pkg octave-io
+func_check_dpkg octave
+func_check_dpkg octave-signal
+func_check_dpkg octave-io
 if [ $check_res -eq 0 ]; then
     printf "pass for Octave packages\n"
 else


### PR DESCRIPTION
2 commits. Main one:

Fixes (untested?) commit f9587e0 ("env-check: display optional
octave package dependency") that added the octave checks and misused
the (misnamed) func_check_pkg() function. That function works only for
packages with an executable of the same name.

Add new func_check_dpkg() that runs a dpkg check instead.

Fixes: #780

Signed-off-by: Marc Herbert <marc.herbert@intel.com>