### PR TITLE
kmod: add support for ES83x6 platforms

### DIFF
--- a/tools/kmod/sof_insert.sh
+++ b/tools/kmod/sof_insert.sh
@@ -72,6 +72,9 @@ insert_module snd_soc_max98373_sdw
 insert_module snd_soc_max98373_i2c
 insert_module snd_soc_max98390
 
+insert_module snd_soc_es8316
+insert_module snd_soc_es8326
+
 # insert top-level ACPI/PCI SOF drivers. They will register SOF components and
 # load machine drivers as needed. Do not insert any other sort of audio module,
 # code dependencies will be used to load the relevant modules.

--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -149,6 +149,7 @@ remove_module snd_soc_skl_hda_dsp
 remove_module snd_soc_sdw_rt700
 remove_module snd_soc_sdw_rt711_rt1308_rt715
 remove_module snd_soc_sof_sdw
+remove_module snd_soc_sof_es8336
 remove_module snd_soc_ehl_rt5660
 remove_module snd_soc_intel_hda_dsp_common
 remove_module snd_soc_intel_sof_maxim_common
@@ -209,6 +210,9 @@ remove_module snd_soc_rl6347a
 
 remove_module snd_soc_wm8804_i2c
 remove_module snd_soc_wm8804
+
+remove_module snd_soc_es8316
+remove_module snd_soc_es8326
 
 remove_module snd_soc_max98090
 remove_module snd_soc_ts3a227e


### PR DESCRIPTION
Add missing machine driver and codecs. The 8326 is added for future
support, the driver is not even upstream just yet.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>