### PR TITLE
sof-kernel-log-check: filter ptp_kvm issues

### DIFF
--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -383,6 +383,10 @@ ignore_str="$ignore_str"'|I/O error, dev loop., sector 0 op 0x0:.READ. flags 0x8
 # https://github.com/thesofproject/sof-test/issues/888
 ignore_str="$ignore_str"'|nvme0: Admin Cmd\(0x[[:digit:]]+\), I/O Error \(sct 0x0 / sc 0x2\)'
 
+# PTP KVM errors
+# https://github.com/thesofproject/sof-test/issues/891
+ignore_str="$ignore_str"'|fail to initialize ptp_kvm'
+
 #
 # SDW related logs
 #


### PR DESCRIPTION
Across the board fails in  https://sof-ci.sh.intel.com/#/result/planresultdetail/11848

BugLink: https://github.com/thesofproject/sof-test/issues/891
Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>