### PR TITLE
lib.sh: need `sudo bash -c ...` to expand `fw_profile/*` as root

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -896,7 +896,9 @@ print_module_params()
     echo "----------------------------------------"
 
     echo "--------- Printing debugfs settings ----------"
-    sudo grep -H ^ /sys/kernel/debug/sof/fw_profile/* || true
+    # Need /bin/sh to expand '*' as root.
+    # Need "|| true" to support older kernels.
+    sudo /bin/sh -c 'grep -H ^ /sys/kernel/debug/sof/fw_profile/*' || true
     echo "----------------------------------------------"
 }
 


### PR DESCRIPTION
Fixes commit 46219fad9ec8 ("case-lib/lib.sh: use sudo to access debugfs files")