### PR TITLE
Rename is_zephyr() to is_zephyr_ldc(). No functional change.

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -65,7 +65,7 @@ function func_exit_handler()
         dlogi "pkill -TERM $loggerBin"
         sudo pkill -TERM "$loggerBin" || {
             dloge "sof-logger was already dead"
-            if is_zephyr; then
+            if is_zephyr_ldc; then
                 dloge 'Downgrading sof-logger failure to SKIP because of known'
                 dloge 'issue https://github.com/thesofproject/sof/issues/5352'
                 # Pretend we got at least one line of logs to fool the

--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -787,7 +787,10 @@ sof_firmware_boot_complete()
     journalctl_cmd "$@" | grep -i 'sof.*firmware[[:blank:]]*boot[[:blank:]]*complete'
 }
 
-is_zephyr()
+# If the firmware is loaded then you probably want to use the newer
+# 'is_firmware_file_zephyr()' instead. Zephyr will have no .ldc file in
+# the future.
+is_zephyr_ldc()
 {
     local ldcFile
     ldcFile=$(find_ldc_file) || {
@@ -800,8 +803,10 @@ is_zephyr()
     test "$znum" -gt 10
 }
 
-# FIXME: the kernel driver should give us the FW path
-# https://github.com/thesofproject/linux/issues/3867
+# TODO: switch to new debugfs `fw_profile`, see
+# https://github.com/thesofproject/linux/issues/3867 and friends. Keep this existing
+# journalctl_cmd() code as a fallback for older kernels or when the firmware has been
+# unloaded. Fallback similar to the one in commit 646a3b3b71003
 get_firmware_path()
 {
     journalctl_cmd -k |

--- a/test-case/multiple-pipeline.sh
+++ b/test-case/multiple-pipeline.sh
@@ -154,7 +154,7 @@ ps_checks()
 main()
 {
     local platf; platf=$("${TESTDIR}"/tools/sof-dump-status.py --platform)
-    if [ "$platf" = bdw ] && [ "$f_arg" != 'p' ] && ! is_zephyr; then
+    if [ "$platf" = bdw ] && [ "$f_arg" != 'p' ] && ! is_zephyr_ldc; then
         skip_test \
             "multi-capture disabled on BDW https://github.com/thesofproject/sof/issues/3170"
     fi


### PR DESCRIPTION
We want to get rid of the .ldc file in Zephyr soon, so change the name of `is_zephyr()` to make it less appealing.

Zero functional change.