### PR TITLE
lib: check locale for alsabat

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -782,6 +782,15 @@ check_ntp_sync()
     timedatectl show | grep -q "NTPSynchronized=yes"
 }
 
+# alsabat will return -2 for "C.UTF-8" locale
+# every case with alsabat should call this at beginning
+check_locale_for_alsabat()
+{
+    if locale | grep -i 'C.utf-8'; then
+        die 'Try C.utf8 instead, see https://github.com/alsa-project/alsa-utils/issues/192'
+    fi
+}
+
 re_enable_ntp_sync()
 {
     # disable synchronization first

--- a/test-case/check-alsabat.sh
+++ b/test-case/check-alsabat.sh
@@ -58,6 +58,8 @@ then
 	exit 2
 fi
 
+check_locale_for_alsabat
+
 # If MODEL is defined, set proper gain for the platform
 if [ -z "$MODEL" ]; then
     # treat as warning only

--- a/test-case/check-fw-echo-reference.sh
+++ b/test-case/check-fw-echo-reference.sh
@@ -20,8 +20,7 @@ set -e
 rm -f /tmp/bat.wav.*
 
 # shellcheck source=case-lib/lib.sh
-libdir=$(dirname "${BASH_SOURCE[0]}")
-source "$libdir"/../case-lib/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
 OPT_NAME['t']='tplg'         OPT_DESC['t']='tplg file, default value is env TPLG: $''TPLG'
 OPT_HAS_ARG['t']=1             OPT_VAL['t']="$TPLG"

--- a/test-case/check-fw-echo-reference.sh
+++ b/test-case/check-fw-echo-reference.sh
@@ -49,6 +49,8 @@ if [ "$PIPELINE_COUNT" != "2" ]; then
     die "Only detect $PIPELINE_COUNT pipeline(s) from topology, but two are needed"
 fi
 
+check_locale_for_alsabat
+
 for idx in $(seq 0 $((PIPELINE_COUNT - 1)))
 do
     type=$(func_pipeline_parse_value "$idx" type)


### PR DESCRIPTION
alsabat always returns -2 for "C.UTF-8" locale. Suggest user set locale to "C.utf8" to avoid this issue.

see https://github.com/alsa-project/alsa-utils/issues/192

Signed-off-by: Yong-an Lu <yongan.lu@intel.com>