### PR TITLE
Add mutual exclusion and journalctl logging

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -100,6 +100,8 @@ function func_exit_handler()
 
     fi
 
+    stop_test || exit_status=1
+
     storage_checks || exit_status=1
 
     if [[ "$KERNEL_CHECKPOINT" =~ ^[0-9]{10} ]]; then

--- a/case-lib/logging_ctl.sh
+++ b/case-lib/logging_ctl.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+is_subtest()
+{
+    # PPID: The process ID of the shell's parent.
+    # get current script parent process name
+    local ppcmd
+    ppcmd=$(ps -p $PPID -o cmd --noheader|awk '{print $2;}')
+    local ext_message="" cmd
+    # confirm this script is loaded by other script, and add the flag for it
+    file "$ppcmd" 2>/dev/null |grep -q 'shell script'
+}
+
 # using aliases to cover log defines --- more like C log functions
 _func_log_cmd()
 {
@@ -26,13 +37,11 @@ _func_log_cmd()
     # open aliases for script, so it can use the dlogx commands instead of
     # writing functions
     shopt -s expand_aliases
-    # PPID: The process ID of the shell's parent.
-    # get current script parent process name
-    local ppcmd
-    ppcmd=$(ps -p $PPID -o cmd --noheader|awk '{print $2;}')
-    local ext_message="" cmd
-    # confirm this script is loaded by other script, and add the flag for it
-    file "$ppcmd" 2>/dev/null |grep -q 'shell script' && ext_message=" Sub-Test:"
+
+    if is_subtest; then
+        ext_message=" Sub-Test:"
+    fi
+
     for key in "${!LOG_LIST[@]}";
     do
         # dymaic alias the command with different content


### PR DESCRIPTION
This solves two major and recurring problems:

- Double CI reservations where a surprising number of tests pass anyway and
  the rest fails in extremely time consuming ways. Now only one test can
  run at a time.

- Missing correlation between journalctl and test start/stop. Inability
to find when tests start and stop.

- Missing correlation between ktime used in dmesg and wallclock

Sample, new journalctl output:
```
May 31 17:58:56 [8007]: /tmp/sof-test-card0.lock already taken by PID 6147! Starting 7976 anyway.
May 31 17:58:56 [8011]: sof-test 7976 starting
May 31 18:00:09 [8361]: /tmp/sof-test-card0.lock already taken by PID 6147! Starting 8329 anyway.
May 31 18:00:09 [8365]: sof-test 8329 starting
May 31 18:00:34 [8533]: sof-test 8502 starting
May 31 18:00:38 [8638]: sof-test 8502 ending
May 31 18:00:49 [8741]: sof-test 8710 starting
May 31 18:00:53 [8846]: sof-test 8710 ending
May 31 18:01:20 [9226]: sof-test 9090 ending
May 31 18:01:48 [9323]: sof-test 9292 starting
May 31 18:03:53 [9519]: sof-test 9488 starting
May 31 18:04:23 [9725]: sof-test 9694 starting
May 31 18:04:27 [9829]: Lock file /tmp/sof-test-card0.lock already removed! Concurrent testing?
May 31 18:11:06 [10369]: sof-test 10339: starting
May 31 18:11:11 [10473]: sof-test 10339: Lock file /tmp/sof-test-card0.lock already removed! Concurrent testing?
May 31 18:11:23 [10584]: sof-test 10554: starting
May 31 18:11:27 [10688]: sof-test 10554: lock file /tmp/sof-test-card0.lock already removed! Concurrent testing?
May 31 18:36:07 [11183]: 8256.48 sof-test 11151: starting
May 31 18:36:11 [11289]: 8260.71 sof-test 11151: lock file /tmp/sof-test-card0.lock already removed! Concurrent testing?
May 31 18:37:57 [11514]: 8357.18 sof-test 11482: starting
May 31 18:38:01 [11624]: 8361.43 sof-test 11482: lock file /tmp/sof-test-card0.lock already removed! Concurrent testing?
May 31 18:39:50 [11809]: ktime=8469 sof-test 11777: starting
May 31 18:39:55 [11915]: ktime=8474 sof-test 11777: lock file /tmp/sof-test-card0.lock already removed! Concurrent testing?
May 31 18:41:33 [12140]: ktime=8572 sof-test 12108: starting
May 31 18:41:37 [12246]: ktime=8576 sof-test 12108: unexpected value in /tmp/sof-test-card0.lock! Concurrent testing?
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>