### PR TITLE
sof_remove: remove module snd_soc_intel_sof_realtek_common

### DIFF
--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -152,6 +152,7 @@ remove_module snd_soc_sof_sdw
 remove_module snd_soc_ehl_rt5660
 remove_module snd_soc_intel_hda_dsp_common
 remove_module snd_soc_intel_sof_maxim_common
+remove_module snd_soc_intel_sof_realtek_common
 
 #-------------------------------------------
 # SOF client drivers


### PR DESCRIPTION
snd_soc_intel_sof_realtek_common is missing on remove so that we need to add it in modules removed.

Related test failure : see inner daily testresult 10553 ADLP_GMB_I2S check-kmod-load-unload-25

With this commit , the failure was gone

