### PR TITLE
sof-kernel-log-check: ignore i2c_hid_acpi i2c-GDIX0000:00 errors

### DIFF
--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -268,6 +268,11 @@ case "$platform" in
         # Bug Report: https://github.com/thesofproject/sof-test/issues/838
         # New TGLU_UP_HDA_ZEPHYR device reporting "TPM interrupt not working" errors.
         ignore_str="$ignore_str"'|kernel: tpm tpm0: \[Firmware Bug\]: TPM interrupt not working, polling instead'
+	# 'failed to change power setting' and other errors observed at
+	# boot time on one TGLU_VOLT_SDW. Internal issue #174.  GOODIX
+	# touchscreen
+	# /sys/devices/pci0000:00/0000:00:15.1/i2c_designware.1/i2c-1/i2c-GDIX0000:00
+	ignore_str="$ignore_str"'|kernel: i2c_hid_acpi i2c-GDIX0000:00'
         ;;
     ehl)
 	# i915 crtc logs can be ignored


### PR DESCRIPTION
Ignore 'failed to change power setting` and other boot time
failures. See:
https://sof-ci.sh.intel.com/#/result/planresultdetail/9950?model=TGLU_VOLT_SDW&testcase=verify-kernel-boot-log

Note the failure does not seem fatal, `echo i2c-GDIX0000:00 >
/sys/bus/i2c/drivers/i2c_hid_acpi/bind` still seems to work on the
device reporting the error.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>