### PR TITLE
alsa_settings: CAVS_NOCODEC: reset values to 0dB/on with script

### DIFF
--- a/alsa_settings/CAVS_NOCODEC.sh
+++ b/alsa_settings/CAVS_NOCODEC.sh
@@ -1,21 +1,11 @@
 set -e
 
-# SSP playback
-amixer -c sofnocodec cset name='PGA1.0 1 Master Playback Volume' 32
-amixer -c sofnocodec cset name='PGA3.0 3 Master Playback Volume' 32
-amixer -c sofnocodec cset name='PGA5.0 5 Master Playback Volume' 32
+# to set the volume as 0dB we have to use the scontrol interface
+amixer -Dhw:0 scontrols | sed -e "s/^.*'\(.*\)'.*/\1/" | while read -r mixer_name; do
+     amixer -Dhw:0 -- sset "$mixer_name" 0dB;
+done
 
-# SSP capture
-amixer -c sofnocodec cset name='PGA2.0 2 Master Capture Switch' on
-amixer -c sofnocodec cset name='PGA2.0 2 Master Capture Volume' 50
-
-amixer -c sofnocodec cset name='PGA4.0 4 Master Capture Switch' on
-amixer -c sofnocodec cset name='PGA4.0 4 Master Capture Volume' 50
-
-amixer -c sofnocodec cset name='PGA6.0 6 Master Capture Switch' on
-amixer -c sofnocodec cset name='PGA6.0 6 Master Capture Volume' 50
-
-# DMIC capture
-amixer -c sofnocodec cset name='Dmic0 Capture Switch' on
-amixer -c sofnocodec cset name='Dmic0 Capture Volume' 50
-amixer -c sofnocodec cset name='Dmic1 2nd Capture Volume' 50
+# to turn the switches on we have to use the control interface
+amixer -Dhw:0 controls | grep Switch | sed -e 's/.*numid=\([^,]*\),.*/\1/' | while read -r i; do
+    amixer -Dhw:0 cset numid=$i on;
+done

--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -745,6 +745,13 @@ re_enable_ntp_sync()
 # param1: platform name
 set_alsa_settings()
 {
+    # If MODEL is defined, set proper gain for the platform
+    if [ -z "$1" ]; then
+	# treat as warning only
+	dlogw "NO MODEL is defined. Please define MODEL to run alsa_settings/MODEL.sh"
+	return 0
+    fi
+
     # ZEPHYR platform shares same tplg, remove '_ZEPHYR' from platform name
     local PNAME="${1%_ZEPHYR}"
     dlogi "Run alsa setting for $PNAME"

--- a/test-case/check-alsabat.sh
+++ b/test-case/check-alsabat.sh
@@ -59,13 +59,7 @@ then
 fi
 
 # If MODEL is defined, set proper gain for the platform
-if [ -z "$MODEL" ]; then
-    # treat as warning only
-    dlogw "NO MODEL is defined. Please define MODEL to run alsa_settings/MODEL.sh"
-else
-    #dlogi "apply alsa settings for alsa_settings/MODEL.sh"
-    set_alsa_settings "$MODEL"
-fi
+set_alsa_settings "$MODEL"
 
 logger_disabled || func_lib_start_log_collect
 

--- a/test-case/check-volume-levels.sh
+++ b/test-case/check-volume-levels.sh
@@ -90,6 +90,8 @@ main () {
     fi
 
     sof-kernel-log-check.sh "$KERNEL_CHECKPOINT"
+
+    set_alsa_settings "$MODEL"
 }
 
 #

--- a/test-case/volume-basic-test.sh
+++ b/test-case/volume-basic-test.sh
@@ -89,4 +89,6 @@ done
 #clean up background aplay
 pkill -9 aplay
 
+set_alsa_settings "$MODEL"
+
 exit 0


### PR DESCRIPTION
We should not encode specific mixer values that are tied to a
topology. The values should always be 0dB and all switches on, this
can be done with a script.

Credits to Marc Herbert for the sed regexp for the controls string.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>