### PR TITLE
lib.sh: make MAX_WAIT_FW_LOADING platform dependent

### DIFF
--- a/case-lib/config.sh
+++ b/case-lib/config.sh
@@ -99,4 +99,6 @@ ENABLE_STORAGE_CHECKS=${ENABLE_STORAGE_CHECKS:-0}
 # Set MAX Polling time to check FW Loading. If FW is already loaded, it will
 # return immediately. Default value is set to 60 seconds, because i915 driver
 # timeout is 60 seconds.
-MAX_WAIT_FW_LOADING=${MAX_WAIT_FW_LOADING:-70}
+
+# The default value is defined in case-lib/lib.sh. You can preempt it here:
+# MAX_WAIT_FW_LOADING=${MAX_WAIT_FW_LOADING:-90}

--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -77,6 +77,15 @@ start_test()
         return 0
     }
 
+    if test -z "$MAX_WAIT_FW_LOADING"; then
+        local _pltf; _pltf=$("$SCRIPT_HOME/tools/sof-dump-status.py" -p)
+        case "$_pltf" in
+            # broken i915 with long timeout, see comments in config.sh
+            mtl) MAX_WAIT_FW_LOADING=70;;
+            *)   MAX_WAIT_FW_LOADING=10;; # more than enough
+        esac
+    fi
+
     # Check for whether SOF fW is loaded or not before starting any test.
     # Only start the polling for firmware boot complete when SOF soundcard is not available
     # setup_kernel_check_point has already -1 second to avoid TOCTOU race condition


### PR DESCRIPTION
We don't want to wait for 70s in every test on every platform when the firmware does not load. When multiplied by the number of tests in a plan this can cause a considerable waste of hardware resources.

i915 timeout aside, 10s has proved over a long period to be more than enough.

Fixes: #1059