### PR TITLE
Test-case: test-speaker.sh: Use pink noise for non-48 kHz rates

### DIFF
--- a/test-case/test-speaker.sh
+++ b/test-case/test-speaker.sh
@@ -43,8 +43,15 @@ do
     dev=$(func_pipeline_parse_value "$idx" dev)
     snd=$(func_pipeline_parse_value "$idx" snd)
 
-    dlogc "speaker-test -D $dev -r $rate -c $channel -f $fmt -l $tcnt -t wav -P 8"
-    speaker-test -D "$dev" -r "$rate" -c "$channel" -f "$fmt" -l "$tcnt" -t wav -P 8 2>&1 |tee "$LOG_ROOT"/result_"$idx".txt
+    # speaker-test only supports wav for 48 kHz test, pink noise works for all rates
+    if [ "$rate" = "48000" ]; then
+	sound_type="wav"
+    else
+	sound_type="pink"
+    fi
+
+    dlogc "speaker-test -D $dev -r $rate -c $channel -f $fmt -l $tcnt -t $sound_type -P 8"
+    speaker-test -D "$dev" -r "$rate" -c "$channel" -f "$fmt" -l "$tcnt" -t "$sound_type" -P 8 2>&1 |tee "$LOG_ROOT"/result_"$idx".txt
     resultRet=${PIPESTATUS[0]}
 
     if grep -nr -E "error|failed" "$LOG_ROOT"/result_"$idx".txt ||


### PR DESCRIPTION
The speaker test fails with -t wav internally for other than "-r 48000" because it is not re-sampling the wav "Front center" etc. clips. Using pink noise for non-48 kHz works around this limitation and allows to test with all sample rates. Also the test are not depending on spoken channels names. Channels order can be subjectively checked with the 48 kHz test.