### PR TITLE
volume-basic-test.sh: catch amixer failures and log all controls

### DIFF
--- a/test-case/volume-basic-test.sh
+++ b/test-case/volume-basic-test.sh
@@ -28,6 +28,8 @@ OPT_HAS_ARG['l']=1         OPT_VAL['l']=2
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
 OPT_HAS_ARG['s']=0             OPT_VAL['s']=1
 
+set -e
+
 func_opt_parse_option "$@"
 setup_kernel_check_point
 tplg=${OPT_VAL['t']}
@@ -86,7 +88,7 @@ do
 done
 
 #clean up background aplay
-pkill -9 aplay
+pkill -9 aplay || true
 
 dlogi "Reset all PGA volume to 0dB"
 reset_sof_volume || die "Failed to reset some PGA volume to 0dB."

--- a/test-case/volume-basic-test.sh
+++ b/test-case/volume-basic-test.sh
@@ -61,6 +61,8 @@ sleep 1
 
 sofcard=${SOFCARD:-0}
 readarray -t pgalist < <(amixer -c"$sofcard" controls | awk -Fname= 'toupper($2) ~ /PGA/ { print $2 }')
+# This (1) provides some logging (2) avoids skip_test if amixer fails
+amixer -c"$sofcard" controls
 dlogi "pgalist number = ${#pgalist[@]}"
 [[ ${#pgalist[@]} -ne 0 ]] || skip_test "No PGA control is available"
 


### PR DESCRIPTION
This (1) provides some logging (2) avoids `skip_test` if amixer fails