### PR TITLE
check-sof-logger: add missing sof-kernel-log-check.sh

### DIFF
--- a/test-case/check-sof-logger.sh
+++ b/test-case/check-sof-logger.sh
@@ -137,6 +137,9 @@ print_logs_exit()
         printf '\n'
     done
     test -z "$errmsg" || dloge "$errmsg"
+
+    sof-kernel-log-check.sh "$KERNEL_CHECKPOINT" || exit_code=1
+
     exit "$exit_code"
 }
 


### PR DESCRIPTION
This would have caught kernel crash
https://sof-ci.01.org/linuxpr/PR3645/build166/devicetest/?model=CML_RVP_SDW_ZEPHYR&testcase=check-sof-logger

This check is especially important considering check-sof-logger unload
and reloads kernel modules.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>