### PR TITLE
check-playback: add check for FW performance

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -693,6 +693,26 @@ ipc4_used()
     return 0
 }
 
+is_ipc4_zephyr(){
+    # check if the ipc_type first
+    ipc4_used || return 1
+
+    local firmware_path znum
+    local firmware_name=dsp_basefw.bin
+    fw_mod_para=/sys/module/snd_sof_pci/parameters/fw_path
+
+    if [ ! -s "$fw_mod_para" ]; then
+        firmware_path=$(cat $fw_mod_para)
+    else
+        # TODO: let the kernel driver expose the FW path
+        # and get the FW path by grepping journalctl.
+        return 1
+    fi
+
+    znum=$(strings "/lib/firmware/$firmware_path/$firmware_name" | grep -c -i zephyr)
+    test "$znum" -gt 10
+}
+
 logger_disabled()
 {
     local ldcFile

--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -293,6 +293,24 @@ find_ldc_file()
     printf '%s' "$ldcFile"
 }
 
+func_mtrace_collect()
+{
+    local clogfile=$LOG_ROOT/mtrace.txt
+
+    if [ -z "$MTRACE" ]; then
+        MTRACE=$(command -v mtrace-reader.py) || {
+            dlogw 'No mtrace-reader.py found in PATH'
+            return 1
+        }
+    fi
+
+    local mtraceCmd="$MTRACE"
+    dlogi "Starting ${mtraceCmd[*]}"
+    # Cleaned up by func_exit_handler() in hijack.sh
+    # shellcheck disable=SC2024
+    sudo "${mtraceCmd[@]}" >& "$clogfile" &
+}
+
 func_sof_logger_collect()
 {
     logfile=$1

--- a/test-case/check-playback.sh
+++ b/test-case/check-playback.sh
@@ -97,6 +97,15 @@ do
                     func_lib_lsof_error_dump "$snd"
                     die "aplay on PCM $dev failed at $i/$loop_cnt."
                 }
+
+		tplg_basename=$(basename $tplg)
+		platform=$(sof-dump-status.py -p)
+		is_ipc4_zephyr && {
+		    data_file=$LOG_ROOT/mtrace.txt
+		    test_reference_key="${platform}-${tplg_basename}-ipc4-zephyr-check-playback-${dev}"
+		    TOPDIR="$(dirname "${BASH_SOURCE[0]}")"/..
+		    $TOPDIR/tools/sof-ll-timer-check.py ${data_file} $test_reference_key $TOPDIR/tools/sof-ll-timer-check-db.json
+		}
             done
         done
     done

--- a/tools/sof-ll-timer-check-db.json
+++ b/tools/sof-ll-timer-check-db.json
@@ -1,0 +1,11 @@
+[
+    {
+	"test-key": "tgl-sof-tgl-nocodec.tplg-ipc4-zephyr-check-playback-hw:0,0" ,
+	"ll-timer-avg":  2589
+    },
+    {
+	"test-key": "tgl-sof-tgl-nocodec.tplg-ipc4-zephyr-check-playback-hw:0,1" ,
+	"ll-timer-avg":  2589
+    }
+]
+

--- a/tools/sof-ll-timer-check.py
+++ b/tools/sof-ll-timer-check.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+'''Script to analyze performance data in SOF FW log output'''
+
+import sys
+import re
+import json
+from statistics import median
+
+# allowed error margin before error is raised for
+# lower observed performance (1.05 -> 5% difference
+# required to raise error)
+AVG_ERROR_MARGIN = 1.05
+
+max_vals = []
+avg_vals = []
+overruns = 0
+
+f = open(sys.argv[1])
+
+for line in f:
+    m = re.search('.*ll timer avg ([0-9]*), max ([0-9]*), overruns ([0-9]*)', line)
+    if m:
+        avg_vals.append(int(m.group(1)))
+        max_vals.append(int(m.group(2)))
+        overruns += int(m.group(3))
+
+median_avg_vals = median(avg_vals)
+print("Measurements:\t\t%d" % len(avg_vals))
+print("Median avg reported:\t%d" % median_avg_vals)
+print("Median max reported:\t%d" % median(max_vals))
+print("Highest max reported:\t%d" % max(max_vals))
+
+if overruns:
+    print("ERROR: %s overruns detected" % overruns, file=sys.stderr)
+    sys.exit(-1)
+
+if len(sys.argv) < 4:
+    print("No reference data for key '%s', unable to check performance against reference")
+    sys.exit(0)
+
+median_avg_ref = None
+dbfile = open(sys.argv[3])
+ref_key = sys.argv[2]
+ref_data_all = json.load(dbfile)
+
+for ref in ref_data_all:
+    if ref["test-key"] == ref_key:
+        median_avg_ref = ref["ll-timer-avg"]
+        break
+
+if not median_avg_ref:
+    print("No reference data for key '%s', unable to check performance against reference" % ref_key)
+    sys.exit(0)
+
+median_avg_ref_w_margin = median_avg_ref * AVG_ERROR_MARGIN
+if median_avg_vals > median_avg_ref_w_margin:
+    print("ERROR: ll-timer-avg median %d over threshold %d (%d without margin)" % (median_avg_vals, median_avg_ref_w_margin, median_avg_ref), file=sys.stderr)
+    sys.exit(-1)


### PR DESCRIPTION
**NOTE:** This PR is based on top of https://github.com/thesofproject/sof-test/pull/956

check-playback: add check for FW performance
    
Add a tool to analyze the performance traces that are emitted
by the FW low-latency scheduler, and use this tool in the check
playback test case.
    
The tool requires output of FW logs and currently only supports
the mtrace output available in SOF Zephyr IPC4 builds. This can
be extended later for other output types.
  
The sof-ll-timer-check.py can do some simple global check like
observing occurences of low-latency scheduler overruns and raise
an error in this case.
    
For most of the analysis, sof-ll-timer-check.py needs reference
data detailing what the expected performance level should be.
To implement this, a simple JSON database is added via
sof-ll-timer-check-db.json that is used to query the reference
data. As this data is manually maintained, it is expected
reference data is only used for a small set of key use-cases for
any given platform.
