### PR TITLE
Add test case for sof component performance check

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -168,6 +168,14 @@ function func_exit_handler()
         exit_status=$ret
     fi
 
+    # Only do performance analysis on test passed
+    [ "x$exit_status" != "x0" ] || {
+        # On performance analysis return error, set exit code
+        if ! perf_analyze; then
+           exit_status=1
+        fi
+    }
+
     # We must always print some 'Test Result' otherwise some callers
     # will time out. These strings must match (at least) Jenkins'
     # expectations, see internal sof-framework/clsTestCase.py

--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -872,4 +872,30 @@ reset_sof_volume()
     done
 }
 
+DO_PERF_ANALYSIS=0
+
+perf_analyze()
+{
+    local perf_cmd
+
+    [ "X$DO_PERF_ANALYSIS" == "X1" ] || return 0
+
+    dlogi "Checking SOF component performance"
+    if [ -e "$LOG_ROOT/mtrace.txt" ]; then
+        if [ -e "$LOG_ROOT/dmesg.txt" ]; then
+            perf_cmd="sof_perf_analyzer.py --kmsg=$LOG_ROOT/dmesg.txt $LOG_ROOT/mtrace.txt"
+        else
+            perf_cmd="sof_perf_analyzer.py $LOG_ROOT/mtrace.txt"
+        fi
+        dlogc "$perf_cmd"
+        eval "$perf_cmd" || {
+            dloge "SOF component performace analysis tool exit with error"
+            return 1
+        }
+    else
+        dloge "Firmware trace file not found"
+        return 1
+    fi
+}
+
 start_test

--- a/test-case/check-performance.sh
+++ b/test-case/check-performance.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+##
+## Case Name: check-performance
+## Preconditions:
+##    N/A
+## Description:
+##    Run aplay and arecord to playback and capture
+##    pipelines of the benchmark topology:
+##        sof-hda-benchmark-generic-PLATFORM.tplg
+## Case step:
+##    1. Parse TPLG file to get pipeline with type of playback
+##       and capture (exclude HDMI pipeline)
+##    2. Specify the audio parameters
+##    3. Run aplay and arecord on each pipeline with audio parameters
+## Expect result:
+##    The return value of aplay/arecord is 0
+##    Performance statistics are printed
+##
+
+set -e
+
+# It is pointless to perf component in HDMI pipeline, so filter out HDMI pipelines
+# shellcheck disable=SC2034
+NO_HDMI_MODE=true
+
+# shellcheck source=case-lib/lib.sh
+source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
+
+OPT_NAME['t']='tplg'     OPT_DESC['t']='tplg file, default value is env TPLG: $''TPLG'
+OPT_HAS_ARG['t']=1         OPT_VAL['t']="$TPLG"
+
+OPT_NAME['d']='duration' OPT_DESC['d']='aplay/arecord duration in second'
+OPT_HAS_ARG['d']=1         OPT_VAL['d']=30
+
+OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
+OPT_HAS_ARG['s']=0             OPT_VAL['s']=1
+
+func_opt_parse_option "$@"
+
+tplg=${OPT_VAL['t']}
+duration=${OPT_VAL['d']}
+
+logger_disabled || func_lib_start_log_collect
+
+setup_kernel_check_point
+func_lib_check_sudo
+func_pipeline_export "$tplg" "type:any"
+
+for idx in $(seq 0 $((PIPELINE_COUNT - 1)))
+do
+        channel=$(func_pipeline_parse_value "$idx" channel)
+        rate=$(func_pipeline_parse_value "$idx" rate)
+        dev=$(func_pipeline_parse_value "$idx" dev)
+        pcm=$(func_pipeline_parse_value "$idx" pcm)
+        type=$(func_pipeline_parse_value "$idx" type)
+
+        # Currently, copier will convert bit depth to S32_LE despite what bit depth
+        # is used in aplay, so make S32_LE as base bit depth for performance analysis.
+        fmt=S32_LE
+
+        dlogi "Running (PCM: $pcm [$dev]<$type>) in background"
+        if [ "$type" == "playback" ]; then
+            aplay_opts -D "$dev" -c "$channel" -r "$rate" -f "$fmt" -d "$duration" /dev/zero -q &
+        else
+            arecord_opts -D "$dev" -c "$channel" -r "$rate" -f "$fmt" -d "$duration" /dev/null -q &
+        fi
+done
+
+dlogi "Waiting for aplay/arecord process to exit"
+sleep $((duration + 2))
+
+# Enable performance analysis
+# shellcheck disable=SC2034
+DO_PERF_ANALYSIS=1


