### PR TITLE
kmod: sof_insert: add missing skl support

### DIFF
--- a/tools/kmod/sof_insert.sh
+++ b/tools/kmod/sof_insert.sh
@@ -89,6 +89,7 @@ insert_module snd_sof_acpi_intel_bdw
 insert_module snd_sof_pci # ipc_type=1 # sof_pci_debug=1 ...
 
 insert_module snd_sof_pci_intel_tng
+insert_module snd_sof_pci_intel_skl
 insert_module snd_sof_pci_intel_apl
 insert_module snd_sof_pci_intel_cnl
 insert_module snd_sof_pci_intel_icl


### PR DESCRIPTION
snd_sof_pci_intel_skl is referenced in sof_remove.sh but not in
sof_insert.sh. Add the missing support

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>