### PR TITLE
check-sof-logger: add support for mtrace log with IPC4

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -410,7 +410,7 @@ check_error_in_file()
     # -B 2 shows the header line when the first etrace message is an ERROR
     # -A 1 shows whether the ERROR is last or not.
     if (set -x
-        grep -B 2 -A 1 -i -w -e 'ERR' -e 'ERROR' "$1"
+        grep -B 2 -A 1 -i --word-regexp -e 'ERR' -e 'ERROR' -e '<err>' "$1"
        ); then
        return 1
     fi

--- a/test-case/check-sof-logger.sh
+++ b/test-case/check-sof-logger.sh
@@ -3,20 +3,20 @@
 ##
 ## Case Name: check-sof-logger
 ## Preconditions:
-##    sof-logger installed in system path
-##    ldc file is in /etc/sof/ or /lib/firmware
+##    sof-logger, cavstool.py and mtrace-reader.py installed in system path
+##    dictionary (ldc) file is in /etc/sof/ or /lib/firmware
 ##
 ## Description:
-##    Checks basic functionality of the sof-logger itself. Does not test
+##    Checks basic functionality of the logging tools. Does not test
 ##    the firmware, i.e., does NOT fail when errors are found in the
 ##    logs.
 ##
 ## Case step:
-##    1. check sof-logger in system
-##    2. check ldc file in system
-##    3. run sof-logger
+##    1. check existance of logging tools in system
+##    2. check presence of dictionary files in system
+##    3. run logging tools
 ## Expect result:
-##    sof-logger produces some output and did not fail
+##    Fimrware log output is detected and the tools did not report error
 ##
 
 set -e

--- a/test-case/check-sof-logger.sh
+++ b/test-case/check-sof-logger.sh
@@ -174,14 +174,20 @@ reload_drivers()
 
     "${TOPDIR}"/tools/kmod/sof_insert.sh
 
+    # sof-test assumes SOF card to be loaded as first (card0)
+    # card in the system
+    CARD_NODE="/proc/asound/card0/id"
+
     # The DSP may unfortunately need multiple retries to boot, see
     # https://github.com/thesofproject/sof/issues/3395
-    dlogi "Polling /sys/kernel/debug/sof/etrace, waiting for DSP boot..."
+    dlogi "Polling ${CARD_NODE}, waiting for DSP boot..."
     for i in $(seq 1 5); do
-        if sudo test -e /sys/kernel/debug/sof/etrace; then break; fi
+        if sudo test -e ${CARD_NODE} ; then
+            dlogi "Found ${CARD_NODE}."
+            break;
+        fi
         sleep 1
     done
-    dlogi "Found /sys/kernel/debug/sof/etrace."
 }
 
 main()


### PR DESCRIPTION
Add support for "mtrace" debugfs interface implemented by SOF driver when it is used in IPC4 mode. Use this instead of cavstool.py.

BugLink: https://github.com/thesofproject/sof-test/issues/970
Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>