### PR TITLE
tplgtool2: dump core ID for any widget not scheduled on core 0

### DIFF
--- a/tools/tplgtool2.py
+++ b/tools/tplgtool2.py
@@ -738,8 +738,8 @@ class GroupedTplg:
 
     @cached_property
     def coreids(self):
-        "All available core IDs."
-        cores = set()
+        "Core 0 is the default value."
+        cores = {0}
         for widget in self.widget_list:
             core = self.get_core_id(widget)
             if core is not None:


### PR DESCRIPTION
Dump core ID if some widgets are running on core 1 or 2 and the rest defaults to core 0.