### PR TITLE
verify-kernel-boot-log.sh: don't SKIP when i915 is missing

### DIFF
--- a/test-case/verify-kernel-boot-log.sh
+++ b/test-case/verify-kernel-boot-log.sh
@@ -66,6 +66,7 @@ wait_is_system_running()
         DISPLAY=:0 xrandr --listmonitors
         DISPLAY=:1024 xrandr --listmonitors
         sudo grep -i connected /sys/kernel/debug/dri/0/i915_display_info
+        true
     )
     die "Some services are not running correctly"
 }


### PR DESCRIPTION
`grep something missing_file` returns 2. When the file is missing this is misinterpreted as SKIP as seen in daily test run 20752. This happens because the grep is the last command in the subshell.

The `grep /sys/kernel/debug/dri/0/i915_display_info` and the including subshell are not part of the test; ignore their exit code and let the rest of the test code decide what the exit value of the test is.

Fixes commit aadd7707cb261

Signed-off-by: Marc Herbert <marc.herbert@intel.com>