### PR TITLE
verify-kernel-boot-log.sh: add "standalone" dmesg.txt back

### DIFF
--- a/test-case/verify-kernel-boot-log.sh
+++ b/test-case/verify-kernel-boot-log.sh
@@ -24,7 +24,10 @@ boot_log_exit_handler()
 {
     local exit_code=$1
 
+    # For issues with sound daemons, display, USB, network, NTP, systemd, etc.
     journalctl --boot > "$LOG_ROOT"/boot_log.txt
+    # More focused
+    journalctl --dmesg > "$LOG_ROOT"/dmesg.txt
 
     print_test_result_exit "$exit_code"
 }


### PR DESCRIPTION
Interleaving could be useful when it's a problem with a sound daemon but tend to turn these off and most of the time it's just making SOF logs harder to read.

Keep boot_log.txt which is useful for all non-audio issues.

Fixes commit c8565e8b210d ("verify-kernel-boot-log.sh: fix missing boot logs on failure")