### PR TITLE
case-lib: remove check for log ldc file

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -874,13 +874,6 @@ is_ipc4()
 
 logger_disabled()
 {
-    local ldcFile
-    # Some firmware/OS configurations do not support logging.
-    ldcFile=$(find_ldc_file) || {
-        dlogi '.ldc dictionary file not found, SOF logs collection disabled'
-        return 0 # 0 is 'true'
-    }
-
     # Disable logging when available...
     if [ ${OPT_VAL['s']} -eq 0 ]; then
         return 0


### PR DESCRIPTION
Checking for ldc (log dictionary) file existance as a way to decide whether to enable or disable logging during a test case, is no longer applicable as SOF supports multiple firmware logging solutions that do not use an ldc file.

Remove the check as it no longer makes sense.

Link: https://github.com/thesofproject/sof-test/issues/1216