### PR TITLE
check-alsabat.sh: use 821Hz as default test frequency

### DIFF
--- a/test-case/check-alsabat.sh
+++ b/test-case/check-alsabat.sh
@@ -34,7 +34,7 @@ OPT_NAME['c']='pcm_c'      	OPT_DESC['c']='pcm for capture. Example: hw:1,0'
 OPT_HAS_ARG['c']=1             OPT_VAL['c']=''
 
 OPT_NAME['f']='frequency'       OPT_DESC['f']='target frequency'
-OPT_HAS_ARG['f']=1             OPT_VAL['f']=997
+OPT_HAS_ARG['f']=1             OPT_VAL['f']=821
 
 OPT_NAME['n']='frames'          OPT_DESC['n']='test frames'
 OPT_HAS_ARG['n']=1             OPT_VAL['n']=240000


### PR DESCRIPTION
Lower the default test frequency from 997Hz to 821Hz. Most SOF topologies use 1000Hz tick rate, and test frequency close to this scheduling frequency can mask certain type of errors (like SOF bug

Link: https://github.com/thesofproject/sof/issues/6709
Suggested-by: Seppo Ingalsuo <seppo.ingalsuo@linux.intel.com>
Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>