### PR TITLE
check-pause-resume: handle volume MAX output in expect

### DIFF
--- a/test-case/check-pause-release-suspend-resume.sh
+++ b/test-case/check-pause-release-suspend-resume.sh
@@ -121,6 +121,10 @@ rm -rf /tmp/sof-test.lock
 #   catch: Evaluate script and trap exceptional returns
 #   after ms: Ms must be an integer giving a time in milliseconds.
 #       The command sleeps for ms milliseconds and then returns.
+# FIXME: this test was broken by 46dadd0 ("Add mutual exclusion and journalctl logging")
+#       because it never was compatible with is_subtest()
+# FIXME: Need to handle more of aplay/arecord output. Need to apply similar fix with
+#       check-pause-resume.sh, multiple-pause-resume.sh
 expect <<AUDIO
 spawn $cmd -D $pcm -r $rate -c $channel -f $fmt -vv -i $dummy_file -q
 set i 1

--- a/test-case/multiple-pause-resume.sh
+++ b/test-case/multiple-pause-resume.sh
@@ -115,18 +115,22 @@ func_pause_resume_pipeline()
     #   after ms: Ms must be an integer giving a time in milliseconds.
     #       The command sleeps for ms milliseconds and then returns.
     dlogi "$pcm to command: $cmd -D $dev -r $rate -c $channel -f $fmt -vv -i $file -q"
+
+    # NOTE: Purposely we don't handle 'Volume MAX' case. So that the MAX output can fall into
+    #       'anything else' case and error out.
+    # FIXME: share this expect script as a common function
     expect <<END &
 spawn $cmd -D $dev -r $rate -c $channel -f $fmt -vv -i $file -q
 set i 1
 expect {
-    "*#*+*\%" {
+    -re "#.*\%\r" {
         set sleep_t [expr int([expr rand() * $rnd_range]) + $rnd_min ]
         puts "\r(\$i/$repeat_count) pcm'$pcm' cmd'$cmd' id'$idx': Wait for \$sleep_t ms before pause"
         send " "
         after \$sleep_t
         exp_continue
     }
-    "*PAUSE*" {
+    "=== PAUSE ===" {
         set sleep_t [expr int([expr rand() * $rnd_range]) + $rnd_min ]
         puts "\r(\$i/$repeat_count) pcm'$pcm' cmd'$cmd' id'$idx': Wait for \$sleep_t ms before resume"
         send " "
@@ -134,6 +138,20 @@ expect {
         incr i
         if { \$i > $repeat_count } { exit 0 }
         exp_continue
+    }
+    -re ".*\:.*\n"|"Hardware PCM card.*\n" {
+        puts "\rexpect ignore dump-hw-params"
+        after 10
+        exp_continue
+    }
+    default {
+        puts "\rError: timeout or eof detected, exit 1"
+        exit 1
+    }
+# this is conventional default, anything else hit here
+    "^?*\n" {
+        puts "\rError: unexpected output detected, exit 1. $expect_out(0,string)"
+        exit 1
     }
 }
 exit 1


### PR DESCRIPTION
When volume is MAX, current expect misses the case. Why volume is MAX is
separate question. Momentary pop can be ingored but if volume is 100% DC
return error.
And added for ignoring dump-hw-params and last case is anything else,
it means unexpected outputs, will return error also.

This is example of output from aplay or arecord.
1. Playing
"##    +                                            | 11%"
2. When paused
"=== PAUSE ==="
3. When volume is MAX
"##################################################+| MAX"

Signed-off-by: Fred Oh <fred.oh@linux.intel.com>

related:
- https://github.com/thesofproject/linux/issues/3766