### PR TITLE
sof_perf_analyzer: fix exception when kernel message not provided

### DIFF
--- a/tools/sof_perf_analyzer.py
+++ b/tools/sof_perf_analyzer.py
@@ -247,7 +247,10 @@ def format_perf_info() -> list[str] | None:
     '''Format SOF trace performance statistics'''
     if len(perf_stats):
         lines: list[str] = []
-        max_name_len = max(len(name) for name in component_name.values())
+        if args.kmsg:
+            max_name_len = max(len(name) for name in component_name.values())
+        else:
+            max_name_len = len('COMP_NAME') # The length of the first column title
         name_fmt = '{:>' + f'{max_name_len}' + '},'
         title_fmt = name_fmt + ' {:>10}, {:>12}, {:>12}, {:>12},'
         title_fmt = title_fmt + ' {:>13}, {:>13}, {:>13}, {:>18}'


### PR DESCRIPTION
If kernel message file is not provided, the component_name dict will be empty, in calculating the maximum length of component names, we calls the max function with an empty sequence, which raises below error:
    "ValueError: max() arg is an empty sequence"

This patch checks if component_name dict is empty, and on empty, provides a default value.