### PR TITLE
verify-kernel-boot-log.sh: add delay before checking NTP sync

### DIFF
--- a/test-case/verify-kernel-boot-log.sh
+++ b/test-case/verify-kernel-boot-log.sh
@@ -82,6 +82,9 @@ ntp_check()
         # before stopping ntp and after enabling ntp.
         re_enable_ntp_sync
 
+        # In normal case, it will trigger NTP sync immediately,
+        # but expect some network delay.
+        sleep 5
         if check_ntp_sync; then
             printf '\nTime Check: NTP Synchronized after re-enabling ntp sync\n'
         else


### PR DESCRIPTION
re_enable_ntp_sync will trigger ntp sync immediately, but it may take some time due to network delay. Some delay is required before checking ntp sync again.

@plbossart found the failure.
https://sof-ci.01.org/linuxpr/PR4209/build3362/devicetest/index.html?model=TGLU_RVP_SDW_IPC4ZPH&testcase=verify-kernel-boot-log

@marc-hb left the comment long back ago, I looked down the point.
https://github.com/thesofproject/sof-test/pull/779#discussion_r1115155292