### PR TITLE
check-kmod-load-unload: remove hard-coded 10s timeout

### DIFF
--- a/test-case/check-kmod-load-unload.sh
+++ b/test-case/check-kmod-load-unload.sh
@@ -91,8 +91,7 @@ do
         die "Found error(s) in kernel log after module insertion"
 
     dlogi "checking if firmware is loaded successfully"
-    # Check every 1s for 10s
-    if poll_wait_for 1 10 sof_firmware_boot_complete --since=@"$KERNEL_CHECKPOINT"; then
+    if poll_wait_for 1 "$MAX_WAIT_FW_LOADING" sof_firmware_boot_complete --since=@"$KERNEL_CHECKPOINT"; then
         grep_firmware_info_in_logs --since=@"$KERNEL_CHECKPOINT"
     else
          die "Failed to load firmware after module insertion"


### PR DESCRIPTION
We already have a parameter for boot timeouts, let's use it. This enables kmod tests on MTL RVP.

Closes: https://github.com/thesofproject/sof-test/issues/1037