### PR TITLE
verify-kernel-boot-log.sh: fix missing boot logs on failure

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -3,6 +3,9 @@
 SUDO_CMD=$(command -v sudo)
 
 # Overwrite other functions' exit to perform environment cleanup
+#
+# TODO: split this into smaller functions that "special" test cases can
+# re-use separately instead of all this or nothing.
 function func_exit_handler()
 {
     local exit_status=${1:-0}

--- a/test-case/verify-kernel-boot-log.sh
+++ b/test-case/verify-kernel-boot-log.sh
@@ -18,10 +18,16 @@ set -e
 # shellcheck source=case-lib/lib.sh
 source "$(dirname "${BASH_SOURCE[0]}")"/../case-lib/lib.sh
 
-start_test
-# TODO: replace start_test with this:
-# trap 'print_test_result_exit $?' EXIT
-# https://github.com/thesofproject/sof-test/issues/1112
+trap 'boot_log_exit_handler $?' EXIT
+
+boot_log_exit_handler()
+{
+    local exit_code=$1
+
+    journalctl --boot > "$LOG_ROOT"/boot_log.txt
+
+    print_test_result_exit "$exit_code"
+}
 
 main()
 {


### PR DESCRIPTION
Provide a new, boot_logs.txt file no matter what happens. Note that file now includes user-space logs, not just kernel logs.

Also: fix bug where script times out and does not run when the SOF
firmware is not loaded: no need to define NO_POLL_FW_LOADING anymore.

The trick is to stop calling `start_test()`. verify-kernel-boot-log.sh is not an audio test!

Fixes sof-test issues #1036 and #1112, find more details there.