### PR TITLE
case-lib: is_ipc4: use new debugfs file instead of kernel parameter

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -891,6 +891,10 @@ print_module_params()
     # all snd_hda* modules
     grep -H ^ /sys/module/snd_hda*/parameters/* || true
     echo "----------------------------------------"
+
+    echo "--------- Printing debugfs settings ----------"
+    grep -H ^ /sys/kernel/debug/sof/fw_profile/* || true
+    echo "----------------------------------------------"
 }
 
 # "$@" is optional, typically: --since=@"$epoch".

--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -296,9 +296,16 @@ fake_kern_error()
 get_ldc_subdir()
 {
     local subdir='intel/sof' # default
-    if test -e /sys/module/snd_sof_pci/parameters/fw_path; then
-        local fw_path
-        fw_path=$(cat /sys/module/snd_sof_pci/parameters/fw_path)
+    local fw_path
+    local fw_path_info='/sys/kernel/debug/sof/fw_path'
+
+    # either $fw_path_info exists, OR we redefine $fw_path_info with
+    # the backwards-compatible alternative based on kernel parameter
+    test -e $fw_path_info ||
+	fw_path_info='/sys/module/snd_sof_pci/parameters/fw_path'
+
+    if fw_path=$(cat $fw_path_info); then
+	# "cat" was succesful
         if [ "$fw_path" != '(null)' ]; then
             subdir=${fw_path%/} # strip any trailing slash
             subdir=${subdir%/community}

--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -904,7 +904,7 @@ grep_firmware_info_in_logs()
     # dump the version info and ABI info
     # "head -n" makes this compatible with set -e.
     journalctl_cmd "$@" | grep "Firmware info" -A1 | head -n 12
-    # For dumping the firmware information when DUT runs IPC4 mode 
+    # For dumping the firmware information when DUT runs IPC4 mode
     journalctl_cmd "$@" | grep "firmware version" -A1 | head -n 12
     # dump the debug info
     journalctl_cmd "$@" | grep "Firmware debug build" -A3 | head -n 12


### PR DESCRIPTION
First step to remove use of kernel parameters

Link: https://github.com/thesofproject/linux/pull/4902
Link: https://github.com/thesofproject/sof-test/issues/1166