### PR TITLE
case-lib: add an option to control fallback behavior

### DIFF
--- a/case-lib/config.sh
+++ b/case-lib/config.sh
@@ -70,3 +70,14 @@ SUDO_LEVEL=${SUDO_LEVEL:-}
 # waited by the internal test runner used by sof/jenkins CI and that
 # test runner does not define SOF_TEST_INTERVAL (internal bug 158)
 SOF_TEST_INTERVAL=${SOF_TEST_INTERVAL:-5}
+
+# If we don't have SOF card in the system in SOF test, the default fallback
+# to test pipelines from /proc behavior will cause false positive, because
+# we are testing USB sound card or Nvidia HDMI under this condition.
+#
+# This option is used to control the fallback behavior. It should be set
+# to 'false' for SOF test,  and set to 'true' for legacy HDA test.
+#
+# Refer to: https://github.com/thesofproject/sof-test/issues/471 and
+# https://github.com/thesofproject/sof-test/issues/913 for more information.
+FALLBACK_TO_PROC=${FALLBACK_TO_PROC:-false}

--- a/case-lib/pipeline.sh
+++ b/case-lib/pipeline.sh
@@ -17,6 +17,9 @@ func_pipeline_export()
     # For legacy HDA platform, there is no topology, we have to export pipeline
     # parameters from proc file system.
     is_sof_used || {
+        [ "$FALLBACK_TO_PROC" == "true" ] ||
+            die "No SOF sound card found and fallback mode disabled, failing."
+
         filter_str="$2"
         dlogi "No SOF sound card found, exporting pipeline parameters from proc file system"
         tmp_pipeline_params=$(mktemp /tmp/pipeline-params.XXXXXXXX)


### PR DESCRIPTION
Previously, if SOF card is not detected from the system,
we will export pipelines from proc file system, this is
good for legacy HDA test, but for SOF test, this causes
false positive because usually under this condition, we
are testing USB sound card or Nvidia HDMI.

This patch adds an option to control the fallback behavior,
It should be set to 'false' for SOF test,  and set to 'true'
for legacy HDA test.

Signed-off-by: Chao Song <chao.song@linux.intel.com>
