### PR TITLE
tplgtool2.py: show widget CPC in topology graph

### DIFF
--- a/tools/tplgtool2.py
+++ b/tools/tplgtool2.py
@@ -234,6 +234,7 @@ class SofVendorToken(enum.IntEnum):
     SOF_TKN_COMP_FORMAT = 402
     SOF_TKN_COMP_CORE_ID = 404
     SOF_TKN_COMP_UUID = 405
+    SOF_TKN_COMP_CPC = 406
     # sof_ssp_tokens
     SOF_TKN_INTEL_SSP_CLKS_CONTROL = 500
     SOF_TKN_INTEL_SSP_MCLK_ID = 501
@@ -923,6 +924,9 @@ class TplgGraph:
                 self.show_core == 'auto' and self._tplg.has_core_differences
             ):
                 sublabel2 += f'<BR ALIGN="CENTER"/><SUB>core:{core}</SUB>'
+        comp_cpc = GroupedTplg.get_widget_token_value(widget, SofVendorToken.SOF_TKN_COMP_CPC)
+        if comp_cpc is not None:
+            sublabel2 += f'<BR ALIGN="CENTER"/><SUB>cpc:{comp_cpc}</SUB>'
         display_name = name
         wname = widget.widget.name
         # See the *_NUM_REGEX above

--- a/tools/tplgtool2.py
+++ b/tools/tplgtool2.py
@@ -690,10 +690,10 @@ class GroupedTplg:
             return default
 
     @staticmethod
-    def get_core_id(widget: Container, default = None):
-        "Get widget core ID."
-        return GroupedTplg.get_priv_element(widget["widget"], SofVendorToken.SOF_TKN_COMP_CORE_ID, default)
-    
+    def get_widget_token_value(widget: Container, token: SofVendorToken, default = None):
+        "Get the value for specified token"
+        return GroupedTplg.get_priv_element(widget["widget"], token, default)
+
     @staticmethod
     def get_widget_uuid(widget: Container, default = None):
         "Get widget UUID."
@@ -741,7 +741,7 @@ class GroupedTplg:
         "All available core IDs."
         cores = set()
         for widget in self.widget_list:
-            core = self.get_core_id(widget)
+            core = self.get_widget_token_value(widget, SofVendorToken.SOF_TKN_COMP_CORE_ID)
             if core is None:
                 cores.add(-1) # placeholder for the lack of core ID
             else:
@@ -917,7 +917,7 @@ class TplgGraph:
         attr = {}
         if not self.without_nodeinfo:
             sublabel = self.node_sublabel(widget)
-        core = GroupedTplg.get_core_id(widget)
+        core = GroupedTplg.get_widget_token_value(widget, SofVendorToken.SOF_TKN_COMP_CORE_ID)
         if core is not None:
             if self.show_core == 'always' or (
                 self.show_core == 'auto' and self._tplg.has_core_differences


### PR DESCRIPTION
This patch adds support to show widget CPC value
int topology graph.

![sof-hda-generic-4ch](https://github.com/thesofproject/sof-test/assets/52959957/8af1c205-aed7-44c5-a2a4-527eae5d3afa)
