### PR TITLE
LNLM_SDW_AIOC.sh: overrides the headset detected_mode

### DIFF
--- a/alsa_settings/LNLM_SDW_AIOC.sh
+++ b/alsa_settings/LNLM_SDW_AIOC.sh
@@ -4,6 +4,10 @@ set -e
 amixer -c sofsoundwire cset name='Headphone Switch' on
 amixer -c sofsoundwire cset name='rt711 FU05 Playback Volume' 80
 
+# override jack detection mode to headset
+# related linux pr: https://github.com/thesofproject/linux/pull/4969
+amixer -c sofsoundwire cset name='rt711 GE49 Selected Mode' 2 || true
+
 # enable headset capture
 amixer -c sofsoundwire cset name='Headset Mic Switch' on
 amixer -c sofsoundwire cset name='rt711 FU0F Capture Switch' on


### PR DESCRIPTION
LNL RVP keep toggling between headphone and headset. Overrides to headset only for the test.

Related kernel PR: https://github.com/thesofproject/linux/pull/4969