### PR TITLE
kmod: add snd_soc_sdw_utils module - take2

### DIFF
--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -182,8 +182,8 @@ remove_module snd_soc_cml_rt1011_rt5682
 remove_module snd_soc_skl_hda_dsp
 remove_module snd_soc_sdw_rt700
 remove_module snd_soc_sdw_rt711_rt1308_rt715
-remove_module snd_soc_sdw_utils
 remove_module snd_soc_sof_sdw
+remove_module snd_soc_sdw_utils
 remove_module snd_soc_sof_es8336
 remove_module snd_soc_ehl_rt5660
 remove_module snd_soc_intel_sof_board_helpers


### PR DESCRIPTION
wrong order as shown in

https://sof-ci.01.org/linuxpr/PR5068/build3857/devicetest/index.html?model=CML_RVP_SDW-ipc3&testcase=check-sof-logger