### PR TITLE
sof-kernel-log-check: fix regexp used to filter out NVME harmless issues

### DIFF
--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -381,7 +381,7 @@ ignore_str="$ignore_str"'|I/O error, dev loop., sector 0 op 0x0:.READ. flags 0x8
 
 # NVME harmless errors added in 5.18-rc1
 # https://github.com/thesofproject/sof-test/issues/888
-ignore_str="$ignore_str"'|nvme0: Admin Cmd(0x[:digit:]+), I/O Error (sct 0x0 / sc 0x2)'
+ignore_str="$ignore_str"'|nvme0: Admin Cmd\(0x[[:digit:]]+\), I/O Error \(sct 0x0 / sc 0x2\)'
 
 #
 # SDW related logs


### PR DESCRIPTION
Our reviews and CI missed the mistake with missing brackets leading to
the following warning:

grep: character class syntax is [[:space:]], not [:space:]

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>