### PR TITLE
alsa_settings: change amixer settings for MTLP_RVP_SDW

### DIFF
--- a/alsa_settings/MTLP_RVP_SDW.sh
+++ b/alsa_settings/MTLP_RVP_SDW.sh
@@ -6,5 +6,5 @@ amixer -c sofsoundwire cset name='rt711 FU05 Playback Volume' 60
 
 # enable headset capture
 amixer -c sofsoundwire cset name='Headset Mic Switch' on
-amixer -c sofsoundwire cset name='rt711 ADC 08 Capture Switch' on
-amixer -c sofsoundwire cset name='rt711 ADC 08 Capture Volume' 25
+amixer -c sofsoundwire cset name='rt711 FU0F Capture Switch' on
+amixer -c sofsoundwire cset name='rt711 FU0F Capture Volume' 43


### PR DESCRIPTION
Overall amplitude of the captured waveform is about 50%.

tested with https://github.com/thesofproject/linux/pull/4295