### PR TITLE
sof-kernel-log-check: temporarily filter out NVME harmless issues

### DIFF
--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -379,6 +379,10 @@ ignore_str="$ignore_str"'|iwlwifi [[:digit:].:]+: '
 # https://github.com/thesofproject/sof-test/issues/874
 ignore_str="$ignore_str"'|I/O error, dev loop., sector 0 op 0x0:.READ. flags 0x80700'
 
+# NVME harmless errors added in 5.18-rc1
+# https://github.com/thesofproject/sof-test/issues/888
+ignore_str="$ignore_str"'|nvme0: Admin Cmd(0x[:digit:]+), I/O Error (sct 0x0 / sc 0x2)'
+
 #
 # SDW related logs
 #


### PR DESCRIPTION
kernel 5.18-rc1 added a set of harmless NVME errors that we should
filter out until removed upstream.

BugLink: https://github.com/thesofproject/sof-test/issues/888
Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>