### PR TITLE
lib.sh: Dump fw version for IPC4

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -532,6 +532,8 @@ grep_firmware_info_in_logs()
     # dump the version info and ABI info
     # "head -n" makes this compatible with set -e.
     journalctl_cmd "$@" | grep "Firmware info" -A1 | head -n 12
+    # For dumping the firmware information when DUT runs IPC4 mode 
+    journalctl_cmd "$@" | grep "firmware version" -A1 | head -n 12
     # dump the debug info
     journalctl_cmd "$@" | grep "Firmware debug build" -A3 | head -n 12
 }


### PR DESCRIPTION
function grep_firmware_info_in_logs helps us to get information of firmware including its version conveniently.

As for IPC4, the keyword is "firmware version" instead of "Firmware info". So add the keyword for catch fw version under
IPC4 mode.

This will affect the console output of testcase verify-sof-firmware-load.sh and it can help us to tell whether cavs fw or sof fw is actually used.

**its effects**
[dmesg]
```
ubuntu@sh-tglu-rvp-hda-zephyr-02:~/sof-test$ TPLG=/lib/firmware/intel/avs-tplg/cavs-mixin-mixout-hda.tplg MODEL=TGLU_UP_HDA_CAVSIPC4 ~/sof-test/test-case/verify-sof-firmware-load.sh
2022-05-11 11:10:03 UTC [INFO] Checking SOF Firmware load info in kernel log
[    3.671067] kernel: sof-audio-pci-intel-tgl 0000:00:1f.3: firmware boot complete
May 11 09:10:45 kernel: sof-audio-pci-intel-tgl 0000:00:1f.3: firmware boot complete
[    3.565298] kernel: sof-audio-pci-intel-tgl 0000:00:1f.3: Loaded firmware version: 10.29.0.5399
[    3.565301] kernel: sof-audio-pci-intel-tgl 0000:00:1f.3: Firmware name: ADSPFW, header length: 52, module count: 23
--
[    3.675087] kernel: sof-audio-pci-intel-tgl 0000:00:1f.3: Booted firmware version: 10.29.0.5399
[    3.675092] kernel: sof-audio-pci-intel-tgl 0000:00:1f.3: Firmware tracing is not available
2022-05-11 11:10:03 UTC [INFO] Test Result: PASS!
```

Signed-off-by: Xiaoyun Wu(Iris) <xiaoyun.wu@intel.com>