### PR TITLE
sof-kernel-log-check: filter out TPM operation cancelled

### DIFF
--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -277,6 +277,8 @@ case "$platform" in
         # Bug Report: https://github.com/thesofproject/sof-test/issues/838
         # New TGLU_UP_HDA_ZEPHYR device reporting "TPM interrupt not working" errors.
         ignore_str="$ignore_str"'|kernel: tpm tpm0: \[Firmware Bug\]: TPM interrupt not working, polling instead'
+        # Bug Report: https://github.com/thesofproject/sof-test/issues/936
+        ignore_str="$ignore_str"'|kernel: tpm tpm0: Operation Canceled'
         ;;
     ehl)
         # i915 crtc logs can be ignored


### PR DESCRIPTION
Filter out new log:
[  971.469391] kernel: tpm tpm0: Operation Canceled

Link: https://github.com/thesofproject/sof-test/issues/986
Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>