### PR TITLE
lib.sh,hijack.sh: restore ability to be sourced interactively

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -2,11 +2,19 @@
 
 SUDO_CMD=$(command -v sudo)
 
-trap 'func_exit_handler $?' EXIT
+# Register cleanup callback only when we're sourced by lib.sh itself
+# sourced by just other file level. Not when sourced interactively and
+# not when run as a "subtest".
+if [ "${#BASH_SOURCE[@]}" -eq 3 ]; then
+    trap 'func_exit_handler $?' EXIT
+fi
+
 # Overwrite other functions' exit to perform environment cleanup
 function func_exit_handler()
 {
     local exit_status=${1:-0}
+
+    dlogi "Starting func_exit_handler($exit_status)"
 
     # call trace
     if [ "$exit_status" -ne 0 ] ; then

--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -870,4 +870,8 @@ reset_sof_volume()
     done
 }
 
-start_test
+# Invoke start_test() only when we're sourced by just one other file
+# level. Not when sourced interactively and not when run as a "subtest".
+if [ "${#BASH_SOURCE[@]}" -eq 2 ]; then
+    start_test
+fi

--- a/case-lib/logging_ctl.sh
+++ b/case-lib/logging_ctl.sh
@@ -64,7 +64,7 @@ _func_log_directory()
     : "${SOF_LOGS_BASE:=${SCRIPT_HOME}}"
 
     local case_name log_dir timetag
-    case_name=$(basename "$SCRIPT_NAME")
+    case_name=$(basename -- "$SCRIPT_NAME")
     case_name=${case_name%.*}
     log_dir="${SOF_LOGS_BASE}/logs/$case_name"
     timetag=$(date +%F"-"%T)"-$RANDOM"


### PR DESCRIPTION
Run `start_test()` and `func_exit_handler()` only in "normal" usage, not
when sourced interactively (for interactive debug) and not as a subtest.

With this commit it's not possible to do this without any side-effect:

```
( source case-lib/lib.sh )
```

More to the point, it's now possible to run this and start interactive
testing without any unwanted actions:

```
source case-lib/lib.sh
get_firmware_path
```

- #1170 
- #1033 