### PR TITLE
[SKIP SOF-TEST] .github: upgrade actions/checkout to version 4

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,7 +21,9 @@ jobs:
   shellcheck:
     runs-on: ubuntu-22.04
     steps:
-      - {uses: actions/checkout@v2, with: {fetch-depth: 0}}
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: shellcheck
         env:
           BASE_REF: ${{ github.base_ref }}
@@ -33,7 +35,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       # :-( https://github.community/t/support-for-yaml-anchors/16128
-      - {uses: actions/checkout@v2, with: {fetch-depth: 0}}
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - run: python --version
 
       # Package index is "out of date by design"


### PR DESCRIPTION
Fixes the following warning showing every time:

> The following actions uses node12 which is deprecated and will be
> forced to run on node16: actions/checkout@v2. For more info:
> https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

Example:
https://github.com/thesofproject/sof-test/actions/runs/7345203885