### PR TITLE
[RFC]: Pipe journalctl command to grep instead of using the -g option

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -604,7 +604,7 @@ disable_kernel_check_point()
 # shellcheck disable=SC2120
 sof_firmware_boot_complete()
 {
-    journalctl_cmd "$@" --grep 'sof.*firmware[[:blank:]]*boot[[:blank:]]*complete'
+    journalctl_cmd "$@" | grep -i 'sof.*firmware[[:blank:]]*boot[[:blank:]]*complete'
 }
 
 is_zephyr()

--- a/tools/sof-get-default-tplg.sh
+++ b/tools/sof-get-default-tplg.sh
@@ -20,7 +20,7 @@ main()
     local tplg_file
 
     # Find the most recently loaded
-    tplg_file=$(sudo journalctl -q -k -g 'loading topology' |
+    tplg_file=$(sudo journalctl -q -k | grep -i 'loading topology' |
                 awk -F: '{ topo=$NF; } END { print topo }'
              )
 


### PR DESCRIPTION
The reason for this is to allow the tests based on journalctl -g "some string" to run on i.MX platforms. At this moment, running
journalctl -q -k -g "loading" results in the following error: Compiled without pattern matching support.