### PR TITLE
kernel-log-check: ignore I2C GDIX touchscreen errors on all products

### DIFF
--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -268,11 +268,6 @@ case "$platform" in
         # Bug Report: https://github.com/thesofproject/sof-test/issues/838
         # New TGLU_UP_HDA_ZEPHYR device reporting "TPM interrupt not working" errors.
         ignore_str="$ignore_str"'|kernel: tpm tpm0: \[Firmware Bug\]: TPM interrupt not working, polling instead'
-        # 'failed to change power setting' and other errors observed at
-        # boot time on one TGLU_VOLT_SDW. Internal issue #174.  GOODIX
-        # touchscreen
-        # /sys/devices/pci0000:00/0000:00:15.1/i2c_designware.1/i2c-1/i2c-GDIX0000:00
-        ignore_str="$ignore_str"'|kernel: i2c_hid_acpi i2c-GDIX0000:00'
         ;;
     ehl)
         # i915 crtc logs can be ignored
@@ -280,6 +275,15 @@ case "$platform" in
         # i915 0000:00:02.0: [drm] *ERROR* Suspending crtc's failed with -22
         ignore_str="$ignore_str""|i915 [[:digit:].:]+: \[drm\] \*ERROR\* Suspending crtc's failed with -[[:digit:]]+"
 esac
+
+# 'failed to change power setting' and other errors observed at boot
+# time on one TGLU_VOLT_SDW. Internal issue #174.  GOODIX touchscreen
+# /sys/devices/pci0000:00/0000:00:15.1/i2c_designware.1/i2c-1/i2c-GDIX0000:00
+#
+# Also: Failed to fetch the HID Descriptor / unexpected bcdVersion (0x0000)
+# on one CML_HEL_RT5682
+ignore_str="$ignore_str"'|kernel: i2c_hid_acpi i2c-GDIX0000:00'
+
 
 # below are new error level kernel logs from journalctl --priority=err
 # that did not influence system and can be ignored


### PR DESCRIPTION
More Goodix errors were just caught on a different system:

https://sof-ci.01.org/sofpr/PR5449/build12176/devicetest/?model=CML_HEL_RT5682&testcase=verify-kernel-boot-log
```
Feb 23 16:59:09 jf-cml-hel-rt5682-02 kernel: Linux version 5.13.0-28-generic  (gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.>
Feb 23 16:59:09 jf-cml-hel-rt5682-02 kernel: i2c_hid_acpi i2c-GDIX0000:00: unexpected HID descriptor bcdVersion (0x0000)
Feb 23 16:59:09 jf-cml-hel-rt5682-02 kernel: i2c_hid_acpi i2c-GDIX0000:00: Failed to fetch the HID Descriptor

Feb 28 21:08:07 jf-cml-hel-rt5682-02 kernel: Linux version 5.16.0-rc1-daily-default-20220227-0  (gcc (Ubunt>
Feb 28 21:08:07 jf-cml-hel-rt5682-02 kernel: i2c_hid_acpi i2c-GDIX0000:00: unexpected HID descriptor bcdVersion (0x0000)
Feb 28 21:08:07 jf-cml-hel-rt5682-02 kernel: i2c_hid_acpi i2c-GDIX0000:00: Failed to fetch the HID Descriptor
```
See internal issue 174

Signed-off-by: Marc Herbert <marc.herbert@intel.com>