### PR TITLE
sof-dump-status.py: don't crash on unknown Intel audio PCI devices

### DIFF
--- a/tools/sof-dump-status.py
+++ b/tools/sof-dump-status.py
@@ -135,8 +135,13 @@ class clsSYSCardInfo():
                     # 1st line of PCI config space in hex
                     tmp_line = tmp_output[i].split()
                     break
-            pci_info['hw_id']="0x" + tmp_line[2] + tmp_line[1] + " 0x" + tmp_line[4] + tmp_line[3]
-            pci_info['hw_name'] = self._pci_ids["0x" + tmp_line[4] + tmp_line[3]]
+            pci_dev_id = "0x" + tmp_line[4] + tmp_line[3]
+            pci_info['hw_id'] = "0x" + tmp_line[2] + tmp_line[1] + " " + pci_dev_id
+            try:
+                pci_info['hw_name'] = self._pci_ids[pci_dev_id]
+            except KeyError:
+                pci_info['hw_name'] = "PCI ID unknown by sof-dump-status.py"
+
             self.pci_lst.append(pci_info)
 
     def loadACPI(self):


### PR DESCRIPTION
Set pci_info['hw_name'] to "PCI device unknown by SOF" and keep going.

Before this commit, any test that invokes sof-dump-status.py for any reason crashes like this when the PCI ID is unknown:

```
Traceback (most recent call last):
  File "sof-test/tools/sof-dump-status.py", line 497, in <module>
    sysinfo.loadPCI()
  File "sof-test/tools/sof-dump-status.py", line 139, in loadPCI
    pci_info['hw_name'] = self._pci_ids["0x" + tmp_line[4] + tmp_line[3]]
KeyError: '0xe328'
```

The lack of a known PCI ID does not have to be fatal: there are plenty of use cases where the PCI ID is not needed. This commit makes it possible to run all these test cases even when the PCI ID is unknown.

This could help with #288 too.