### PR TITLE
verify-kernel-log.sh: guard "xrandr" with a short "timeout"

### DIFF
--- a/test-case/verify-kernel-boot-log.sh
+++ b/test-case/verify-kernel-boot-log.sh
@@ -146,8 +146,9 @@ show_daemons_session_display()
      # a session-specific, /run/user/ tmpfs that cannot be seen over ssh (or from any
      # other session). Sometimes this shows XWAYLAND.
      # As of April 2024 there does not seem to be any Wayland equivalent for `xrandr`
-     DISPLAY=:0 xrandr --listmonitors
-     DISPLAY=:1024 xrandr --listmonitors
+     for d in 0 1024; do
+         DISPLAY=:"$d"  timeout -k 3 5 xrandr --listmonitors
+     done
 
      ls -l /sys/class/drm/
      set +x # can't use set -x because of the crazy "sudo()" in hijack.sh


### PR DESCRIPTION
xrandr can hang! Who could have known? See evidence in:

- https://github.com/thesofproject/linux/pull/5009#issuecomment-2122857477

Don't wait for CI to timeout and kill the whole script so we don't lose precious logs.