### PR TITLE
lib.sh: increase MAX_WAIT_FW_LOADING to 13s for CML

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -82,7 +82,11 @@ start_test()
         case "$_pltf" in
             # broken i915 with long timeout, see comments in config.sh
             mtl) MAX_WAIT_FW_LOADING=70;;
-            *)   MAX_WAIT_FW_LOADING=10;; # more than enough
+            # rt1011 i2c-10EC1011:00 needs 10 seconds on cml-hel-rt5682,
+            # see https://github.com/thesofproject/sof-test/pull/1095
+            cml) MAX_WAIT_FW_LOADING=13;;
+            # TODO: try to reduce this
+            *)   MAX_WAIT_FW_LOADING=10;;
         esac
     fi
 


### PR DESCRIPTION
rt1011 i2c-10EC1011:00 needs about 10 seconds to boot every time on cml-hel-rt5682, see evidence in #1095

```
21:59:16 snd_sof:ipc3_log_header: sof-audio-pci-intel-cnl 0000:00:1f.3: ipc tx: 0x30130000: GLB_TPLG_MSG: PIPE_COMPLETE
21:59:16 snd_sof:sof_ipc3_complete_pipeline: sof-audio-pci-intel-cnl 0000:00:1f.3: tplg: complete pipeline PIPELINE.1.SSP0.OUT id 5
21:59:16 snd_sof:ipc3_log_header: sof-audio-pci-intel-cnl 0000:00:1f.3: ipc tx: 0x30130000: GLB_TPLG_MSG: PIPE_COMPLETE
21:59:16 snd_hda_codec_hdmi ehdaudio0D2: ASoC: sink widget AIF1TX overwritten
21:59:16 snd_hda_codec_hdmi ehdaudio0D2: ASoC: source widget AIF1RX overwritten
21:59:16 rt1011 i2c-10EC1011:00: ADC offset=0x0
21:59:16 rt1011 i2c-10EC1011:00: Gain0 offset=0x1ffeea
21:59:16 rt1011 i2c-10EC1011:00: Gain1 offset=0x1ffed2
21:59:17 usbcore: registered new interface driver snd-usb-audio
21:59:18 rt1011 i2c-10EC1011:00: r0 resistance about 7.26 ohm, reg=0x2337F6
21:59:19 rt1011 i2c-10EC1011:01: ADC offset=0x0
21:59:19 rt1011 i2c-10EC1011:01: Gain0 offset=0x1bf
21:59:19 rt1011 i2c-10EC1011:01: Gain1 offset=0x196
21:59:21 rt1011 i2c-10EC1011:01: r0 resistance about 6.89 ohm, reg=0x2521A7
21:59:21 rt1011 i2c-10EC1011:02: ADC offset=0x0
21:59:21 rt1011 i2c-10EC1011:02: Gain0 offset=0x1ffca4
21:59:21 rt1011 i2c-10EC1011:02: Gain1 offset=0x1ffd97
21:59:23 rt1011 i2c-10EC1011:02: r0 resistance about 5.92 ohm, reg=0x2B2D08
21:59:23 rt1011 i2c-10EC1011:03: ADC offset=0x0
21:59:23 rt1011 i2c-10EC1011:03: Gain0 offset=0x276
21:59:23 rt1011 i2c-10EC1011:03: Gain1 offset=0x2d2
21:59:25 rt1011 i2c-10EC1011:03: r0 resistance about 6.16 ohm, reg=0x297CAC
21:59:26 snd_sof:sof_pcm_new: sof-audio-pci-intel-cnl 0000:00:1f.3: creating new PCM DMIC16kHz
21:59:26 snd_sof:sof_pcm_new: sof-audio-pci-intel-cnl 0000:00:1f.3: spcm: allocate Sound Trigger Capture 8 capture DMA buffer size 0x83400 max 0x138800
21:59:26 snd_sof:sof_pcm_new: sof-audio-pci-intel-cnl 0000:00:1f.3: creating new PCM Port1
21:59:26 snd_sof:sof_pcm_new: sof-audio-pci-intel-cnl 0000:00:1f.3: spcm: allocate Passthrough Playback 0 playback DMA buffer size 0x10000 max 0x10000
```