### PR TITLE
check-suspend-resume: lsusb -t  ->  lsusb -tvv

### DIFF
--- a/test-case/check-suspend-resume.sh
+++ b/test-case/check-suspend-resume.sh
@@ -96,7 +96,7 @@ save_initial_stats()
     dlogi "https://docs.kernel.org/driver-api/pm/devices.html#sys-devices-power-wakeup-files"
     printf '\n'
     lspci;    printf '\n'
-    lsusb -t; printf '\n\n'
+    lsusb -tvv; printf '\n\n'
 }
 
 check_suspend_fails()


### PR DESCRIPTION
This will help when we have a lot of USB errors like in

https://sof-ci.01.org/softestpr/PR906/build27/devicetest/?model=WHL_UPEXT_HDA_ZEPHYR&testcase=check-suspend-resume-with-playback-5

Example before:
```
$ lsusb  -t

/:  Bus 02.Port 1: Dev 1, Class=root_hub, Driver=xhci_hcd/6p, 10000M
/:  Bus 01.Port 1: Dev 1, Class=root_hub, Driver=xhci_hcd/12p, 480M
    |__ Port 10: Dev 6, If 0, Class=Wireless, Driver=, 12M
    |__ Port 10: Dev 6, If 1, Class=Wireless, Driver=, 12M
```
Example after:
```
$ lsusb -tvv

/:  Bus 02.Port 1: Dev 1, Class=root_hub, Driver=xhci_hcd/6p, 10000M
    ID 1d6b:0003 Linux Foundation 3.0 root hub
    /sys/bus/usb/devices/  /dev/bus/usb/002/001
/:  Bus 01.Port 1: Dev 1, Class=root_hub, Driver=xhci_hcd/12p, 480M
    ID 1d6b:0002 Linux Foundation 2.0 root hub
    /sys/bus/usb/devices/usb1  /dev/bus/usb/001/001
    |__ Port 10: Dev 6, If 0, Class=Wireless, Driver=, 12M
        ID 8087:0025 Intel Corp.
        /sys/bus/usb/devices/1-10  /dev/bus/usb/001/006
    |__ Port 10: Dev 6, If 1, Class=Wireless, Driver=, 12M
        ID 8087:0025 Intel Corp.
        /sys/bus/usb/devices/1-10  /dev/bus/usb/001/006
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>