### PR TITLE
sof_perf_analyzer: fix incomplete pandas table printing

### DIFF
--- a/tools/sof_perf_analyzer.py
+++ b/tools/sof_perf_analyzer.py
@@ -240,7 +240,9 @@ def print_perf_info():
     '''Output SOF performance info'''
     stats = perf_stats.rename_axis('COMP_ID').reset_index()
     # pylint: disable=C0209
-    with pd.option_context('display.float_format', '{:0.3f}'.format):
+    with pd.option_context('display.float_format', '{:0.3f}'.format,
+                           'display.max_rows', None,
+                           'display.max_columns', None):
         print(stats)
 
     if args.out2csv is not None:


### PR DESCRIPTION
By default, pandas will only show part of the table in printing if the table have a row number greater than display.max_rows, or a column number greater than display.max_columns,

This patch makes sure the whole pandas table is printed by setting display.max_rows and display.max_columns to None in printing context.

Fixes: https://github.com/thesofproject/sof-test/issues/1117