### PR TITLE
sof-kernel-log-check: ignore i915 firmware loading error

### DIFF
--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -279,6 +279,11 @@ case "$platform" in
         # unclaimed access happens when try to read/write something that is powered down
         # issue link : internal issue #243
         ignore_str="$ignore_str"'|i915 [[:digit:].:]+: \[drm\] \*ERROR\* Unclaimed access detected .+'
+        # i915 firmware loading error on ADLP_SKU0B00_SDCA
+        # BugLink: https://github.com/thesofproject/sof-test/issues/1048
+        ignore_str="$ignore_str"'|i915 [[:digit:].:]+: \[drm\] \*ERROR\* GT0: GuC initialization failed'
+        ignore_str="$ignore_str"'|i915 [[:digit:].:]+: \[drm\] \*ERROR\* GT0: Enabling uc failed'
+        ignore_str="$ignore_str"'|i915 [[:digit:].:]+: \[drm\] \*ERROR\* GT0: Failed to initialize GPU'
         ;;
     tgl)
         # Bug Report: https://github.com/thesofproject/sof-test/issues/838


### PR DESCRIPTION
Filter out below errors:
[ 8196.630952] kernel: i915 0000:00:02.0: [drm] *ERROR* GT0: GuC initialization failed -ENXIO
[ 8196.630953] kernel: i915 0000:00:02.0: [drm] *ERROR* GT0: Enabling uc failed (-5)
[ 8196.630955] kernel: i915 0000:00:02.0: [drm] *ERROR* GT0: Failed to initialize GPU, declaring it wedged!

Link: https://github.com/thesofproject/linux/issues/4530

cc:
- https://github.com/thesofproject/sof-test/pull/869