### PR TITLE
Fix check-kmod-load-unload. Make it and verify-sof-firmware-load IPC4-compatible

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -443,6 +443,17 @@ print_module_params()
     echo "----------------------------------------"
 }
 
+# "$@" is optional, typically: --since=@"$epoch".
+# shellcheck disable=SC2120
+grep_firmware_info_in_logs()
+{
+    # dump the version info and ABI info
+    # "head -n" makes this compatible with set -e.
+    journalctl_cmd "$@" | grep "Firmware info" -A1 | head -n 12
+    # dump the debug info
+    journalctl_cmd "$@" | grep "Firmware debug build" -A3 | head -n 12
+}
+
 # check if NTP Synchronized, if so return 0 otherwise return 1
 check_ntp_sync()
 {

--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -395,6 +395,13 @@ disable_kernel_check_point()
     KERNEL_CHECKPOINT="disabled"
 }
 
+# "$@" is optional, usually: --since=@"$epoch_checkpoint"
+# shellcheck disable=SC2120
+sof_firmware_boot_complete()
+{
+    journalctl_cmd "$@" --grep 'sof.*firmware[[:blank:]]*boot[[:blank:]]*complete'
+}
+
 is_zephyr()
 {
     local ldcFile

--- a/test-case/check-kmod-load-unload.sh
+++ b/test-case/check-kmod-load-unload.sh
@@ -91,8 +91,11 @@ do
         die "Found error(s) in kernel log after module insertion"
 
     dlogi "checking if firmware is loaded successfully"
-    "$(dirname "${BASH_SOURCE[0]}")"/verify-sof-firmware-load.sh ||
+    if sof_firmware_boot_complete --since=@"$KERNEL_CHECKPOINT"; then
+        grep_firmware_info_in_logs --since=@"$KERNEL_CHECKPOINT"
+    else
          die "Failed to load firmware after module insertion"
+    fi
 
     # successful remove/insert module pass
     dlogi "==== firmware boot complete: $idx of $loop_cnt ===="

--- a/test-case/verify-sof-firmware-load.sh
+++ b/test-case/verify-sof-firmware-load.sh
@@ -26,10 +26,8 @@ cmd="journalctl_cmd"
 
 dlogi "Checking SOF Firmware load info in kernel log"
 if $cmd | grep -q " sof-audio.*Firmware.*version"; then
-    # dump the version info and ABI info
-    $cmd | grep "Firmware info" -A1 | head -n 12
-    # dump the debug info
-    $cmd | grep "Firmware debug build" -A3 | head -n 12
+
+    grep_firmware_info_in_logs
     exit 0
 
 else # failed, show some logs

--- a/test-case/verify-sof-firmware-load.sh
+++ b/test-case/verify-sof-firmware-load.sh
@@ -25,7 +25,7 @@ setup_kernel_check_point
 cmd="journalctl_cmd"
 
 dlogi "Checking SOF Firmware load info in kernel log"
-if $cmd | grep -q " sof-audio.*Firmware.*version"; then
+if sof_firmware_boot_complete; then
 
     grep_firmware_info_in_logs
     exit 0


### PR DESCRIPTION
See commit messages.

Fixes #842 and #845. Follows the direction discussed and agreed at the bottom of superseded #855

Thanks to the addition of KERNEL_CHECKPOINT logic, also fixes bug where a very old firmware load was enough to make `check-kmod-load-unload.sh` pass.
