### PR TITLE
lib: wait for fw loaded before starting any test

### DIFF
--- a/case-lib/config.sh
+++ b/case-lib/config.sh
@@ -90,3 +90,13 @@ FALLBACK_TO_PROC=${FALLBACK_TO_PROC:-false}
 
 # Skip the storage checks if they aren't required
 ENABLE_STORAGE_CHECKS=${ENABLE_STORAGE_CHECKS:-0}
+
+# start_test in lib.sh will check whether FW is loaded before every test case.
+# If FW LOADING is not a prerequisite for the test, or if you just want to skip
+# the check, then define NO_POLL_FW_LOADING to true.
+# NO_POLL_FW_LOADING=true
+
+# Set MAX Polling time to check FW Loading. If FW is already loaded, it will
+# return immediately. Default value is set to 60 seconds, because i915 driver
+# timeout is 60 seconds.
+MAX_WAIT_FW_LOADING=${MAX_WAIT_FW_LOADING:-70}

--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -74,6 +74,18 @@ start_test()
         return 0
     }
 
+    # Check for whether SOF fW is loaded or not before starting any test
+    # without --since=@"$KERNEL_CHECKPOINT", it will be scan for current boot
+    # fw loaded -> sof module removed case can't be detected.
+    # Mainly it is going to check whether the sof-test can be started after boot/reboot
+    if [ -z "$NO_POLL_FW_LOADING" ]; then
+        if poll_wait_for 1 "$MAX_WAIT_FW_LOADING" sof_firmware_boot_complete; then
+            dlogi "Good to start the test, FW is loaded!"
+        else
+            die "FW is not loaded for $MAX_WAIT_FW_LOADING"
+        fi
+    fi
+
     export SOF_TEST_TOP_PID="$$"
     local prefix; prefix="ktime=$(ktime) sof-test PID=${SOF_TEST_TOP_PID}"
     local ftemp; ftemp=$(mktemp --tmpdir sof-test-XXXXX)


### PR DESCRIPTION
This is going to check whether the sof-test can be started after boot/reboot.

If FW LOADING is not a prerequisite for the test, this can be skipped, by defining NO_POLL_FW_LOADING=true

Another benefit with this change, if FW is not loaded it will be failed instead of TIMEOUT.