### PR TITLE
[SKIP CI] verify-kernel-log: change ADL skip_test reason

### DIFF
--- a/test-case/verify-kernel-boot-log.sh
+++ b/test-case/verify-kernel-boot-log.sh
@@ -37,7 +37,7 @@ main()
     platform=$(sof-dump-status.py -p)
     case "$platform" in
         adl)
-            skip_test "$platform is under active development"
+            skip_test "internal #99: missing GPU firmware and others on $platform"
             ;;
     esac
 


### PR DESCRIPTION
ADL is not "in development" anymore but we still have some errors. Add
reference to internal bug number.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>