### PR TITLE
sof-kernel-log-check: ignore i915 Error Unclaimed access detected for…

### DIFF
--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -267,6 +267,10 @@ case "$platform" in
         # i915 0000:00:02.0: [drm] *ERROR* AUX A/DDI A/PHY A: did not complete or timeout within 10ms (status 0xad4003ff)
         # i915 0000:00:02.0: [drm] *ERROR* AUX A/DDI A/PHY A: not done (status 0xad4003ff)
         ignore_str="$ignore_str"'|i915 [[:digit:].:]+: \[drm\] \*ERROR\* AUX .+'
+        # i915 Unclaimed access detected, something to do with DMC in ADL
+        # unclaimed access happens when try to read/write something that is powered down
+        # issue link : internal issue #243
+        ignore_str="$ignore_str"'|i915 [[:digit:].:]+: \[drm\] \*ERROR\* Unclaimed access detected .+'
         ;;
     tgl)
         # Bug Report: https://github.com/thesofproject/sof-test/issues/838


### PR DESCRIPTION
… ADL

The unclaimed access error happens when try to read/write something
that is powered down. Something to do with DMC fw loading. Even with this
error, this affects only graphics not audio or HDMI.

Signed-off-by: Fred Oh <fred.oh@linux.intel.com>