### PR TITLE
kmod: add rt722_sdca codec

### DIFF
--- a/tools/kmod/sof_insert.sh
+++ b/tools/kmod/sof_insert.sh
@@ -51,6 +51,7 @@ insert_module snd_soc_rt712_sdca
 insert_module snd_soc_rt712_sdca_dmic
 insert_module snd_soc_rt715
 insert_module snd_soc_rt715_sdca
+insert_module snd_soc_rt722_sdca
 insert_module snd_soc_rt1308
 insert_module snd_soc_rt1308_sdw
 insert_module snd_soc_rt1316_sdw

--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -236,6 +236,7 @@ remove_module snd_soc_rt712_sdca
 remove_module snd_soc_rt712_sdca_dmic
 remove_module snd_soc_rt715
 remove_module snd_soc_rt715_sdca
+remove_module snd_soc_rt722_sdca
 remove_module snd_soc_rt1308
 remove_module snd_soc_rt1308_sdw
 remove_module snd_soc_rt1316_sdw


### PR DESCRIPTION
rt722_sdca codec is missing in kmod scripts.