### PR TITLE
Improve topology python scripts for ipc4

### DIFF
--- a/test-case/check-keyword-detection.sh
+++ b/test-case/check-keyword-detection.sh
@@ -55,7 +55,7 @@ duration=${OPT_VAL['d']}
 
 logger_disabled || func_lib_start_log_collect
 
-func_pipeline_export "$tplg" "kpbm:any"
+func_pipeline_export "$tplg" "kpb:any"
 
 if test "$PIPELINE_COUNT" != "1"; then
     die "detected $PIPELINE_COUNT wov pipeline(s) from topology, but 1 is needed"

--- a/tools/sof-tplgreader.py
+++ b/tools/sof-tplgreader.py
@@ -2,6 +2,7 @@
 
 from tplgtool import TplgParser, TplgFormatter
 from common import format_pipeline, export_pipeline
+import re
 
 class clsTPLGReader:
     def __init__(self):
@@ -43,6 +44,7 @@ class clsTPLGReader:
                 pgas = formatter.find_comp_for_pcm(pcm, 'PGA')
                 eqs = formatter.find_comp_for_pcm(pcm, 'EQ')
                 kwds = formatter.find_comp_for_pcm(pcm, 'KPBM')
+                kwds_ipc4 = formatter.find_comp_for_pcm(pcm, 'kpb')
                 asrcs = formatter.find_comp_for_pcm(pcm, 'ASRC')
                 codec_adapters = formatter.find_comp_for_pcm(pcm, 'CODEC_ADAPTER')
                 pipeline_dict = {}
@@ -55,6 +57,7 @@ class clsTPLGReader:
                 clsTPLGReader.attach_comp_to_pipeline(pgas, pcm['capture'], "PGA", pipeline_dict)
                 clsTPLGReader.attach_comp_to_pipeline(eqs, pcm['capture'], "EQ", pipeline_dict)
                 clsTPLGReader.attach_comp_to_pipeline(kwds, pcm['capture'], "KPBM", pipeline_dict)
+                clsTPLGReader.attach_comp_to_pipeline(kwds_ipc4, pcm['capture'], "kpb", pipeline_dict)
                 clsTPLGReader.attach_comp_to_pipeline(asrcs, pcm['capture'], "ASRC", pipeline_dict)
                 clsTPLGReader.attach_comp_to_pipeline(codec_adapters, pcm['capture'], "CODEC_ADAPTER", pipeline_dict)
                 # supported formats of playback pipeline in formats[0]
@@ -351,14 +354,14 @@ PIPELINE_$ID['key']='value' ''')
 
     # If run general test case on WOV pipeline or ECHO REFERENCE capture pipeline, there will be error
     # due to no feed data, and they should be blocked in general test case.
-    default_block_keyword = 'kpbm:any;type:capture & echo;'
+    default_block_keyword = 'kpbm:any;kpb:any;type:capture & echo;'
     # if no filter or block item is specified, the "block_none" here will help to
     # block nothing
     block_str = "block_none"
     # user specified block items from command line
     cmd_block_str = ret_args['block'].strip() if ret_args['block'] is not None else ''
 
-    if ret_args['filter'] is not None and 'kpbm' not in ret_args['filter'] and 'echo' not in ret_args['filter']:
+    if ret_args["filter"] is not None and not re.search('echo|kpb', ret_args["filter"]):
         block_str = default_block_keyword + cmd_block_str
     else:
         block_str = cmd_block_str if cmd_block_str != '' else block_str

--- a/tools/sof-tplgreader.py
+++ b/tools/sof-tplgreader.py
@@ -102,16 +102,6 @@ class clsTPLGReader:
                 pipeline['snd'] += 'p'
             else:
                 pipeline['snd'] += 'c'
-        # find interweaved pipelines
-        # echo: echo reference pipelines
-        # smart_amp: dsm pipelines
-        interweaved_comps = ['echo', 'smart_amp']
-        for comp in interweaved_comps:
-            interweaved_dict = formatter.find_interweaved_pipeline(comp)
-            if interweaved_dict:
-                for pipeline in self._pipeline_lst:
-                    if pipeline['cap_name'] in interweaved_dict['sname']:
-                        pipeline[comp] = interweaved_dict[comp]
         return 0
 
     # The following functions re-implement built-in Python sets

--- a/tools/tplgtool.py
+++ b/tools/tplgtool.py
@@ -749,12 +749,12 @@ class TplgFormatter:
                 TplgFormatter.recursive_search_comp(elem, comp_type, comp_list, direction)
 
         if type(node) != list and direction == "forward":
-            if node["widget"]["name"].startswith(comp_type):
+            if node["widget"]["name"].lower().startswith(comp_type):
                 if not comp_in_list(node, comp_list): comp_list.append(node["widget"])
             TplgFormatter.recursive_search_comp(node["sink"], comp_type, comp_list, direction)
 
         if type(node) != list and direction == "backward":
-            if node["widget"]["name"].startswith(comp_type):
+            if node["widget"]["name"].lower().startswith(comp_type):
                 if not comp_in_list(node, comp_list): comp_list.append(node["widget"])
             TplgFormatter.recursive_search_comp(node["source"], comp_type, comp_list, direction)
 
@@ -763,7 +763,7 @@ class TplgFormatter:
     def find_connected_comp(ref_node, comp_type):
         if ref_node is None:
             return None
-        comp_type = comp_type.upper() # to upper case
+        comp_type = comp_type.lower()
         comp_list = []
         node = ref_node
         TplgFormatter.recursive_search_comp(node, comp_type, comp_list, "forward")


### PR DESCRIPTION
Yongan has a new version of tplgtool2.py, and we are supposed to do a new sof-tplgreader.py based on tplgtool2.py, however, no one has time for it. the old sof-tplgreader.py and tplgtool.py are still used.
So this patch does the improvement based on old python scripts, to make the pipeline filter better for IPC4. 

The main purpose is to filter out wov capture pipeline in normal capturing. so this is needed before adding wov pipeline to ipc4 nocodec topology 