### PR TITLE
lib.sh: Workaround sof-test output alignment issue

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -373,8 +373,10 @@ func_mtrace_collect()
     local mtraceCmd=("$MTRACE")
     dlogi "Starting ${mtraceCmd[*]} >& $clogfile &"
     # Cleaned up by func_exit_handler() in hijack.sh
+    # The use of 'bash -c' is a workaround for below issue:
+    # https://github.com/thesofproject/sof-test/issues/1151
     # shellcheck disable=SC2024
-    sudo "${mtraceCmd[@]}" >& "$clogfile" &
+    sudo bash -c "${mtraceCmd[*]} >& $clogfile &"
 }
 
 func_lib_log_post_process()


### PR DESCRIPTION
If sof-test test case is run manually and locally, the output of sof-test is messy, the lines are not aligned left at the beginning of each line, some
lines start in the middle of a line, which makes
the output log hard to follow.

This patch helps to workaround the above issue.

Link: https://github.com/thesofproject/sof-test/issues/1151