### PR TITLE
alsa_settings: increase gain on headphone volume on GLK

### DIFF
--- a/alsa_settings/GLK_BOB_DA7219.sh
+++ b/alsa_settings/GLK_BOB_DA7219.sh
@@ -6,13 +6,13 @@ amixer -c sofglkda7219max cset name='Headphone Volume' 54
 amixer -c sofglkda7219max cset name='Headphone Switch' 1
 amixer -c sofglkda7219max cset name='Headphone ZC Gain Switch' 0
 amixer -c sofglkda7219max cset name='Headphone Jack Switch' 1
-amixer -c sofglkda7219max cset name='Playback Digital Volume' 111 111
+amixer -c sofglkda7219max cset name='Playback Digital Volume' 111
 amixer -c sofglkda7219max cset name='Playback Digital Switch' 1
 amixer -c sofglkda7219max cset name='Playback Digital Gain Ramp Switch' 1
 amixer -c sofglkda7219max cset name='Out DACR Mux' 3
 amixer -c sofglkda7219max cset name='Out DAIR Mux' 0
 amixer -c sofglkda7219max cset name='Mixer Out FilterL DACL Switch' 1
-amixer -c sofglkda7219max cset name='Mixer Out FilterR DACR Switch' 1 10
+amixer -c sofglkda7219max cset name='Mixer Out FilterR DACR Switch' 1
 amixer -c sofglkda7219max cset name='PGA1.0 1 Master Playback Volume' 32
 
 # set HDMI volume

--- a/alsa_settings/GLK_BOB_DA7219.sh
+++ b/alsa_settings/GLK_BOB_DA7219.sh
@@ -2,7 +2,7 @@ set -e
 
 # enable headset playback
 amixer -c sofglkda7219max cset name='Headphone Gain Ramp Switch' 1
-amixer -c sofglkda7219max cset name='Headphone Volume' 35 35
+amixer -c sofglkda7219max cset name='Headphone Volume' 54
 amixer -c sofglkda7219max cset name='Headphone Switch' 1
 amixer -c sofglkda7219max cset name='Headphone ZC Gain Switch' 0
 amixer -c sofglkda7219max cset name='Headphone Jack Switch' 1


### PR DESCRIPTION
Headphone Volume is set too low. 0db is most common setting but I set intentionally 3 db lower for safety.

For Headphone Volume for the device,
34 is -23db
54 is -3db
57 is 0db

Before with 34
![Screenshot from 2023-06-29 12-38-18](https://github.com/thesofproject/sof-test/assets/45636982/4cb0fe92-39d5-4219-a3b4-8634631db58a)

After with 54
![Screenshot from 2023-06-29 12-38-27](https://github.com/thesofproject/sof-test/assets/45636982/aad038d2-a764-4046-9070-6323fade2cab)
