### PR TITLE
sof-get-default-tplg.sh: return full /lib/firmware/sof-tplg/*.tplg path

### DIFF
--- a/tools/sof-get-default-tplg.sh
+++ b/tools/sof-get-default-tplg.sh
@@ -5,8 +5,42 @@
 #
 # sof-audio-pci 0000:00:0e.0: loading topology:intel/sof-tplg/sof-apl-pcm512x.tplg
 #
-# sof-apl-pcm512x.tplg will be returned
+# /lib/firmware/intel/sof-tplg/sof-apl-pcm512x.tplg will be returned
 #
+# CAVEAT: the SOF drivers CANNOT predict which particular
+# /lib/firmware/[updates]/[5.16.12]/ base directory will be used and the
+# kernel is hopelessly quiet about what firmware files it loads so this
+# script always assumes '/lib/firmware/' See
+# https://github.com/thesofproject/sof-test/issues/667
 
-tplg_file=$(sudo journalctl -k -g topology |awk -F ':' '/tplg/ {print $NF;}'|tail -n 1)
-[[ "$tplg_file" ]] && basename "$tplg_file" || echo ""
+set -e
+
+main()
+{
+    local tplg_file
+
+    # Find the most recently loaded
+    tplg_file=$(sudo journalctl -q -k -g 'loading topology' |
+                awk -F: '{ topo=$NF; } END { print topo }'
+             )
+
+    [ -n "$tplg_file" ] || {
+        >&2 printf 'ERROR: no topology loading found in kernel logs\n'
+        # At least one test (check-reboot) relies on an empty stdout
+        exit 1
+    }
+
+    tplg_file=/lib/firmware/"$tplg_file"
+
+    # Make sure we were not tricked by /lib/firmware/updates/ or any
+    # other issue.
+    [ -e  "$tplg_file" ] || {
+        >&2 printf '%s found in the kernel logs but not on the filesystem??\n' \
+            "$tplg_file"
+        exit 1
+    }
+
+    printf '%s\n' "$tplg_file"
+}
+
+main "$@"


### PR DESCRIPTION
This fixes the confusion between (for instance)
```
  /lib/firmware/intel/avs-tplg/sof-hda-generic-idisp.tplg
```
and
```
  /lib/firmware/intel/sof-tplg/sof-hda-generic-idisp.tplg
```
The other option was to return `sof-tplg/sof-hda-generic-idisp.tplg` but
this would have required all users of this script to adapt whereas this
change will hopefully go unnoticed.

Also add some error handling, comments and other cleanups.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>