### PR TITLE
start_test(): reduce default MAX_WAIT_FW_LOADING to 3s

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -85,8 +85,7 @@ start_test()
             # rt1011 i2c-10EC1011:00 needs 10 seconds on cml-hel-rt5682,
             # see https://github.com/thesofproject/sof-test/pull/1095
             cml) MAX_WAIT_FW_LOADING=13;;
-            # TODO: try to reduce this
-            *)   MAX_WAIT_FW_LOADING=10;;
+            *)   MAX_WAIT_FW_LOADING=3;;
         esac
     fi
 


### PR DESCRIPTION
Outside known issues we want to know when the firmware takes unusually long to load.