### PR TITLE
lib.sh: add EHL to the list of "slow storage" systems

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -199,7 +199,7 @@ storage_checks()
     case "$platf" in
         # BYT Minnowboards run from SD cards.
         # BSW Cyan has pretty bad eMMC too.
-        byt|cht) megas=4 ; max_sync=25 ;;
+        byt|cht|ehl) megas=4 ; max_sync=25 ;;
         *) megas=100; max_sync=7 ;;
     esac
 


### PR DESCRIPTION
Our EHL system uses eMMC and fails the "fast" storage
check from time to time. See internal issue 280 and
daily results 14411

Signed-off-by: Marc Herbert <marc.herbert@intel.com>