### PR TITLE
add support to output sof performance data to csv

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -901,9 +901,9 @@ perf_analyze()
     dlogi "Checking SOF component performance"
     if [ -e "$LOG_ROOT/mtrace.txt" ]; then
         if [ -e "$LOG_ROOT/dmesg.txt" ]; then
-            perf_cmd="sof_perf_analyzer.py --kmsg=$LOG_ROOT/dmesg.txt $LOG_ROOT/mtrace.txt"
+            perf_cmd="sof_perf_analyzer.py --kmsg=$LOG_ROOT/dmesg.txt --out2csv $LOG_ROOT/sof_perf.csv $LOG_ROOT/mtrace.txt "
         else
-            perf_cmd="sof_perf_analyzer.py $LOG_ROOT/mtrace.txt"
+            perf_cmd="sof_perf_analyzer.py --out2csv $LOG_ROOT/sof_perf.csv $LOG_ROOT/mtrace.txt"
         fi
         dlogc "$perf_cmd"
         eval "$perf_cmd" || {


### PR DESCRIPTION
Two commits:
- support to output csv for performance data in sof_perf_analyzer
- enable the feature in sof-test case

An example of CSV output: [sof_perf.csv](https://github.com/thesofproject/sof-test/files/12519387/sof_perf.csv)
