### PR TITLE
multiple-pipeline: simplify testing options with playback/capture/all 

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -43,6 +43,9 @@ fi
 
 _SOF_TEST_LOCK_FILE=/tmp/sof-test-card"$SOFCARD".lock
 
+# define min/max function
+minvalue() { printf '%d' $(( "$1" < "$2"  ? "$1" : "$2" )); }
+
 # This implements two important features:
 #
 # 1. Log the start of each test with the current ktime in journalctl.

--- a/test-case/multiple-pipeline.sh
+++ b/test-case/multiple-pipeline.sh
@@ -96,12 +96,15 @@ func_run_pipeline_with_type()
     func_pipeline_export "$tplg" "type:$direction $opt_filter"
     local -a idx_lst
     if [ ${OPT_VAL['r']} -eq 0 ]; then
-        idx_lst=("$(seq 0 $((PIPELINE_COUNT - 1)))")
+        # shellcheck disable=SC2207
+        idx_lst=($(seq 0 $((PIPELINE_COUNT - 1))))
     else
         # convert array to line, shuf to get random line, covert line to array
-        idx_lst=("$(seq 0 $((PIPELINE_COUNT - 1)) | sed 's/ /\n/g' | shuf | xargs)")
+        # shellcheck disable=SC2207
+        idx_lst=($(seq 0 $((PIPELINE_COUNT - 1)) | sed 's/ /\n/g' | shuf | xargs))
     fi
-    for idx in ${idx_lst[*]}
+
+    for idx in "${idx_lst[@]}"
     do
         channel=$(func_pipeline_parse_value "$idx" channel)
         rate=$(func_pipeline_parse_value "$idx" rate)


### PR DESCRIPTION
-f option was introduced to decide whether to fill the pipeline with
playback or capture first. But it causes more confusion. Now still keep
-f option, but to simplify the pipeline mode option.

playback mode : only plyaback pipeline
capture mode : only capture pipelines
all mode : run both playback and capture pipelines

Simple usage example:

* playback pipelines only
multiple-pipeline-playback.sh # playback with default values
multiple-pipeline-playback.sh -c 5 -l 15
or
multiple-pipeline.sh -f p -c 5 -l 15

* capture pipelines only
multiple-pipeline-capture.sh # capture with default values
multiple-pipeline-capture.sh -c 5 -l 15
or
multiple-pipeline.sh -f c -c 5 -l 15

* all pipelines, set pipeline count large enough (SOF CI need to change the command from '-f p' to '-f a')
multiple-pipeline.sh -f a -c 20 -l 50

fixes:
- https://github.com/thesofproject/sof-test/issues/1022