### PR TITLE
[DNM] test-case/multiple-pipeline.sh: ignore aplay/arecord early exit

### DIFF
--- a/test-case/multiple-pipeline.sh
+++ b/test-case/multiple-pipeline.sh
@@ -142,8 +142,9 @@ ps_checks()
     play_count=$(ps --no-headers -C aplay   | wc -l)
     total_count=$((rec_count + play_count))
 
-    [ "$total_count" -eq "$max_count" ] ||
-        func_error_exit "Running process count is $total_count, but $max_count is expected"
+    # ignore cases of 8770
+    #[ "$total_count" -eq "$max_count" ] ||
+    #    func_error_exit "Running process count is $total_count, but $max_count is expected"
 
     [ "$rec_count" = 0 ] || sof-process-state.sh arecord >/dev/null ||
         func_error_exit "Caught abnormal process status of arecord"


### PR DESCRIPTION
Ignore early exit to allow runnning tests for longer without stopping in case https://github.com/thesofproject/sof/issues/8770 occurs.