### PR TITLE
verify-kernel-boot-log: add DISPLAY=:0 xrandr --listmonitors

### DIFF
--- a/test-case/verify-kernel-boot-log.sh
+++ b/test-case/verify-kernel-boot-log.sh
@@ -62,6 +62,8 @@ wait_is_system_running()
         systemctl "$manager" --no-pager --failed
         systemctl "$manager" | grep -v active
         systemctl "$manager" is-system-running
+        # See https://github.com/thesofproject/sof-test/discussions/964
+        DISPLAY=:0 xrandr --listmonitors
     )
     die "Some services are not running correctly"
 }

--- a/test-case/verify-kernel-boot-log.sh
+++ b/test-case/verify-kernel-boot-log.sh
@@ -58,7 +58,7 @@ wait_is_system_running()
     if [ $ret = 124 ]; then
         dloge "$0 timed out waiting $wait_secs seconds for ${cmd[*]}"
     fi
-    (   set +e; set +x
+    (   set +e; set -x
         systemctl "$manager" --no-pager --failed
         systemctl "$manager" | grep -v active
         systemctl "$manager" is-system-running


### PR DESCRIPTION
The lack of monitor causes a org.gnome.Shell failure to start when using
AutomaticLoginEnable=True, see
https://github.com/thesofproject/sof-test/discussions/964 for details.