### PR TITLE
kmod: sof_remove: Drop Pulseaudio test and stop including case-lib/li…

### DIFF
--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -2,12 +2,6 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright(c) 2018 Intel Corporation. All rights reserved.
 
-
-TOPDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
-
-# shellcheck source=case-lib/lib.sh
-source "$TOPDIR"/case-lib/lib.sh
-
 remove_module() {
 
     local MODULE="$1"
@@ -23,13 +17,6 @@ remove_module() {
 exit_handler()
 {
     local exit_status="$1"
-    # Even without any active audio, pulseaudio can use modules
-    # "non-deterministically". So even if we are successful this time,
-    # warn about any running pulseaudio because it could make us fail
-    # the next time.
-    if pgrep -a pulseaudio; then
-        systemctl_show_pulseaudio
-    fi
 
     if test "$exit_status" -ne 0; then
         lsmod | grep -e sof -e snd -e sound -e drm


### PR DESCRIPTION
…b.sh

The PA test does not make much sense anymore as distros are moving or moved to use PW and the audio servers should have been disabled in the DUT anyways to not interfere with tests (PA/PW will probe the new card on module load for example).

Including case-lib/lib.sh have the side effect that it will 'start a test'. This involves checking if the firmware is booted, but if we have booted up in legacy or DSPless mode the script aborts and one has to figure out [1] how to force the script to do what it supposed to be doing: removing the modules.

This is a helper script, not a test case.

[1]
NO_POLL_FW_LOADING=false tools/kmod/sof_remove.sh
Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>