### PR TITLE
tplgtool2: print all supported formats of PCM and adjust alignment

### DIFF
--- a/tools/tplgtool2.py
+++ b/tools/tplgtool2.py
@@ -720,7 +720,7 @@ class GroupedTplg:
     def print_pcm_info(self):
         r"""Print pcm info, like::
 
-        pcm=Speaker;id=2;type=playback;fmt=S16_LE;rate_min=48000;rate_max=48000;ch_min=2;ch_max=2;
+        pcm=Speaker;id=2;type=playback;rate_min=48000;rate_max=48000;ch_min=2;ch_max=2;fmts=S16_LE S32_LE
         """
         for pcm in self.pcm_list:
             name = pcm["pcm_name"]
@@ -729,13 +729,14 @@ class GroupedTplg:
             fmt_list = self.get_pcm_fmt(pcm)
             cap_index = int(pcm_type == "capture") # 1 for capture, 0 for playback
             cap = pcm["caps"][cap_index]
-            fmt = fmt_list[cap_index][0] # only show first format
+            fmts = ' '.join(fmt_list[cap_index])
             rate_min = cap["rate_min"]
             rate_max = cap["rate_max"]
             ch_min = cap["channels_min"]
             ch_max = cap["channels_max"]
-            print(f"pcm={name};id={pcm_id};type={pcm_type};fmt={fmt};"
-            f"rate_min={rate_min};rate_max={rate_max};ch_min={ch_min};ch_max={ch_max};")
+            print(f"pcm={name};id={pcm_id};type={pcm_type};"
+            f"rate_min={rate_min};rate_max={rate_max};ch_min={ch_min};ch_max={ch_max};"
+            f"fmts={fmts}")
 
     @cached_property
     def coreids(self):

--- a/tools/tplgtool2.py
+++ b/tools/tplgtool2.py
@@ -720,8 +720,10 @@ class GroupedTplg:
     def print_pcm_info(self):
         r"""Print pcm info, like::
 
-        pcm=Speaker;id=2;type=playback;rate_min=48000;rate_max=48000;ch_min=2;ch_max=2;fmts=S16_LE S32_LE
+        pcm_id=2;name=Speaker;type=playback;rate_min=48000;rate_max=48000;ch_min=2;ch_max=2;fmts=S16_LE S32_LE
         """
+        max_name_len=max(len(pcm["pcm_name"]) for pcm in self.pcm_list)
+
         for pcm in self.pcm_list:
             name = pcm["pcm_name"]
             pcm_id = pcm["pcm_id"]
@@ -734,8 +736,8 @@ class GroupedTplg:
             rate_max = cap["rate_max"]
             ch_min = cap["channels_min"]
             ch_max = cap["channels_max"]
-            print(f"pcm={name};id={pcm_id};type={pcm_type};"
-            f"rate_min={rate_min};rate_max={rate_max};ch_min={ch_min};ch_max={ch_max};"
+            print(f"pcm_id={pcm_id:>2};name={name.ljust(max_name_len, ' ')};type={pcm_type:<8};"
+            f"rate_min={rate_min:>6};rate_max={rate_max:>6};ch_min={ch_min};ch_max={ch_max};"
             f"fmts={fmts}")
 
     @cached_property


### PR DESCRIPTION
Make print_pcm_info() show all supported formats of a PCM. The alignment and order of PCM attributes are also adjusted.

Update history:
v2: use fmts = ' '.join(fmt_list[cap_index]) to get all supported formats
      follow previous "key=value;"  format for PCM ID and name.
      make PCM name right-aligned to the longest PCM name


Example: sof-mtl-max98357a-rt5682-ssp2-ssp0-2ch-pdm1.tplg
Before change:
```
pcm=Headset;id=0;type=duplex;fmt=S16_LE;rate_min=48000;rate_max=48000;ch_min=2;ch_max=2;
pcm=Speakers;id=1;type=playback;fmt=S16_LE;rate_min=48000;rate_max=48000;ch_min=2;ch_max=2;
pcm=Bluetooth;id=2;type=duplex;fmt=S16_LE;rate_min=8000;rate_max=48000;ch_min=1;ch_max=2;
pcm=HDMI1;id=5;type=playback;fmt=S16_LE;rate_min=48000;rate_max=48000;ch_min=2;ch_max=8;
pcm=HDMI2;id=6;type=playback;fmt=S16_LE;rate_min=48000;rate_max=48000;ch_min=2;ch_max=8;
pcm=HDMI3;id=7;type=playback;fmt=S16_LE;rate_min=48000;rate_max=48000;ch_min=2;ch_max=8;
pcm=EchoRef;id=29;type=capture;fmt=S16_LE;rate_min=48000;rate_max=48000;ch_min=2;ch_max=2;
pcm=Deepbuffer Jack Out;id=31;type=playback;fmt=S16_LE;rate_min=48000;rate_max=48000;ch_min=2;ch_max=2;
pcm=DMIC Raw;id=99;type=capture;fmt=S32_LE;rate_min=48000;rate_max=48000;ch_min=2;ch_max=2;
```
After change:
```
pcm_id= 0;name=Headset            ;type=duplex  ;rate_min= 48000;rate_max= 48000;ch_min=2;ch_max=2;fmt=S16_LE S24_LE S32_LE
pcm_id= 1;name=Speakers           ;type=playback;rate_min= 48000;rate_max= 48000;ch_min=2;ch_max=2;fmt=S16_LE S24_LE S32_LE
pcm_id= 2;name=Bluetooth          ;type=duplex  ;rate_min=  8000;rate_max= 48000;ch_min=1;ch_max=2;fmt=S16_LE
pcm_id= 5;name=HDMI1              ;type=playback;rate_min= 48000;rate_max= 48000;ch_min=2;ch_max=8;fmt=S16_LE S32_LE
pcm_id= 6;name=HDMI2              ;type=playback;rate_min= 48000;rate_max= 48000;ch_min=2;ch_max=8;fmt=S16_LE S32_LE
pcm_id= 7;name=HDMI3              ;type=playback;rate_min= 48000;rate_max= 48000;ch_min=2;ch_max=8;fmt=S16_LE S32_LE
pcm_id=29;name=EchoRef            ;type=capture ;rate_min= 48000;rate_max= 48000;ch_min=2;ch_max=2;fmt=S16_LE S24_LE S32_LE
pcm_id=31;name=Deepbuffer Jack Out;type=playback;rate_min= 48000;rate_max= 48000;ch_min=2;ch_max=2;fmt=S16_LE S24_LE S32_LE
pcm_id=99;name=DMIC Raw           ;type=capture ;rate_min= 48000;rate_max= 48000;ch_min=2;ch_max=2;fmt=S32_LE
```
