### PR TITLE
check-sof-logger: fix cavstool banner check

### DIFF
--- a/test-case/check-sof-logger.sh
+++ b/test-case/check-sof-logger.sh
@@ -231,7 +231,7 @@ main()
             boot_banner='dma-trace.c.*FW ABI.*tag.*hash'
         fi
 
-        head -n 1 "$tracef" | grep -q "$tool_banner"  ||
+        head -n 5 "$tracef" | grep -q "$tool_banner"  ||
             print_logs_exit 1 "Log header not found in ${tracef}"
 
         # See initial message SOF PR #3281 / SOF commit 67a0a69


### PR DESCRIPTION
The test started failing with recent Zephyr upstream due to combination of use of "asyncio.get_event_loop().run_until_complete(main())" in cavstool.py , which triggers a deprecation warning on Python 3.10 and newer.

Make the cavstool check more robust by checking for multiple lines of text in cavstool output for the tool banner.

Suggested-by: Marc Herbert <marc.herbert@intel.com>
Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>