### PR TITLE
verify-tplg-binary.sh: create .png in $LOG_ROOT instead of /tmp

### DIFF
--- a/test-case/verify-tplg-binary.sh
+++ b/test-case/verify-tplg-binary.sh
@@ -44,7 +44,7 @@ main()
     # This one can find more problems, see sof-test#1054
     dlogi "Checking topology file with tplgtool2.py: $tplg_path"
     ( set -x
-      tplgtool2.py -D /tmp/ "$tplg_path" ) || {
+      tplgtool2.py -D "${LOG_ROOT}" "$tplg_path" ) || {
         ret=$?
         die "tplgtool2.py returned $ret"
     }

--- a/test-case/verify-tplg-binary.sh
+++ b/test-case/verify-tplg-binary.sh
@@ -43,7 +43,8 @@ main()
 {
     # This one can find more problems, see sof-test#1054
     dlogi "Checking topology file with tplgtool2.py: $tplg_path"
-    tplgtool2.py -D /tmp/ "$tplg_path" || {
+    ( set -x
+      tplgtool2.py -D /tmp/ "$tplg_path" ) || {
         ret=$?
         die "tplgtool2.py returned $ret"
     }

--- a/tools/tplgtool2.py
+++ b/tools/tplgtool2.py
@@ -1246,8 +1246,8 @@ Enables internal globbing mode: the single positional argument is not a file but
 --tplgroot, see below. To pass multiple patterns use "," to separate them.""")
         # The below options are used to control generated graph
         parser.add_argument('-D', '--directory', type=str, default=".", help="output directory for generated graph")
-        parser.add_argument('-F', '--format', type=str, default="png", help="output format for generated graph, check "
-            "https://graphviz.gitlab.io/_pages/doc/info/output.html for all supported formats")
+        parser.add_argument('-F', '--format', type=str, default="png", help="output format for generated graph, defaults to 'png'."
+            "check https://graphviz.gitlab.io/_pages/doc/info/output.html for all supported formats")
         parser.add_argument('-V', '--live_view', action="store_true", help="generate and view topology graph")
         parser.add_argument('-w', '--without_nodeinfo', action="store_true", help="show only widget names, no additional node info ")
         parser.add_argument('-c', '--show_core', choices=['never', 'auto', 'always'], default='auto',


### PR DESCRIPTION
3 commits. Main one:

------
verify-tplg-binary.sh: create .png in $LOG_ROOT instead of /tmp

It's better next to the "other" logs. Also means there's a single, usual
place to clean up.

We'd rather not create it at all but it's not optional.