### PR TITLE
verify-kernel-module-load-probe.sh: Shellcheck fixes.

### DIFF
--- a/test-case/verify-kernel-module-load-probe.sh
+++ b/test-case/verify-kernel-module-load-probe.sh
@@ -13,7 +13,8 @@ set -e
 ##    find sof relative module
 
 # source from the relative path of current folder
-source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
+# shellcheck source=case-lib/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
 func_opt_parse_option "$@"
 
@@ -21,7 +22,8 @@ setup_kernel_check_point
 
 dlogi "Checking if sof relative modules loaded"
 dlogc "lsmod | grep \"sof\""
-lsmod | grep "sof"
-[[ $? -ne 0 ]] && dloge "No available sof module found! Dumping lsmod:" && lsmod && exit 1
 
-exit 0
+lsmod | grep "sof" || {
+    lsmod
+    die "No available sof module found!"
+}


### PR DESCRIPTION
SC1091 (info): Not following: ./../case-lib/lib.sh: openBinaryFile: does not exist (No such file or directory)

Fixed lib.sh reference to be recognized by shellcheck.

SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.

Rewrote lsmod/grep conditional to check exit status directly. As previously written, and with set -e, the program flow on a grep failure would never reach the $? -ne 0 check.

Removed unnecessary "exit 0" from end of script.

Signed-off-by: Greg Galloway <greg.galloway@intel.com>