### PR TITLE
hijack: roll back signal before func_exit_handler

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -6,6 +6,9 @@ trap 'func_exit_handler $?' EXIT
 # Overwrite other functions' exit to perform environment cleanup
 function func_exit_handler()
 {
+    # roll back signal to avoid infinity recursive calls
+    trap '' EXIT
+
     local exit_status=${1:-0}
 
     # call trace


### PR DESCRIPTION
if any function inside func_exit_handle calls exit indirectly, it will lead
to infinity recursive calls. Roll back the signal in the beginning of the
handler to avoid such cases.

Signed-off-by: Yong-an Lu <yongan.lu@intel.com>