### PR TITLE
verify-tplg-binary.sh: Shellcheck fixes.

### DIFF
--- a/test-case/verify-tplg-binary.sh
+++ b/test-case/verify-tplg-binary.sh
@@ -19,20 +19,21 @@ set -e
 # shellcheck source=case-lib/lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
-OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $''TPLG'
+OPT_NAME['t']='tplg'     OPT_DESC['t']="tplg file, default value is env TPLG: $TPLG"
 OPT_HAS_ARG['t']=1         OPT_VAL['t']="$TPLG"
 
 func_opt_parse_option "$@"
 setup_kernel_check_point
 tplg=${OPT_VAL['t']}
 
-tplg_path=`func_lib_get_tplg_path "$tplg"`
-[[ "$?" != "0" ]] && die "No available topology for this test case"
+tplg_path=$(func_lib_get_tplg_path "$tplg") ||
+    die "No available topology ($tplg) for this test case"
 
 dlogi "Checking topology file: $tplg_path"
-dlogi "Found file: $(md5sum $tplg_path|awk '{print $2, $1;}')"
-tplgData=$(sof-tplgreader.py $tplg_path 2>/dev/null)
-[[ -z "$tplgData" ]] && die "No valid pipeline(s) found in $tplg_path"
+dlogi "Found file: $(md5sum "$tplg_path" | awk '{print $2, $1;}')"
+tplgData=$(sof-tplgreader.py "$tplg_path") ||
+    die "No valid pipeline(s) found in $tplg_path"
+
 dlogi "Valid pipeline(s) in this topology:"
 echo "===========================>>"
 echo "$tplgData"


### PR DESCRIPTION
SC2006: Use $(...) notation instead of legacy backticked `...`. 

SC2181: Check exit code directly with e.g. 'if mycmd;', not indirectly with `$?`. 
Rewrote the tplg_path assignment to use `$( )` and to not compare against `$?`

SC2086: Double quote to prevent globbing and word splitting. 
Rewrote some tplg_path references to be double-quoted.

Signed-off-by: Greg Galloway <greg.galloway@intel.com>