### PR TITLE
multiple-pipeline: skip the Smart Amp playback pipeline when testing

### DIFF
--- a/test-case/multiple-pipeline.sh
+++ b/test-case/multiple-pipeline.sh
@@ -105,7 +105,7 @@ func_run_pipeline_with_type()
 
         dlogi "Testing: $pcm [$dev]"
 
-        "${APP_LST[$1]}" -D "$dev" -c "$channel" -r "$rate" -f "$fmt" "${DEV_LST[$1]}" -q &
+        "${APP_LST[${1%% *}]}" -D "$dev" -c "$channel" -r "$rate" -f "$fmt" "${DEV_LST[${1%% *}]}" -q &
 
         : $((tmp_count--))
         if [ "$tmp_count" -le 0 ]; then return 0; fi
@@ -170,7 +170,7 @@ do
         'c')
             tmp_count=$max_count
             func_run_pipeline_with_type "capture"
-            func_run_pipeline_with_type "playback"
+            func_run_pipeline_with_type "playback & ~smart_amp"
             ;;
         *)
             die "Wrong -f argument $f_arg, see -h"


### PR DESCRIPTION
multiple capture pipelines

In this case, if we test all capture pipeline at same time, but
capture pipeline count is less than requested count defined by
-c option, playback pipeline will be started to ensure requested
number of pipelines are running in parallel.

Consider this scenario, the capture pipeline count is less than
requested count and the tplg contains both Smart Amplifier pipeline
and Echo reference capture pipeline. The EC capture pipeline start
first, then smart amp playback pipeline follow, this will cause ipc
tx timed out. This patch skips the smart amp playback pipeline when
testing multiple capture pipelines to avoid such scenario.

Signed-off-by: Keqiao Zhang <keqiao.zhang@intel.com>