### PR TITLE
check-sof-logger.sh: do not wait for D3 suspend

### DIFF
--- a/test-case/check-sof-logger.sh
+++ b/test-case/check-sof-logger.sh
@@ -160,8 +160,6 @@ reload_drivers()
         if sudo test -e /sys/kernel/debug/sof/etrace; then break; fi
         sleep 1
     done
-    # Now give enough time to go to D3 suspend
-    sleep 4
 }
 
 main()


### PR DESCRIPTION
I added this wait for D3 in commit 6a8871fb849a ("check-sof-logger:
reload drivers first") that made the test more deterministic but I'm not
100% sure why it's now waiting for D3. Probably to minimize changes
because before the addition of reload_drivers() the DSP was most likely
in D3.

While I recently made cavstool compatible with D3, the protocol used by
cavstool is still different from the other traces: it won't print ANY
log while the DSP is off. So change the test behavior to grab logs
immediately after reloading the drivers / rebooting the DSP.

This may also help with
https://github.com/thesofproject/sof/issues/4333,
https://github.com/thesofproject/linux/issues/3448
and others linked from there.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>