### PR TITLE
check-sof-logger.sh Predicate LDC search on !zephyr

### DIFF
--- a/test-case/check-sof-logger.sh
+++ b/test-case/check-sof-logger.sh
@@ -53,10 +53,12 @@ fi
 loggerBin=$(type -p sof-logger)
 dlogi "Found file: $(md5sum "$loggerBin" | awk '{print $2, $1;}')"
 
-dlogi "Looking for ldc File ..."
-ldcFile=$(find_ldc_file) || die ".ldc file not found!"
+if ! is_firmware_file_zephyr; then
+    dlogi "Looking for ldc File ..."
+    ldcFile=$(find_ldc_file) || die ".ldc file not found!"
 
-dlogi "Found file: $(md5sum "$ldcFile"|awk '{print $2, $1;}')"
+    dlogi "Found file: $(md5sum "$ldcFile"|awk '{print $2, $1;}')"
+fi
 
 # etrace shared memory mailbox, newer feature.
 etrace_file=$LOG_ROOT/logger.etrace.txt


### PR DESCRIPTION
[I haven't completely figured out how this script runs in CI, so this patch is mostly thrown up blind for review.  But this is where the error in CI is coming from, I believe]

Zephyr builds don't produce .ldc files anymore, don't look for them and fail.

Fixes: #1216