### PR TITLE
hijack: don't collect logger if SOF_LOGGING=none

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -101,8 +101,8 @@ function func_exit_handler()
 
     fi
 
-    if is_ipc4 && is_firmware_file_zephyr; then
-	local mtraceBin; mtraceBin=mtrace-reader.py
+    if [ "$SOF_LOGGING" != 'none' ] && is_ipc4 && is_firmware_file_zephyr; then
+        local mtraceBin; mtraceBin=mtrace-reader.py
         dlogi "pkill -TERM -f $mtraceBin"
         sudo pkill -TERM -f "$mtraceBin" || {
             dloge "mtrace-reader.py was already dead"


### PR DESCRIPTION
SOF_LOGGING=none means no logger log. This condition must be checked before the other conditions.