### PR TITLE
test: add an option to skip the DMIC pipelines

### DIFF
--- a/case-lib/config.sh
+++ b/case-lib/config.sh
@@ -58,6 +58,12 @@ SUDO_LEVEL=${SUDO_LEVEL:-}
 #
 # NO_BT_MODE=true
 
+# Sometimes the DMIC support is not ready on some new platforms.
+# We want to skip the DMIC test for some purposes. Add an option
+# to skip the DMIC pipeline.
+#
+# NO_DMIC_MODE=true
+
 # SOF_TEST_INTERVAL informs sof-test of how long the external test
 # runner waits between the end of one sof-test and the start of the next
 # sof-test. sof-test uses this value to assign the corresponding kernel

--- a/case-lib/pipeline.sh
+++ b/case-lib/pipeline.sh
@@ -53,6 +53,8 @@ func_pipeline_export()
     [ -z "$NO_HDMI_MODE" ] || opt="$opt & ~pcm:HDMI"
     # In no Bluetooth mode, exclude BT pipelines
     [ -z "$NO_BT_MODE" ] || opt="$opt & ~pcm:Bluetooth"
+    # In no DMIC mode, exclude DMIC pipelines
+    [ -z "$NO_DMIC_MODE" ] || opt="$opt & ~pcm:DMIC"
     opt="-f '${opt}'"
 
     [[ "$ignore" ]] && opt="$opt -b '$ignore'"


### PR DESCRIPTION
On some new platform, the DMIC support is not ready at the early stage, add an option to disable the DMIC pipelines.

Signed-off-by: Keqiao Zhang <keqiao.zhang@intel.com>