### PR TITLE
check-pause-release-suspend-resume: small fixes

### DIFF
--- a/test-case/check-pause-release-suspend-resume.sh
+++ b/test-case/check-pause-release-suspend-resume.sh
@@ -172,6 +172,10 @@ expect {
         if { \$i > $repeat_count } { exit 0 }
         exp_continue
     }
+    default {
+        puts "aplay exited or we timed out"
+        exit 1
+    }
 }
 AUDIO
 

--- a/test-case/check-pause-release-suspend-resume.sh
+++ b/test-case/check-pause-release-suspend-resume.sh
@@ -149,7 +149,7 @@ expect {
         }
 
         #enter suspend-resume cycle once per pause instance
-        set retval [catch { exec bash check-suspend-resume.sh -l 1 } msg]
+        set retval [catch { exec ${TOPDIR}/test-case/check-suspend-resume.sh -l 1 } msg]
 
         #prints logs from suspend-resume test
         puts \$msg

--- a/test-case/check-pause-release-suspend-resume.sh
+++ b/test-case/check-pause-release-suspend-resume.sh
@@ -51,7 +51,10 @@ set -e
 ##  * No unexpected errors should be present in dmesg during or after test
 ##      completion.
 
-source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
+TOPDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")"/..; pwd)
+
+# shellcheck source=case-lib/lib.sh
+source "$TOPDIR"/case-lib/lib.sh
 
 OPT_NAME['m']='mode'         OPT_DESC['m']='test mode. Example: playback; capture'
 OPT_HAS_ARG['m']=1             OPT_VAL['m']='playback'
@@ -176,9 +179,8 @@ ret=$?
 #flush the output
 echo
 if [ $ret -ne 0 ]; then
-    sof-process-kill.sh
-    [[ $? -ne 0 ]] && dlogw "Kill process catch error"
+    sof-process-kill.sh ||
+        dlogw "Kill process catch error"
     exit $ret
 fi
 sof-kernel-log-check.sh "$KERNEL_CHECKPOINT"
-exit $?


### PR DESCRIPTION
3 commits, check messages.

Note this test seems orphaned, it was notably broken by commit
https://github.com/thesofproject/sof-test/commit/46dadd0c563e6caa0c01c4acec6caf4bdfc30d7f ("Add mutual exclusion and journalctl logging") and no one
noticed (I temporarily disabled https://github.com/thesofproject/sof-test/commit/46dadd0c563e6caa0c01c4acec6caf4bdfc30d7f locally)