### PR TITLE
Add support for MIPI Sys-T logging

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -115,6 +115,9 @@ function func_exit_handler()
             dloge "Log file not found: $logfile"
             exit_status=1
         fi
+
+        # decode dictionary based log formats (if needed)
+        func_lib_log_post_process
     fi
 
     stop_test || exit_status=1

--- a/test-case/check-sof-logger.sh
+++ b/test-case/check-sof-logger.sh
@@ -277,14 +277,22 @@ main()
     # then for the 'FW ABI' banner
     for f in "${stdout_files[@]}"; do
         local tracef="$LOG_ROOT/logger.$f.txt"
+        local syst_prefix="SYS-T RAW DATA:"
         test -e "$tracef" || die "$tracef" not found
 
         local tool_banner boot_banner
         if is_ipc4 && is_firmware_file_zephyr && [ "$f" = 'etrace' ]; then
             # mtrace
-            # No specific tool banner, just check some logs are visible.
-            tool_banner=' .*<.*>'
-            boot_banner='FW ABI.*tag.*zephyr'
+            if head -n 5 "$tracef" | grep -q "$syst_prefix" ; then
+                # MIPI Sys-T Catalog format, just search for Sys-T prefix
+                # that is available without decoding tools and collateral
+                tool_banner=$syst_prefix
+                boot_banner=$syst_prefix
+            else
+                # ascii mtrace, no specfic tool banner, just check for some logs
+                tool_banner=' .*<.*>'
+                boot_banner='FW ABI.*tag.*zephyr'
+            fi
         elif is_firmware_file_zephyr && [ "$f" = 'etrace' ]; then
             # cavstool
             tool_banner=':cavs-fw:'


### PR DESCRIPTION
Add initial support for handling MIPI Sys-T Cat logging in SOF firmware:

- identify FW that emits logging in Sys-T Cat dictionary format
- use systprint tools to decode logs  ( https://github.com/MIPI-Alliance/public-mipi-sys-t )
- no flag day needed, this PR is compatible with other logging types (so can be merged without dependencies)

