### PR TITLE
alsa_settings: set capture gain to 0dB for MTLP_RVP_SDW

### DIFF
--- a/alsa_settings/MTLP_RVP_SDW.sh
+++ b/alsa_settings/MTLP_RVP_SDW.sh
@@ -7,4 +7,4 @@ amixer -c sofsoundwire cset name='rt711 FU05 Playback Volume' 60
 # enable headset capture
 amixer -c sofsoundwire cset name='Headset Mic Switch' on
 amixer -c sofsoundwire cset name='rt711 FU0F Capture Switch' on
-amixer -c sofsoundwire cset name='rt711 FU0F Capture Volume' 43
+amixer -c sofsoundwire cset name='rt711 FU0F Capture Volume' 23


### PR DESCRIPTION
USB sound card is upgraded to stereo recording. After re-evaluating the output, the capture volume was too high. Set to 0dB.

23 is 0 dB
43 is 15 db
1 step = 0.75dB