### PR TITLE
kmod: add mtl pci module

### DIFF
--- a/tools/kmod/sof_insert.sh
+++ b/tools/kmod/sof_insert.sh
@@ -94,7 +94,7 @@ insert_module snd_sof_pci_intel_apl
 insert_module snd_sof_pci_intel_cnl
 insert_module snd_sof_pci_intel_icl
 insert_module snd_sof_pci_intel_tgl
-
+insert_module snd_sof_pci_intel_mtl
 
 # USB
 insert_module snd_usb_audio


### PR DESCRIPTION
Add top mtl pci module.

Signed-off-by: Fred Oh <fred.oh@linux.intel.com>

I should have added this my previous PR, https://github.com/thesofproject/sof-test/pull/896. At that time I addressed only the error I have, sorry about the miss.