### PR TITLE
sof_remove: unload `snd_sof_intel_hda_common` before `soundwire_intel`

### DIFF
--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -120,6 +120,14 @@ remove_module snd_soc_hda_codec
 # platform drivers
 #-------------------------------------------
 remove_module snd_sof_intel_hda_generic
+# Attempt 1/2
+#
+# - In the SDW BRA future this will be "in use by
+#   snd_sof_intel_hda_sdw_bpt" and will fail.  Ignore that failure.
+# - In the 6.5-ish "present" 'soundwire_intel' depends on it so it must
+#   be removed first.
+# https://github.com/thesofproject/sof-test/pull/1182
+remove_module snd_sof_intel_hda_common || true
 
 #-------------------------------------------
 # SoundWire/SOF parts
@@ -133,7 +141,9 @@ remove_module snd_sof_intel_hda_sdw_bpt
 #-------------------------------------------
 # platform drivers - take2
 #-------------------------------------------
+# Attempt 2/2, see above.
 remove_module snd_sof_intel_hda_common
+
 remove_module snd_sof_intel_hda
 remove_module snd_sof_intel_ipc
 remove_module snd_sof_xtensa_dsp


### PR DESCRIPTION
Fixes this failure with older kernel like the 6.5 kernels distributed by Ubuntu:
```
 ERROR: Module soundwire_intel is in use by: snd_sof_intel_hda_common
```
Fixes commit 65951c4d0 ("kmod: fix hda-sdw-bpt dependency") which unloaded all soundwire drivers earlier as a block. This is not a problem with 6.9-ish kernels where snd_sof_intel_hda_common and soundwire_intel can apparently be unloaded in any order but it is a problem with older kernels.

So, unload `snd_sof_intel_hda_common` before soundwire modules to be compatible with any kernel.

See https://github.com/thesofproject/sof-test/pull/1156 for more info.