### PR TITLE
sof-kernel-log-check: ignore i2c_hid_acpi i2c-GDIX0000:00 errors

### DIFF
--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -268,6 +268,8 @@ case "$platform" in
         # Bug Report: https://github.com/thesofproject/sof-test/issues/838
         # New TGLU_UP_HDA_ZEPHYR device reporting "TPM interrupt not working" errors.
         ignore_str="$ignore_str"'|kernel: tpm tpm0: \[Firmware Bug\]: TPM interrupt not working, polling instead'
+        # https://github.com/intel-innersource/drivers.audio.ci.sof-framework/issues/174
+	ignore_str="$ignore_str"'|kernel: i2c_hid_acpi i2c-GDIX0000:00'
         ;;
     ehl)
 	# i915 crtc logs can be ignored


### PR DESCRIPTION
Ignore failures like
https://sof-ci.sh.intel.com/#/result/planresultdetail/9950?model=TGLU_VOLT_SDW&testcase=verify-kernel-boot-log

Signed-off-by: Marc Herbert <marc.herbert@intel.com>