### PR TITLE
check-sof-logger: disable again dma_nudge() workaround for stuck DMA #4333

### DIFF
--- a/test-case/check-sof-logger.sh
+++ b/test-case/check-sof-logger.sh
@@ -205,7 +205,12 @@ main()
 
             # Workaround for DMA trace bug
             # https://github.com/thesofproject/sof/issues/4333
-            if [ "$f" = data ]; then
+#            if [ "$f" = data ]; then
+
+            # let's check whether #4333 was finally fixed by sof #4763
+            # + linux #3523
+            if false; then
+
                 dloge "Empty or stuck DMA trace? Let's try to nudge it."
                 dloge '  vv  Workaround for SOF issue 4333  vv'
                 local second_chance="$LOG_ROOT/logger.dma_trace_bug_4333.txt"


### PR DESCRIPTION
@ujfalusi  has a tentative fix in
https://github.com/thesofproject/linux/pull/3523, remove the
workaround so it can better tested and evaluated.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>
(cherry picked from commit 4b3f84754ddec8051cf3dac6180ef32950c6fdf0)