### PR TITLE
kmod: add snd_soc_sdw_utils module

### DIFF
--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -182,6 +182,7 @@ remove_module snd_soc_cml_rt1011_rt5682
 remove_module snd_soc_skl_hda_dsp
 remove_module snd_soc_sdw_rt700
 remove_module snd_soc_sdw_rt711_rt1308_rt715
+remove_module snd_soc_sdw_utils
 remove_module snd_soc_sof_sdw
 remove_module snd_soc_sof_es8336
 remove_module snd_soc_ehl_rt5660


### PR DESCRIPTION
snd_soc_sdw_utils module is missing in kmod scripts.

This needs to be merged before https://github.com/thesofproject/linux/pull/5068