### PR TITLE
lib.sh: fix recent check_error_in_file() . Exclude BSW

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -363,7 +363,7 @@ check_error_in_file()
     local platf; platf=$(sof-dump-status.py -p)
 
     case "$platf" in
-        byt|bdw)
+        byt|bdw|bsw)
             # Maybe downgrading this to WARN would be enough, see #799
             #  src/trace/dma-trace.c:654  ERROR dtrace_add_event(): number of dropped logs = 8
             dlogw 'not looking for ERROR on BYT/BDW because of known DMA issues #4333 and others'

--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -356,8 +356,6 @@ func_lib_start_log_collect()
     sudo "${loggerCmd[@]}" > "$logfile" &
 }
 
-# -B 2 shows the header line when the first etrace message is an ERROR
-# -A 1 shows whether the ERROR is last or not.
 check_error_in_file()
 {
     local platf; platf=$(sof-dump-status.py -p)
@@ -375,7 +373,11 @@ check_error_in_file()
         dloge "file NOT FOUND: '$1'"
         return 1
     }
-    if grep -B 2 -A 1 -E 'ERRO?R?' "$1"; then
+    # -B 2 shows the header line when the first etrace message is an ERROR
+    # -A 1 shows whether the ERROR is last or not.
+    if (set -x
+        grep -B 2 -A 1 -i -w -e 'ERR' -e 'ERROR' "$1"
+       ); then
        return 1
     fi
 }


### PR DESCRIPTION
2 commits. Main one:

Use -w to catch the words 'ERR' and 'ERROR' and avoid unrelated words
like 'ovERRuns' (unless of course they're prefixed with ERROR)

Fixes recent commit https://github.com/thesofproject/sof-test/commit/87aeb4d5eb79e5200581d444b0c19882d8b27bc8 ("check-sof-logger: catch ERROR in
firmware traces and fail")

Add -i: no reason to catch errors only in upper case.

Log the grep commands using set -x
