### PR TITLE
lib.sh: storage_check: add 'cht' (BSW Cyan) to slow devices

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -656,7 +656,7 @@ logger_disabled()
     # ... across all tests at once.
     # In the future we should support SOF_LOGGING=etrace (only), see
     # sof-test#726
-    if [ "x$SOF_LOGGING" == 'xnone' ]; then
+    if [ "$SOF_LOGGING" == 'none' ]; then
         dlogi 'SOF logs collection globally disabled by SOF_LOGGING=none'
         return 0
     fi

--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -197,8 +197,9 @@ storage_checks()
     local platf; platf=$(sof-dump-status.py -p)
 
     case "$platf" in
-        # Some cheap and old BYTs with eMMC do 2MB/s write or less!
-        byt) megas=4 ; max_sync=25 ;;
+        # BYT Minnowboards run from SD cards.
+        # BSW Cyan has pretty bad eMMC too.
+        byt|cht) megas=4 ; max_sync=25 ;;
         *) megas=100; max_sync=7 ;;
     esac
 


### PR DESCRIPTION
See failures in daily run 13851.