### PR TITLE
Change module CPC calculation

### DIFF
--- a/tools/sof_perf_analyzer.py
+++ b/tools/sof_perf_analyzer.py
@@ -27,8 +27,8 @@ from dataclasses import dataclass
 
 import pandas as pd
 
-# currently, keep CPC = avg_cpu_peak * CPC_MARGIN
-CPC_MARGIN = 1.15
+# currently, keep CPC = max(module peak) * CPC_MARGIN
+CPC_MARGIN = 1.1
 
 @dataclass()
 class TraceItem:
@@ -237,8 +237,7 @@ def analyze_perf_info():
     perf_stats.columns = ['CPU_AVG(MIN)', 'CPU_AVG(AVG)', 'CPU_AVG(MAX)',
                           'CPU_PEAK(MIN)', 'CPU_PEAK(AVG)', 'CPU_PEAK(MAX)']
     perf_stats['PEAK(MAX)/AVG(AVG)'] = perf_stats['CPU_PEAK(MAX)'] / perf_stats['CPU_AVG(AVG)']
-    comp_peak_avg_cycles = perf_info.groupby('COMP_ID')['CPU_PEAK'].mean()
-    perf_stats['MODULE_CPC'] = comp_peak_avg_cycles * CPC_MARGIN
+    perf_stats['MODULE_CPC'] = perf_info.groupby('COMP_ID')['CPU_PEAK'].max() * CPC_MARGIN
     # change data type from float to int
     perf_stats['MODULE_CPC'] = perf_stats['MODULE_CPC'].astype(int)
 


### PR DESCRIPTION
Previously, module CPC is calculated by multiplying the mean
value of cpu_peak with a margin scalar, after internal technical
discussion, change module CPC to the product of maximum value
of module's cpu_peak and the margin scalar, and change the margin
scalar to 1.1 as aligned.