### PR TITLE
lib.sh: lower BYT expectations in new storage_checks()

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -82,8 +82,8 @@ storage_checks()
     local platf; platf=$(sof-dump-status.py -p)
 
     case "$platf" in
-        # Some cheap and old BYTs with eMMC do 10MB/s write or less
-        byt) megas=20 ; max_sync=15 ;;
+        # Some cheap and old BYTs with eMMC do 2MB/s write or less!
+        byt) megas=4 ; max_sync=25 ;;
         *) megas=100; max_sync=5 ;;
     esac
 

--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -83,7 +83,7 @@ storage_checks()
 
     case "$platf" in
         # Some cheap and old BYTs with eMMC do 10MB/s write or less
-        byt|apl) megas=20 ; max_sync=15 ;;
+        byt) megas=20 ; max_sync=15 ;;
         *) megas=100; max_sync=5 ;;
     esac
 


### PR DESCRIPTION
Storage performance on some BYT devices is incredibly slow, see for
instance failures in
https://sof-ci.01.org/linuxpr/PR3552/build164/devicetest