### PR TITLE
multiple-pause-resume.sh: Check for aplay/arecord pid when waiting

### DIFF
--- a/test-case/multiple-pause-resume.sh
+++ b/test-case/multiple-pause-resume.sh
@@ -157,22 +157,28 @@ do
             func_pause_resume_pipeline "$idx"
             pid_lst=("${pid_lst[@]}" $!)
         done
-        # wait for expect script finished
-        dlogi "wait for expect process finished"
+        # wait for aplay/arecord finished
+        dlogi "wait for expect/aplay/arecord process finished"
         iwait=$max_wait_time
         while [ $iwait -gt 0 ]
         do
             iwait=$((iwait - 1))
             sleep 1s
-            [[ ! "$(pidof expect)" ]] && break
+            [[ ! "$(pidof expect aplay arecord)" ]] && break
         done
-        # fix aplay/arecord last output
+        # Catch timout after the wait loop
         echo
-        if [ "$(pidof expect)" ]; then
+        if [ "$(pidof expect aplay arecord)" ]; then
             dloge "Still have expect process not finished after wait for $max_wait_time"
-            # list aplay/arecord processes
+            # list expect/aplay/arecord processes
+            pgrep -a -f expect || true
             pgrep -a -f aplay || true
             pgrep -a -f arecord || true
+
+            # kill aplay/arecord
+            sof-process-kill.sh ||
+                dlogw "Kill process catch error"
+
             exit 1
         fi
         # now check for all expect quit status


### PR DESCRIPTION
It has been observed that the expect process has been terminated (pidof returns with no PID) but the child aplay is still running. This only happens with ChainDMA enabled PCMs where the time to stop the stream takes more than 100ms (from trigger stop to PCM close). With the right timing on such PCM the pidof expect will break the wait loop and we progress to the next iteration which - again with right timing and setup - might fail if the aplay is still in a process of closing and the next iteration includes the same PCM.

Add the aplay and arecord commands to the pidof command to make sure that the iteration has been completed before starting a new one. We will still catch timeouts and in that case we  should kill the stuck processes.