### PR TITLE
sof_perf_analyzer: add skip-to-first-trace option

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -901,9 +901,9 @@ perf_analyze()
     dlogi "Checking SOF component performance"
     if [ -e "$LOG_ROOT/mtrace.txt" ]; then
         if [ -e "$LOG_ROOT/dmesg.txt" ]; then
-            perf_cmd="sof_perf_analyzer.py --kmsg=$LOG_ROOT/dmesg.txt --out2csv $LOG_ROOT/sof_perf.txt $LOG_ROOT/mtrace.txt "
+            perf_cmd="sof_perf_analyzer.py --skip-to-first-trace --kmsg=$LOG_ROOT/dmesg.txt --out2csv $LOG_ROOT/sof_perf.txt $LOG_ROOT/mtrace.txt"
         else
-            perf_cmd="sof_perf_analyzer.py --out2csv $LOG_ROOT/sof_perf.txt $LOG_ROOT/mtrace.txt"
+            perf_cmd="sof_perf_analyzer.py --skip-to-first-trace --out2csv $LOG_ROOT/sof_perf.txt $LOG_ROOT/mtrace.txt"
         fi
         dlogc "$perf_cmd"
         eval "$perf_cmd" || {

--- a/tools/sof_perf_analyzer.py
+++ b/tools/sof_perf_analyzer.py
@@ -26,7 +26,6 @@ import re
 import pathlib
 import argparse
 from typing import TextIO
-from typing import Optional
 from typing import Generator
 from dataclasses import dataclass
 
@@ -115,7 +114,7 @@ def dispatch_trace_item(trace_item: TraceItem):
     if trace_item.func == 'comp_copy':
         collect_perf_info(trace_item)
 
-def skip_to_first_trace(trace_item_gen: TraceItemGenerator) -> Optional[TraceItem]:
+def skip_to_first_trace(trace_item_gen: TraceItemGenerator):
     '''The current sof-test test case may collect some traces belonging to previous
     test case due to mtrace is configured in deferred mode. This function consumes
     those traces from the generator, and return the first trace item of current test.


### PR DESCRIPTION
In CI test, some traces from previous test case will apprear in the mtrace of current test case, this is a know issue.

Previously, we always skip to the first valid trace of this test case, this could raise trouble for developer use of this script.

This patch adds skip-to-first-trace option, for CI test, this option should be set (True), and for developer use, this option should be left as it is (False).