### PR TITLE
verify-kernel-boot-log.sh hotfix: do not override EXIT handler!

### DIFF
--- a/test-case/verify-kernel-boot-log.sh
+++ b/test-case/verify-kernel-boot-log.sh
@@ -20,7 +20,7 @@ source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
 start_test
 # TODO: replace start_test with this:
-trap 'print_test_result_exit $?' EXIT
+# trap 'print_test_result_exit $?' EXIT
 # https://github.com/thesofproject/sof-test/issues/1112
 
 main()


### PR DESCRIPTION
Fixes commit 7c2ede03c9be ("Explicitly invoke start_test() in every test-case/*.sh") which already did the TODO but _without_ removing _start_test(). We want one or the other, not a strange and unpredictable mix of both!

A future commit will actually replace `start_test()`.