### PR TITLE
check-suspend-resume: diff wakeup_sources with --report-identical-files

### DIFF
--- a/test-case/check-suspend-resume.sh
+++ b/test-case/check-suspend-resume.sh
@@ -109,8 +109,11 @@ dump_stats()
     printf '\n'
     grep ^ /sys/power/suspend_stats/*
     printf '\n'
+    # Show colunm names
     sudo cat /sys/kernel/debug/wakeup_sources | head -n 1
-    diff -u "$INITIAL_DBG_SOURCES" <(sudo cat /sys/kernel/debug/wakeup_sources) ||
+    # identical is most likely a bug!
+    sudo diff -u --report-identical-files \
+         "$INITIAL_DBG_SOURCES" /sys/kernel/debug/wakeup_sources ||
         true
     printf '\n'
 }


### PR DESCRIPTION
When the wakeup count gets totally stuck it's possible for the
wakeup_sources to stay completed unchanged. See example at
https://sof-ci.01.org/sofpr/PR5884/build560/devicetest/?model=TGLU_UP_HDA_ZEPHYR&testcase=check-suspend-resume-5

In that case only the header of wakeup_sources gets printed which gives
the wrong impression that wakeup_sources is completely empty! The
`--report-identical-files` diff option avoids that confusion.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>