### PR TITLE
tplgtool2: parse vendor array for DAPM widgets only and raise error for unknown vendor types 

### DIFF
--- a/tools/tplgtool2.py
+++ b/tools/tplgtool2.py
@@ -351,7 +351,7 @@ class TplgBinaryFormat:
             "size" / Int32ul, # size in bytes of the array, including all elements
             "type" / Enum(Int32ul, VendorTupleType),
             "num_elems" / Int32ul, # number of elements in array
-            "elems" / Array(this.num_elems, Switch(this.type, self._vendor_elem_cases))
+            "elems" / Array(this.num_elems, Switch(this.type, self._vendor_elem_cases, default=construct.Error)),
         )
         # expand the union of snd_soc_tplg_private for different sections:
         self._private_raw = Prefixed(


### PR DESCRIPTION
Previously, parsing `cavs-tgl-nocodec.tplg` got stuck because it treat the NHLT table in the manifest private data as a vendor array and didn't catch the unexpected vendor tuple types.

These 2 parts to fix it and improve soundness:

1. parse vendor array for DAPM widgets only
2. raise error for unknown vendor types

Signed-off-by: Yongan Lu <yongan.lu@intel.com>