### PR TITLE
hijack.sh: properly disable shellcheck on fake logfile=$logfile 

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -52,7 +52,10 @@ function func_exit_handler()
         sleep 1
 
         # $logfile is defined in a different file (lib.sh)
-        # shellcheck disable=SC2154
+        # Instead of disabling SC2154 every time $logfile is used, fool
+        # _shellcheck with a "fake" definition here where we can disable
+        # SC2269 only once.
+        # shellcheck disable=SC2154,SC2269
         logfile="$logfile"
 
         local loggerBin wcLog; loggerBin=$(basename "$SOFLOGGER")


### PR DESCRIPTION
Fixes warning found in
https://github.com/thesofproject/sof-test/actions/runs/4635603962/jobs/8202801248?pr=1018 testing PR #1018

See inline comments. Fixes commit 0ccb4c80d2f8716 ("hijack.sh: more generic way to disable unknown $logfile shellcheck")

Different shellcheck versions may warn about this fake definition differently but life is too short to compare them, just disable both SC2154 and SC2269