### PR DESCRIPTION
based on https://github.com/thesofproject/sof-test/pull/1064, add a test case for performance check
```
2023-08-16 06:33:37 UTC [INFO] ktime=524 sof-test PID=2513: starting
2023-08-16 06:33:37 UTC [INFO] Starting /usr/local/bin/mtrace-reader.py >& /home/ubuntu/sof-test/logs/check-performance/2023-08-16-06:33:36-7734/mtrace.txt &
2023-08-16 06:33:37 UTC [INFO] /home/ubuntu/sof-test/test-case/check-performance.sh will use topology /usr/lib/firmware/intel/sof-ace-tplg/sof-hda-generic-4ch.tplg to run the test case
2023-08-16 06:33:37 UTC [INFO] Pipeline list to ignore is specified, will ignore 'pcm=HDA Digital' in test case
2023-08-16 06:33:37 UTC [INFO] Run command to get pipeline parameters
2023-08-16 06:33:37 UTC [COMMAND] sof-tplgreader.py /usr/lib/firmware/intel/sof-ace-tplg/sof-hda-generic-4ch.tplg -f 'type:any & ~pcm:HDMI' -b ' pcm:HDA Digital' -s 0 -e
2023-08-16 06:33:37 UTC [INFO] Running (PCM: HDA Analog [hw:0,0]<playback>) in background
2023-08-16 06:33:37 UTC [COMMAND] aplay   -D hw:0,0 -c 2 -r 48000 -f S32_LE -d 30 /dev/zero -q
2023-08-16 06:33:37 UTC [INFO] Running (PCM: HDA Analog [hw:0,0]<capture>) in background
2023-08-16 06:33:37 UTC [COMMAND] arecord   -D hw:0,0 -c 2 -r 48000 -f S32_LE -d 30 /dev/null -q
2023-08-16 06:33:37 UTC [INFO] Running (PCM: Deepbuffer HDA Analog [hw:0,31]<playback>) in background
2023-08-16 06:33:37 UTC [COMMAND] aplay   -D hw:0,31 -c 2 -r 48000 -f S32_LE -d 30 /dev/zero -q
2023-08-16 06:33:37 UTC [INFO] Running (PCM: DMIC Raw [hw:0,6]<capture>) in background
2023-08-16 06:33:37 UTC [INFO] Waiting for aplay/arecord process to exit
2023-08-16 06:33:37 UTC [COMMAND] arecord   -D hw:0,6 -c 4 -r 48000 -f S32_LE -d 30 /dev/null -q
2023-08-16 06:34:09 UTC [INFO] Starting func_exit_handler(0)
2023-08-16 06:34:09 UTC [INFO] pkill -TERM -f mtrace-reader.py
2023-08-16 06:34:09 UTC [INFO] nlines=1248 /home/ubuntu/sof-test/logs/check-performance/2023-08-16-06:33:36-7734/mtrace.txt
2023-08-16 06:34:09 UTC [INFO] ktime=557 sof-test PID=2513: ending
2023-08-16 06:34:09 UTC [INFO] Checking SOF component performance
2023-08-16 06:34:09 UTC [COMMAND] sof_perf_analyzer.py --kmsg=/home/ubuntu/sof-test/logs/check-performance/2023-08-16-06:33:36-7734/dmesg.txt /home/ubuntu/sof-test/logs/check-performance/2023-08-16-06:33:36-7734/mtrace.txt

                     COMP_NAME,    COMP_ID,  AVG_OF_CPU_AVG, AVG_OF_CPU_PEAK, PEAK_OF_CPU_AVG, PEAK_OF_CPU_PEAK
                    mixout.2.1,  1-0x30000,            3.27,            3.72,            3.30,            13.34
                      gain.2.1,  1-0x60001,            2.61,            3.81,            2.75,            18.93
dai-copier.HDA.Analog.playback,  1-0x40001,            5.25,           10.56,            5.28,            15.55
        host-copier.0.playback,  0-0x40000,            4.57,            5.00,            4.58,            11.21
                      gain.1.1,  0-0x60000,            2.58,            3.76,            2.71,            19.64
                     mixin.1.1,  0-0x20000,            3.49,            3.80,            3.51,             7.93
                     gain.11.1,  4-0x60003,            2.81,            4.05,            3.00,            13.20
         host-copier.6.capture,  4-0x40005,            4.79,            5.49,            4.81,            16.27
dai-copier.DMIC.dmic01.capture,  3-0x40003,            6.92,            7.58,            7.03,            17.18
                          None, 3-0x100000,           15.29,           23.70,           15.29,            25.93
            module-copier.12.2,  3-0x40004,            3.26,            3.39,            3.26,             3.44
                          None,  2-0x40002,            4.24,            4.58,            4.25,             5.84
                          None,  2-0x60002,            2.64,            3.47,            2.75,             9.54
                    mixin.15.1,  2-0x20001,            3.63,            3.77,            3.65,             3.81
         host-copier.0.capture,  6-0x40007,            4.59,            4.76,            4.60,             5.24
 dai-copier.HDA.Analog.capture,  5-0x40006,            5.12,            5.26,            5.14,             5.30
                          None, 5-0x100001,            8.97,           20.77,            8.98,            21.29
2023-08-16 06:34:09 UTC [INFO] Test Result: PASS!
```

There is probably a bug in tools/sof_perf_analyzer.py here, so the component id matching is not work very well (as you see the None in above table), https://github.com/thesofproject/sof-test/blob/7cdf67ceea35969c5746095fdd5c7162a37b7761/tools/sof_perf_analyzer.py#L218 I will fix it later.