### PR TITLE
verify-sof-firmware-load: fix error message according to new test

### DIFF
--- a/test-case/verify-sof-firmware-load.sh
+++ b/test-case/verify-sof-firmware-load.sh
@@ -35,5 +35,5 @@ else # failed, show some logs
     journalctl_cmd --lines 50 || true
     printf ' ------\n  Check journalctl status: \n ---- \n'
     systemctl --no-pager status systemd-journald* || true
-    die "Cannot find the sof audio version"
+    die "Cannot find any 'sof boot complete' message in logs since boot time"
 fi


### PR DESCRIPTION
Fixes commit cd2d7073337332 that now looks for the "firmware boot
complete" message instead of the firmware version(s) but forgot to
update the error message.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>