### PR TITLE
check-sof-logger: fix the DSP boot check

### DIFF
--- a/test-case/check-sof-logger.sh
+++ b/test-case/check-sof-logger.sh
@@ -234,15 +234,11 @@ reload_drivers()
     # The DSP may unfortunately need multiple retries to boot, see
     # https://github.com/thesofproject/sof/issues/3395
     dlogi "Polling ${CARD_NODE}, waiting for DSP boot..."
-    for i in $(seq 1 "${MAX_WAIT_FW_LOADING}" ); do
-        if sudo test -e ${CARD_NODE} ; then
-            dlogi "Found ${CARD_NODE}."
-            break;
-        fi
-        sleep 1
-    done
-
-    test -e ${CARD_NODE} || die "DSP did not boot (node ${CARD_NODE})"
+    if poll_wait_for 1 "$MAX_WAIT_FW_LOADING" sudo test -e ${CARD_NODE} ; then
+        dlogi "Found ${CARD_NODE}."
+    else
+        die "DSP did not boot (node ${CARD_NODE})"
+    fi
 }
 
 main()

--- a/test-case/check-sof-logger.sh
+++ b/test-case/check-sof-logger.sh
@@ -234,13 +234,15 @@ reload_drivers()
     # The DSP may unfortunately need multiple retries to boot, see
     # https://github.com/thesofproject/sof/issues/3395
     dlogi "Polling ${CARD_NODE}, waiting for DSP boot..."
-    for i in $(seq 1 5); do
+    for i in $(seq 1 "${MAX_WAIT_FW_LOADING}" ); do
         if sudo test -e ${CARD_NODE} ; then
             dlogi "Found ${CARD_NODE}."
             break;
         fi
         sleep 1
     done
+
+    test -e ${CARD_NODE} || die "DSP did not boot (node ${CARD_NODE})"
 }
 
 main()


### PR DESCRIPTION
The DSP boot check reload_drivers() must wait longer than 5 seconds as we have many configurations where DSP boot will take more than 60sec (due to e.g. Intel platforms with i915 hardware present but driver not present in the kernel version under test).

Additionally the test case must check whether DSP did boot up after the timeout expires, and fail the test case if it didn't.