### PR TITLE
lib.sh: print snd_hda* module params

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -867,6 +867,9 @@ print_module_params()
 
     # for all the *sof* modules
     grep -H ^ /sys/module/*sof*/parameters/* || true
+
+    # all snd_hda* modules
+    grep -H ^ /sys/module/snd_hda*/parameters/* || true
     echo "----------------------------------------"
 }
 


### PR DESCRIPTION
Useful to check snd_hda_* modules. Especially snd_hda_core module has gpu_bind parameter.