### PR TITLE
Explicitly invoke start_test() in every test-case/*.sh

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -66,6 +66,12 @@ minvalue() { printf '%d' $(( "$1" < "$2"  ? "$1" : "$2" )); }
 #    concurrency 1% of the time, detecting it 99% of the time is much
 #    more than enough to spot reservation problems.
 #
+# 3. Register the func_exit_handler() EXIT trap that collects logs, kills
+#    loggers and prints test results.
+#
+# 4. Waits for the FW to be successfully booted (can be disabled)
+#
+#
 start_test()
 {
     if is_subtest; then

--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -1024,4 +1024,3 @@ perf_analyze()
     fi
 }
 
-start_test

--- a/test-case/check-alsabat.sh
+++ b/test-case/check-alsabat.sh
@@ -73,6 +73,8 @@ frequency=${OPT_VAL['F']}
 sigmak=${OPT_VAL['k']}
 frames=${OPT_VAL['n']}
 
+start_test
+
 if [ "$pcm_p" = "" ]||[ "$pcm_c" = "" ];
 then
 	dloge "No playback or capture PCM is specified. Skip the alsabat test"

--- a/test-case/check-audio-equalizer.sh
+++ b/test-case/check-audio-equalizer.sh
@@ -41,6 +41,8 @@ loop_cnt=${OPT_VAL['l']}
 func_pipeline_export "$tplg" "eq:any"
 sofcard=${SOFCARD:-0}
 
+start_test
+
 # Test equalizer
 func_test_eq()
 {

--- a/test-case/check-capture.sh
+++ b/test-case/check-capture.sh
@@ -57,6 +57,7 @@ loop_cnt=${OPT_VAL['l']}
 out_dir=${OPT_VAL['o']}
 file_prefix=${OPT_VAL['f']}
 
+start_test
 logger_disabled || func_lib_start_log_collect
 
 setup_kernel_check_point

--- a/test-case/check-fw-echo-reference.sh
+++ b/test-case/check-fw-echo-reference.sh
@@ -40,6 +40,7 @@ loop_cnt=${OPT_VAL['l']}
 frames=${OPT_VAL['n']}
 frequency=${OPT_VAL['f']}
 
+start_test
 logger_disabled || func_lib_start_log_collect
 
 func_pipeline_export "$tplg" "echo:any"

--- a/test-case/check-ipc-flood.sh
+++ b/test-case/check-ipc-flood.sh
@@ -34,6 +34,8 @@ lpc_loop_cnt=${OPT_VAL['c']}
 ipc_flood_dfs=${OPT_VAL['f']}
 loop_cnt=${OPT_VAL['l']}
 
+start_test
+
 sof-kernel-dump.sh | grep sof-audio | grep -q "Firmware debug" ||
      skip_test "need debug version firmware"
 

--- a/test-case/check-keyword-detection.sh
+++ b/test-case/check-keyword-detection.sh
@@ -53,6 +53,7 @@ history_depth=${OPT_VAL['s']}
 preamble_time=${OPT_VAL['p']}
 duration=${OPT_VAL['d']}
 
+start_test
 logger_disabled || func_lib_start_log_collect
 
 func_pipeline_export "$tplg" "kpb:any"

--- a/test-case/check-kmod-load-unload-after-playback.sh
+++ b/test-case/check-kmod-load-unload-after-playback.sh
@@ -54,6 +54,8 @@ tplg=${OPT_VAL['t']}
 loop_cnt=${OPT_VAL['l']}
 pb_duration=${OPT_VAL['d']}
 
+start_test
+
 func_pipeline_export "$tplg" "type:playback"
 
 func_lib_check_sudo

--- a/test-case/check-kmod-load-unload.sh
+++ b/test-case/check-kmod-load-unload.sh
@@ -38,6 +38,8 @@ OPT_HAS_ARG['p']=0             OPT_VAL['p']=1
 func_opt_parse_option "$@"
 setup_kernel_check_point
 
+start_test
+
 loop_cnt=${OPT_VAL['l']}
 
 PATH="${PATH%%:*}/kmod:$PATH"

--- a/test-case/check-pause-release-suspend-resume.sh
+++ b/test-case/check-pause-release-suspend-resume.sh
@@ -94,6 +94,8 @@ sleep_period=${OPT_VAL['i']}
 test_mode=${OPT_VAL['m']}
 file_name=${OPT_VAL['F']}
 
+start_test
+
 case $test_mode in
     "playback")
         cmd=aplay

--- a/test-case/check-pause-resume.sh
+++ b/test-case/check-pause-resume.sh
@@ -55,6 +55,9 @@ file_name=${OPT_VAL['f']}
 # configure random value range
 rnd_min=${OPT_VAL['i']}
 rnd_max=${OPT_VAL['a']}
+
+start_test
+
 rnd_range=$(( rnd_max -  rnd_min ))
 [[ $rnd_range -le 0 ]] && dlogw "Error random range scope [ min:$rnd_min - max:$rnd_max ]" && exit 2
 

--- a/test-case/check-performance.sh
+++ b/test-case/check-performance.sh
@@ -41,6 +41,7 @@ func_opt_parse_option "$@"
 tplg=${OPT_VAL['t']}
 duration=${OPT_VAL['d']}
 
+start_test
 logger_disabled || func_lib_start_log_collect
 
 setup_kernel_check_point

--- a/test-case/check-playback.sh
+++ b/test-case/check-playback.sh
@@ -53,7 +53,7 @@ duration=${OPT_VAL['d']}
 loop_cnt=${OPT_VAL['l']}
 file=${OPT_VAL['f']}
 
-
+start_test
 logger_disabled || func_lib_start_log_collect
 
 # checking if source file exists

--- a/test-case/check-reboot.sh
+++ b/test-case/check-reboot.sh
@@ -34,6 +34,8 @@ loop_count=${OPT_VAL['l']}
 delay=${OPT_VAL['d']}
 timeout=${OPT_VAL['t']}
 
+start_test
+
 # write the total & current count to the status file
 status_log=$LOG_ROOT/status.txt
 echo "$loop_count $(uname -r)" >> $status_log

--- a/test-case/check-runtime-pm-double-active.sh
+++ b/test-case/check-runtime-pm-double-active.sh
@@ -58,6 +58,9 @@ func_check_dsp_status()
 func_opt_parse_option "$@"
 tplg=${OPT_VAL['t']}
 loop_count=${OPT_VAL['l']}
+
+start_test
+
 [[ -z $tplg ]] && dloge "Miss tplg file to run" && exit 2
 
 [[ $(sof-dump-status.py --dsp_status 0) == "unsupported" ]] &&

--- a/test-case/check-runtime-pm-status.sh
+++ b/test-case/check-runtime-pm-status.sh
@@ -54,6 +54,9 @@ setup_kernel_check_point
 
 tplg=${OPT_VAL['t']}
 loop_count=${OPT_VAL['l']}
+
+start_test
+
 [[ -z $tplg ]] && die "Miss tplg file to run"
 
 [[ $(sof-dump-status.py --dsp_status 0) == "unsupported" ]] &&

--- a/test-case/check-signal-stop-start.sh
+++ b/test-case/check-signal-stop-start.sh
@@ -43,6 +43,7 @@ count=${OPT_VAL['c']}
 interval=${OPT_VAL['i']}
 test_mode=${OPT_VAL['m']}
 
+start_test
 logger_disabled || func_lib_start_log_collect
 
 case $test_mode in

--- a/test-case/check-smart-amplifier.sh
+++ b/test-case/check-smart-amplifier.sh
@@ -56,6 +56,7 @@ duration=${OPT_VAL['d']}
 loop_cnt=${OPT_VAL['l']}
 tplg=${OPT_VAL['t']}
 
+start_test
 logger_disabled || func_lib_start_log_collect
 
 func_pipeline_export "$tplg" "smart_amp:any"

--- a/test-case/check-sof-logger.sh
+++ b/test-case/check-sof-logger.sh
@@ -27,6 +27,8 @@ source "${TOPDIR}"/case-lib/lib.sh
 
 func_opt_parse_option "$@"
 
+start_test
+
 # check sof-logger location
 type -a sof-logger ||
     die "sof-logger Not Installed!"

--- a/test-case/check-suspend-resume-with-audio.sh
+++ b/test-case/check-suspend-resume-with-audio.sh
@@ -61,6 +61,8 @@ setup_kernel_check_point
 func_lib_check_sudo
 
 tplg=${OPT_VAL['t']}
+
+start_test
 logger_disabled || func_lib_start_log_collect
 
 # overwrite the subscript: test-case LOG_ROOT environment

--- a/test-case/check-suspend-resume.sh
+++ b/test-case/check-suspend-resume.sh
@@ -47,6 +47,8 @@ OPT_HAS_ARG['r']=0         OPT_VAL['r']=0
 func_opt_parse_option "$@"
 func_lib_check_sudo
 
+start_test
+
 type=${OPT_VAL['T']}
 # switch type
 if [ "$type" ]; then

--- a/test-case/check-userspace-cardinfo.sh
+++ b/test-case/check-userspace-cardinfo.sh
@@ -19,11 +19,13 @@ set -e
 # shellcheck source=case-lib/lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
-# check pulseaudio runs properly or not
-func_lib_check_pa || die "Please check whether pulseaudio runs correctly or not"
-
 func_opt_parse_option "$@"
 setup_kernel_check_point
+
+start_test
+
+# check pulseaudio runs properly or not
+func_lib_check_pa || die "Please check whether pulseaudio runs correctly or not"
 
 : $((available_card=0))
 while read -r card; do

--- a/test-case/check-userspace-paplay.sh
+++ b/test-case/check-userspace-paplay.sh
@@ -44,6 +44,8 @@ OPT_HAS_ARG['C']=1         OPT_VAL['C']=2
 func_opt_parse_option "$@"
 setup_kernel_check_point
 
+start_test
+
 round_cnt=${OPT_VAL['r']}
 duration=${OPT_VAL['d']}
 file=${OPT_VAL['f']}

--- a/test-case/check-userspace-parecord.sh
+++ b/test-case/check-userspace-parecord.sh
@@ -51,6 +51,8 @@ format=${OPT_VAL['F']}
 rate=${OPT_VAL['R']}
 channel=${OPT_VAL['C']}
 
+start_test
+
 [[ -e $file ]] || { dlogw "$file does not exist, use /dev/zero as dummy playback source" && file=/dev/null; }
 
 # TODO: check the parameter is valid or not

--- a/test-case/check-volume-levels.sh
+++ b/test-case/check-volume-levels.sh
@@ -58,6 +58,8 @@ ARECORD_WAV1=$(mktemp --suffix=.wav)
 ARECORD_WAV2=$(mktemp --suffix=.wav)
 ARECORD_WAV3=$(mktemp --suffix=.wav)
 
+start_test
+
 #
 # Main test procedure
 #

--- a/test-case/check-xrun-injection.sh
+++ b/test-case/check-xrun-injection.sh
@@ -42,6 +42,7 @@ test_mode=${OPT_VAL['m']}
 count=${OPT_VAL['c']}
 interval=${OPT_VAL['i']}
 
+start_test
 logger_disabled || func_lib_start_log_collect
 
 setup_kernel_check_point

--- a/test-case/multiple-pause-resume.sh
+++ b/test-case/multiple-pause-resume.sh
@@ -53,6 +53,9 @@ loop_count=${OPT_VAL['l']}
 rnd_min=${OPT_VAL['i']}
 rnd_max=${OPT_VAL['a']}
 rnd_range=$((rnd_max - rnd_min))
+
+start_test
+
 [[ $rnd_range -le 0 ]] && dlogw "Error random range scope [ min:$rnd_min - max:$rnd_max ]" && exit 2
 
 tplg=${OPT_VAL['t']}

--- a/test-case/multiple-pipeline.sh
+++ b/test-case/multiple-pipeline.sh
@@ -59,6 +59,8 @@ func_opt_parse_option "$@"
 loop_cnt=${OPT_VAL['l']}
 tplg=${OPT_VAL['t']}
 f_arg=${OPT_VAL['f']}
+
+start_test
 logger_disabled || func_lib_start_log_collect
 
 # skip the Echo Reference pipeline

--- a/test-case/simultaneous-playback-capture.sh
+++ b/test-case/simultaneous-playback-capture.sh
@@ -40,6 +40,8 @@ tplg=${OPT_VAL['t']}
 wait_time=${OPT_VAL['w']}
 loop_cnt=${OPT_VAL['l']}
 
+start_test
+
 # get 'both' pcm, it means pcm have same id with different type
 declare -A tmp_id_lst
 id_lst_str=""
@@ -59,6 +61,7 @@ unset tmp_id_lst tplg_path
 id_lst_str=${id_lst_str/,/} # remove 1st, which is not used
 [[ ${#id_lst_str} -eq 0 ]] && dlogw "no pipeline with both playback and capture capabilities found in $tplg" && exit 2
 func_pipeline_export "$tplg" "id:$id_lst_str"
+
 logger_disabled || func_lib_start_log_collect
 
 func_error_exit()

--- a/test-case/test-socwatch.sh
+++ b/test-case/test-socwatch.sh
@@ -50,6 +50,8 @@ duration=${OPT_VAL['d']}
 wait_time=${OPT_VAL['w']}
 loop_count=${OPT_VAL['l']}
 
+start_test
+
 check_socwatch_module_loaded()
 {
     lsmod | grep -q socwatch || dlogi "socwatch is not loaded"

--- a/test-case/test-speaker.sh
+++ b/test-case/test-speaker.sh
@@ -30,6 +30,8 @@ OPT_HAS_ARG['s']=0             OPT_VAL['s']=1
 
 func_opt_parse_option "$@"
 tplg=${OPT_VAL['t']}
+
+start_test
 logger_disabled || func_lib_start_log_collect
 
 func_pipeline_export "$tplg" "type:playback"

--- a/test-case/verify-bootsequence.sh
+++ b/test-case/verify-bootsequence.sh
@@ -32,6 +32,8 @@ ALSAUCM_VER=1.2.3-15
 func_opt_parse_option "$@"
 setup_kernel_check_point
 
+start_test
+
 main()
 {
     local tmp

--- a/test-case/verify-firmware-presence.sh
+++ b/test-case/verify-firmware-presence.sh
@@ -22,6 +22,8 @@ source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 func_opt_parse_option "$@"
 setup_kernel_check_point
 
+start_test
+
 path=$(sof-dump-status.py -P)
 platform=$(sof-dump-status.py -p)
 fw="$path/sof-$platform.ri"

--- a/test-case/verify-kernel-boot-log.sh
+++ b/test-case/verify-kernel-boot-log.sh
@@ -18,6 +18,11 @@ set -e
 # shellcheck source=case-lib/lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
+start_test
+# TODO: replace start_test with this:
+trap 'print_test_result_exit $?' EXIT
+# https://github.com/thesofproject/sof-test/issues/1112
+
 main()
 {
     printf 'System booted at: '; uptime -s

--- a/test-case/verify-kernel-module-load-probe.sh
+++ b/test-case/verify-kernel-module-load-probe.sh
@@ -20,6 +20,8 @@ func_opt_parse_option "$@"
 
 setup_kernel_check_point
 
+start_test
+
 dlogi "Checking if sof relative modules loaded"
 dlogc "lsmod | grep \"sof\""
 

--- a/test-case/verify-pcm-list.sh
+++ b/test-case/verify-pcm-list.sh
@@ -26,6 +26,8 @@ OPT_HAS_ARG['t']=1         OPT_VAL['t']="${TPLG:-}"
 func_opt_parse_option "$@"
 tplg=${OPT_VAL['t']}
 
+start_test
+
 tplg_path=$(func_lib_get_tplg_path "$tplg") ||
        	die "No available topology for this test case"
 

--- a/test-case/verify-sof-firmware-load.sh
+++ b/test-case/verify-sof-firmware-load.sh
@@ -21,6 +21,8 @@ func_opt_parse_option "$@"
 
 disable_kernel_check_point
 
+start_test
+
 cmd="journalctl_cmd"
 
 dlogi "Checking SOF Firmware load info in kernel log"

--- a/test-case/verify-tplg-binary.sh
+++ b/test-case/verify-tplg-binary.sh
@@ -26,6 +26,8 @@ func_opt_parse_option "$@"
 setup_kernel_check_point
 tplg=${OPT_VAL['t']}
 
+start_test
+
 tplg_path=$(func_lib_get_tplg_path "$tplg") ||
     die "No available topology ($tplg) for this test case"
 

--- a/test-case/verify-ucm-config.sh
+++ b/test-case/verify-ucm-config.sh
@@ -27,6 +27,8 @@ source $(dirname ${BASH_SOURCE[0]})/../case-lib/lib.sh
 func_opt_parse_option "$@"
 setup_kernel_check_point
 
+start_test
+
 declare -A verb_array
 
 # get the cards all verbs. The verbs are the items of SectionUseCase in

--- a/test-case/volume-basic-test.sh
+++ b/test-case/volume-basic-test.sh
@@ -35,6 +35,8 @@ setup_kernel_check_point
 tplg=${OPT_VAL['t']}
 maxloop=${OPT_VAL['l']}
 
+start_test
+
 func_error_exit()
 {
     dloge "$*"


### PR DESCRIPTION
2 commits, main one:

Stop unconditionally imposing start_test() to everything sourcing lib.sh

This makes it possible to source lib.sh without running anything which
can be useful for debugging.

For now this should be a no-op for all tests except two files in `tools/` which
were never really "tests" in the first place:

- tools/kmod/sof_remove.sh
- tools/sof-kernel-log-check.sh

In these, start_test() never made sense it never really run thanks the
(awkward) "is_subtest()" escape.

There are other tests where start_test() should not be invoked either,
most notably test-case/verify-kernel-boot-log.sh in order to fix
https://github.com/thesofproject/sof-test/issues/1112 but this is a huge
commit already; one change at a time.