### PR TITLE
lib.sh: perf_analyze(): drop --skip-to-first-trace

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -966,9 +966,9 @@ perf_analyze()
     dlogi "Checking SOF component performance"
     if [ -e "$LOG_ROOT/mtrace.txt" ]; then
         if [ -e "$LOG_ROOT/dmesg.txt" ]; then
-            perf_cmd="sof_perf_analyzer.py --skip-to-first-trace --kmsg=$LOG_ROOT/dmesg.txt --out2html $LOG_ROOT/sof_perf.html $LOG_ROOT/mtrace.txt"
+            perf_cmd="sof_perf_analyzer.py --kmsg=$LOG_ROOT/dmesg.txt --out2html $LOG_ROOT/sof_perf.html $LOG_ROOT/mtrace.txt"
         else
-            perf_cmd="sof_perf_analyzer.py --skip-to-first-trace --out2html $LOG_ROOT/sof_perf.html $LOG_ROOT/mtrace.txt"
+            perf_cmd="sof_perf_analyzer.py --out2html $LOG_ROOT/sof_perf.html $LOG_ROOT/mtrace.txt"
         fi
         dlogc "$perf_cmd"
         eval "$perf_cmd" || {


### PR DESCRIPTION
(very different from the initial description)

The --skip-to-first-trace option was added as a precaution to exclude
log pollution from before the start of a test, normally the residue traces are
related to trigger stop IPC, dma put and component reset (as you can see).
There could be 10 ~ 20 lines.

mtrace timestamps used to return to zero on every DSP boot, which --skip-to-first-trace
depends on. After SOF commit 76b0979c6453 ("sync time between host and fw for logging"),
mtrace timestamps still return to zero (briefly) but only on "cold" DSP boots,
not on when booting from IMR. Booting from IMR has now been enabled by default
in most configurations. That combination breaks --skip-to-first-trace.

The only practical short-term solution is to turn off --skip-to-first-trace and take
the risk of old logs polluting the test results, which is what this commit does.

If results pollution proves to be a problem, we could in the longer term try to disable
IMR boot just before running this test using sof_debug as discussed in #1153
This would also measure from a possibly cleaner DSP state. New, DSP "debug ops"
being proposed in thesofproject/linux#4726 might also help.