### PR TITLE
verify-firmware-load: add SOF_VERSION_CHECK variable

### DIFF
--- a/test-case/check-kmod-load-unload.sh
+++ b/test-case/check-kmod-load-unload.sh
@@ -90,12 +90,19 @@ do
     sof-kernel-log-check.sh "$KERNEL_CHECKPOINT" ||
         die "Found error(s) in kernel log after module insertion"
 
-    dlogi "checking if firmware is loaded successfully"
-    "$(dirname "${BASH_SOURCE[0]}")"/verify-sof-firmware-load.sh ||
-         die "Failed to load firmware after module insertion"
+    ( set +x
+      if [ "$SOF_VERSION_CHECK" = 'none' ]; then
+	  printf '$''SOF_VERSION_CHECK=none, skipping verify-sof-firmware-load.sh\n'
+	  dlogi "==== firmware boot check skipped: $idx of $loop_cnt ===="
+      else
+	  dlogi "checking if firmware is loaded successfully"
+	  "$(dirname "${BASH_SOURCE[0]}")"/verify-sof-firmware-load.sh ||
+              die "Failed to load firmware after module insertion"
+	  dlogi "==== firmware boot complete: $idx of $loop_cnt ===="
+      fi
+    )
 
     # successful remove/insert module pass
-    dlogi "==== firmware boot complete: $idx of $loop_cnt ===="
 
     # After the last module insertion, it still takes about 10s for 'aplay -l' to show device
     # list. We need to wait before aplay can function. Here, wait dsp status to suspend to

--- a/test-case/run-all-tests.sh
+++ b/test-case/run-all-tests.sh
@@ -21,6 +21,7 @@ very_short_tests()
 
 
 testlist="
+firmware-load
 tplg-binary
 pcm_list
 sof-logger

--- a/test-case/verify-sof-firmware-load.sh
+++ b/test-case/verify-sof-firmware-load.sh
@@ -22,6 +22,13 @@ func_opt_parse_option "$@"
 
 setup_kernel_check_point
 
+( set +x
+    if [ "$SOF_VERSION_CHECK" = 'none' ]; then
+        printf '$''SOF_VERSION_CHECK=none, skipping verify-sof-firmware-load.sh\n'
+        exit 2
+    fi
+)
+
 cmd="journalctl_cmd"
 
 dlogi "Checking SOF Firmware load info in kernel log"


### PR DESCRIPTION
when using SOF_VERSION_CHECK=none, the verify-sof-version-check.sh
script is skipped.

This enables us to pass the kmod load/unload tests with IPC4, e.g with

SOF_VERSION_CHECK=none SOF_LOGGING=none TPLG=/lib/firmware/intel/avs-tplg/sof-hda-generic.tplg ~/sof-test/test-case/check-kmod-load-unload-after-playback.sh

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>