### PR TITLE
Using a shell redirection instead of sof-logger's -o option

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -349,10 +349,11 @@ func_lib_start_log_collect()
 
     # The logger does not like empty '' arguments and $logopt can be
     # shellcheck disable=SC2206
-    local loggerCmd=("$SOFLOGGER" $logopt -l "$ldcFile" -o "$logfile")
+    local loggerCmd=("$SOFLOGGER" $logopt -l "$ldcFile")
     dlogi "Starting ${loggerCmd[*]}"
     # Cleaned up by func_exit_handler() in hijack.sh
-    sudo "${loggerCmd[@]}" &
+    # shellcheck disable=SC2024
+    sudo "${loggerCmd[@]}" > "$logfile" &
 }
 
 # Calling this function is often a mistake because the error message

--- a/test-case/check-sof-logger.sh
+++ b/test-case/check-sof-logger.sh
@@ -78,10 +78,11 @@ run_loggers()
 
     dlogi "Trying to get the DMA trace log with background sof-logger ..."
     dlogc \
-    "sudo $loggerBin  -t -f 3 -l  $ldcFile  -o  $data_file  2>  $error_file  &"
+    "sudo $loggerBin  -t -f 3 -l  $ldcFile   >  $data_file  2>  $error_file  &"
+    # shellcheck disable=SC2024
     sudo timeout -k 3 "$dma_collect_secs"  \
          "$loggerBin" -t -f 3 -l "$ldcFile" \
-         -o "$data_file" 2> "$error_file" & dmaPID=$!
+          > "$data_file" 2> "$error_file" & dmaPID=$!
 
     sleep "$dma_collect_secs"
     loggerStatus=0; wait "$dmaPID" || loggerStatus=$?
@@ -99,8 +100,9 @@ run_loggers()
 
     dlogi "Trying to get the etrace mailbox ..."
     dlogc \
-    "sudo $loggerBin    -f 3 -l  $ldcFile  2>  $etrace_stderr_file  -o  $etrace_file"
-    sudo "$loggerBin"   -f 3 -l "$ldcFile" 2> "$etrace_stderr_file" -o "$etrace_file" || {
+    "sudo $loggerBin    -f 3 -l  $ldcFile  2>  $etrace_stderr_file   >  $etrace_file"
+    # shellcheck disable=SC2024
+    sudo "$loggerBin"   -f 3 -l "$ldcFile" 2> "$etrace_stderr_file"  > "$etrace_file" || {
         etrace_exit=$?
         cat "$etrace_stderr_file" >&2
     }


### PR DESCRIPTION
As sof-logger must run as root, `sudo sof-logger -o ...` creates logs/
directories with a mix of user and root content. Use a plain >
redirection instead so all log files are owned by the user running the
script.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>