### PR TITLE
kmod: remove avs drivers

### DIFF
--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -118,6 +118,12 @@ remove_module snd_intel_sst_core
 remove_module snd_soc_sst_atom_hifi2_platform
 remove_module snd_soc_skl
 
+#-------------------------------------------
+# AVS drivers (not used but loaded)
+#-------------------------------------------
+remove_module snd_soc_avs
+remove_module snd_soc_hda_codec
+
 #------------------------------------------------------
 # obsolete platform drivers - kept to avoid breaking CI
 #------------------------------------------------------


### PR DESCRIPTION
With the addition of the AVS drivers in the default config, the kmod insert/remove tests are now broken

RMMOD	snd_hda_ext_core
rmmod: ERROR: Module snd_hda_ext_core is in use by: snd_soc_avs snd_soc_hda_codec

Make sure thse drivers are removed ahead of time.

Link: https://sof-ci.01.org/linuxpr/PR3881/build841/devicetest/
Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>