### PR TITLE
tplgtool2: skip unknown vendor array

### DIFF
--- a/tools/tplgtool2.py
+++ b/tools/tplgtool2.py
@@ -351,7 +351,10 @@ class TplgBinaryFormat:
             "size" / Int32ul, # size in bytes of the array, including all elements
             "type" / Enum(Int32ul, VendorTupleType),
             "num_elems" / Int32ul, # number of elements in array
-            "elems" / Array(this.num_elems, Switch(this.type, self._vendor_elem_cases))
+            "elems" / Select(
+                Array(this.num_elems, Switch(this.type, self._vendor_elem_cases, default=construct.StopIf(True))),
+                Padding(this.size) # skip unknown vendor array
+            )
         )
         self._private = Prefixed( # snd_soc_tplg_private
             Int32ul, # size


### PR DESCRIPTION
The topology might contain custom vendor array data, which is unrecorgnized by this "standard" topology parser. Previously, it didn't handle this case and will get stuck when parsing that part. Now it will skip the unknown vendor array and continue parsing the rest parts.

Signed-off-by: Yongan Lu <yongan.lu@intel.com>