### PR TITLE
verify-kernel-boot-log.sh: add grep i915_display_info on failure

### DIFF
--- a/test-case/verify-kernel-boot-log.sh
+++ b/test-case/verify-kernel-boot-log.sh
@@ -64,6 +64,8 @@ wait_is_system_running()
         systemctl "$manager" is-system-running
         # See https://github.com/thesofproject/sof-test/discussions/964
         DISPLAY=:0 xrandr --listmonitors
+        DISPLAY=:1024 xrandr --listmonitors
+        sudo grep -i connected /sys/kernel/debug/dri/0/i915_display_info
     )
     die "Some services are not running correctly"
 }


### PR DESCRIPTION
DISPLAY=:0 xrandr --listmonitors is not reliable anymore, see

- https://github.com/thesofproject/sof-test/discussions/964

Keep it anyway because it works on older Ubuntu and probably many other Linux distributions too.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>