### PR TITLE
verify-sof-firmware-load: fix test to actually check the FW is loaded

### DIFF
--- a/test-case/verify-sof-firmware-load.sh
+++ b/test-case/verify-sof-firmware-load.sh
@@ -20,6 +20,9 @@ source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
 func_opt_parse_option "$@"
 
+# We don't use KERNEL_CHECKPOINT in this test. FIXME: (re)move this line
+# after checking how this line interferes with other tests invoking us
+# (e.g.: load-unload test)
 setup_kernel_check_point
 
 cmd="journalctl_cmd"


### PR DESCRIPTION
Searching the logs for the firmware version was stupid because old logs
were enough to make the test pass!

Check whether `/sys/kernel/debug/sof/fw_version` exists instead.

This also makes the test pass with IPC4 and fixes https://github.com/thesofproject/sof-test/issues/842 and https://github.com/thesofproject/sof-test/issues/845

Signed-off-by: Marc Herbert <marc.herbert@intel.com>