### PR TITLE
Revert "check-sof-logger: disable dma_nudge() workaround for stuck DMA issue #4333

### DIFF
--- a/test-case/check-sof-logger.sh
+++ b/test-case/check-sof-logger.sh
@@ -205,8 +205,7 @@ main()
 
             # Workaround for DMA trace bug
             # https://github.com/thesofproject/sof/issues/4333
-#            if [ "$f" = data ]; then
-            if false; then # let's check whether #4333 was finally fixed by #4763
+            if [ "$f" = data ]; then
                 dloge "Empty or stuck DMA trace? Let's try to nudge it."
                 dloge '  vv  Workaround for SOF issue 4333  vv'
                 local second_chance="$LOG_ROOT/logger.dma_trace_bug_4333.txt"


### PR DESCRIPTION
This reverts commit 4b3f84754ddec8051cf3dac6180ef32950c6fdf0.

Looks like we're stuck again, see latest updates in thesofproject/sof#4333

Signed-off-by: Marc Herbert <marc.herbert@intel.com>