### PR TITLE
Fix hijack.sh sudo() to use an array, support whitespace and behave

### DIFF
--- a/test-case/check-ipc-flood.sh
+++ b/test-case/check-ipc-flood.sh
@@ -50,7 +50,7 @@ do
     setup_kernel_check_point
     dlogi "===== [$i/$loop_cnt] loop Begin ====="
     dlogc "sudo bash -c 'echo $lpc_loop_cnt > $ipc_flood_dfs'"
-    sudo bash -c "'echo $lpc_loop_cnt > $ipc_flood_dfs'"
+    sudo bash -c "echo $lpc_loop_cnt > $ipc_flood_dfs"
 
     # check kernel log for each iteration to catch issues
     sof-kernel-log-check.sh "$KERNEL_CHECKPOINT" || die "Caught error in kernel log"

--- a/tools/sof-kernel-dump.sh
+++ b/tools/sof-kernel-dump.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# FIXME: replace calls to this complex and buggy script with much
+# simpler calls to `journalctl -k` which has a slightly different (but
+# customizable) format; a few extra messages and most importantly: never
+# rotates and never loses the first 'Linux version' line.
+
 # dump the kernel information from target
 last_order=${1:-0}
 # check whether parameter 1 has the Non-Number


### PR DESCRIPTION
Overriden commands should work exactly like real commands and support
whitespace and special characters exactly like the real command.

I usually disable the sudo() override locally when using `set -x`
to reduce trace noise considerably. The previous difference between the
sudo() override and the built-in sudo() cost me couple hours twice:

- WIP https://github.com/thesofproject/sof-test/pull/897#discussion_r928074591
- Merged commit 232d40ae3e0a73

No more!

Also fix the return value: 2 means SKIP.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>