### PR TITLE
Fix check-sof-logger.sh

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -309,11 +309,11 @@ get_ldc_subdir()
 {
     local subdir='intel/sof' # default
     local fw_path
-    local fw_path_info='/sys/kernel/debug/sof/fw_path'
+    local fw_path_info='/sys/kernel/debug/sof/fw_profile/fw_path'
 
     # either $fw_path_info exists, OR we redefine $fw_path_info with
     # the backwards-compatible alternative based on kernel parameter
-    test -e $fw_path_info ||
+    sudo test -e $fw_path_info ||
 	fw_path_info='/sys/module/snd_sof_pci/parameters/fw_path'
 
     if fw_path=$(sudo cat $fw_path_info); then

--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -305,8 +305,10 @@ fake_kern_error()
 
 }
 
+# $1: optional (platform) string to strip. Useful for IPC4.
 get_ldc_subdir()
 {
+    local strip_arg="$1"
     local subdir='intel/sof' # default
     local fw_path
     local fw_path_info='/sys/kernel/debug/sof/fw_profile/fw_path'
@@ -323,6 +325,7 @@ get_ldc_subdir()
             subdir=${subdir%/community}
             subdir=${subdir%/intel-signed}
             subdir=${subdir%/dbgkey}
+            test -z "$strip_arg" || subdir=${subdir%/"$strip_arg"}
         fi
     fi
     printf '%s' "$subdir"
@@ -345,7 +348,7 @@ find_ldc_file()
         }
         ldcFile=/etc/sof/sof-"$platf".ldc
         [ -e "$ldcFile" ] || {
-            local subdir; subdir=$(get_ldc_subdir)
+            local subdir; subdir=$(get_ldc_subdir "$platf")
             ldcFile=/lib/firmware/"${subdir}"/sof-"$platf".ldc
         }
     fi


### PR DESCRIPTION
2 commits

As usual, @fredoh9 clean up and simplification of the internal, Intel deployment scripts exposed some old bugs that were hidden so far because we have too many fallbacks in this area.

