### PR TITLE
check-sof-logger.sh: fix no-log-file failures due to RPM

### DIFF
--- a/test-case/check-sof-logger.sh
+++ b/test-case/check-sof-logger.sh
@@ -244,15 +244,11 @@ reload_drivers()
 
     "${TOPDIR}"/tools/kmod/sof_insert.sh
 
-    # sof-test assumes SOF card to be loaded as first (card0)
-    # card in the system
-    CARD_NODE="/proc/asound/card0/id"
-
     # The DSP may unfortunately need multiple retries to boot, see
     # https://github.com/thesofproject/sof/issues/3395
     dlogi "Polling ${CARD_NODE}, waiting for DSP boot..."
-    if poll_wait_for 1 "$MAX_WAIT_FW_LOADING" sudo test -e ${CARD_NODE} ; then
-        dlogi "Found ${CARD_NODE}."
+    if poll_wait_for 1 "$MAX_WAIT_FW_LOADING" sof_firmware_boot_complete --since=@"$KERNEL_CHECKPOINT"; then
+        dlogi "DSP booted successfully."
     else
         die "DSP did not boot (node ${CARD_NODE})"
     fi


### PR DESCRIPTION
The logger test case has a design limitation in that it assumes the SOF DSP to remain powered up between driver reload and start of the logger. This creates a possibility for a race with runtime PM (RPM).

If the DSP goes to runtime suspend during this window, it is not guaranteed that the SOF driver will provide any logs. Some logging mechanisms save the logs that were emitted before suspend (sof-logger/IPC3), but some not (cavstool/IPC3 and mtrace/IPC4).

To limit the window , add a simple ping of all PCM nodes just before logger process is started. This is a crude mechanism but something that works with all variants of SOF. End result is that DSP will be resumed to D0 just before the logger test starts.