### PR TITLE
lib.sh: catch some mtrace-reader failures to start thanks to "OSError"

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -527,7 +527,7 @@ check_error_in_fw_logfile()
     # -B 2 shows the header line when the first etrace message is an ERROR
     # -A 1 shows whether the ERROR is last or not.
     if (set -x
-        grep -B 2 -A 1 -i --word-regexp -e 'ERR' -e 'ERROR' -e '<err>' "$1"
+        grep -B 2 -A 1 -i --word-regexp -e 'ERR' -e 'ERROR' -e '<err>' -e OSError "$1"
        ); then
         # See internal Intel bug #448
         dlogw 'An HTML display bug hides the bracketed Zephyr &lt;loglevels&gt; in this tab,'


### PR DESCRIPTION
This makes tests fail at the end when mtrace-reader.py could be started, for instance because one is already running (see example below)

Reminder: you can use -s to ignore firmware logs.
```
Traceback (most recent call last):
  File "mtrace-reader.py", line 20, in <module>
    fd = os.open(MTRACE_FILE, os.O_RDONLY)
OSError: [Errno 16] Device or resource busy: '/sys/kernel/debug/sof/mtrace/core0'
```