### PR TITLE
check-sof-logger.sh: minor message adjustment for cavstool

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -363,7 +363,7 @@ check_error_in_file()
     local platf; platf=$(sof-dump-status.py -p)
 
     case "$platf" in
-        byt|bdw)
+        byt|bdw|bsw)
             # Maybe downgrading this to WARN would be enough, see #799
             #  src/trace/dma-trace.c:654  ERROR dtrace_add_event(): number of dropped logs = 8
             dlogw 'not looking for ERROR on BYT/BDW because of known DMA issues #4333 and others'

--- a/test-case/check-sof-logger.sh
+++ b/test-case/check-sof-logger.sh
@@ -189,6 +189,8 @@ main()
     # Keeping these confusing DMA names because they're used in
     # several other places.
     stdout_files=(data  etrace)
+    # This is not actually stderr for cavstool, see comment at cavstool
+    # invocation
     stderr_files=(error etrace_stderr)
 
     reload_drivers
@@ -203,7 +205,7 @@ main()
         if test -s "$stderr_file"; then
             print_logs_exit 1 "stderr $stderr_file is not empty"
         fi
-        printf 'GOOD: %s was empty, no stderr output from that sof-logger instance\n' \
+        printf 'GOOD: %s was empty, no (std)err(or) output from that logger\n' \
                logger."$f".txt > "$stderr_file"
     done
 


### PR DESCRIPTION
2 commits, main one:

check-sof-logger.sh: minor message adjustment for cavstool

cavstool does not use stderr for errors but to make the difference
between local logs and remote logs. Adjust the message accordingly.

Fixes commit https://github.com/thesofproject/sof-test/commit/d6c0e76eacbf0d37310ce59a9e78ca2e7d351b8a ("check-sof-logger: add cavstool support")

EDIT: https://sof-ci.01.org/softestpr/PR950/build120/devicetest/ all green.