### PR TITLE
volume-basic-test: Change the control search expression

### DIFF
--- a/test-case/volume-basic-test.sh
+++ b/test-case/volume-basic-test.sh
@@ -58,7 +58,7 @@ sleep 1
 [[ ! $(pidof aplay) ]] && die "$pid process is terminated too early"
 
 sofcard=${SOFCARD:-0}
-pgalist=($(amixer -c"$sofcard" controls | grep -i PGA | sed 's/ /_/g;' | awk -Fname= '{print $2}'))
+pgalist=($(amixer -c"$sofcard" controls | grep "[0-9]\.[0-9]" | sed 's/ /_/g;' | awk -Fname= '{print $2}'))
 dlogi "pgalist number = ${#pgalist[@]}"
 [[ ${#pgalist[@]} -ne 0 ]] || skip_test "No PGA control is available"
 


### PR DESCRIPTION
IPC4 uses "gain" as the widget name instead of "PGA". So searching for
"PGA" would result in the test getting skipped with IPC4. But both IPC3
and IPC4 have the pga widget names suffixed with
".Pipeline_ID.Instance_ID". So use the regular expression to search for
volume controls instead of searching for "PGA".

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>