### PR TITLE
hijack.sh: fail on stable-v2.2 FW errors too

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -111,16 +111,8 @@ function func_exit_handler()
                 exit_status=1
             fi
 
-            # We still have some false positives in stable-v2.2 for now, see
-            # https://github.com/thesofproject/sof-test/pull/1075
-            # https://github.com/thesofproject/sof/pull/9036
-            # etc.
-            if is_firmware_file_zephyr; then
-
-              check_error_in_fw_logfile "$logfile" ||
+            check_error_in_fw_logfile "$logfile" ||
                 exit_status=1
-
-            fi
 
         else
             dloge "Log file not found: $logfile"


### PR DESCRIPTION
Let's see if we can start paying attention to firmware errors in the stable-v2.2 branch too.

Follow-up to #1075