### PR TITLE
Codeowners: add code owner to performance script

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,3 +9,4 @@
 # will be requested to review.
 
 tools/kmod/*            @thesofproject/test-maintainers @plbossart
+tools/sof_perf_analyzer.py @thesofproject/test-maintainers @btian1 @andrula-song


### PR DESCRIPTION
Add btian1 and andrula-song as script: sof_perf_analyzer.py codeowner.