### PR TITLE
multiple-pause-resume.sh: lower the default loop count from 5 to 1

### DIFF
--- a/test-case/multiple-pause-resume.sh
+++ b/test-case/multiple-pause-resume.sh
@@ -27,7 +27,7 @@ OPT_NAME['t']='tplg'     OPT_DESC['t']="tplg file, default value is env TPLG: $T
 OPT_HAS_ARG['t']=1         OPT_VAL['t']="$TPLG"
 
 OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
-OPT_HAS_ARG['l']=1         OPT_VAL['l']=5
+OPT_HAS_ARG['l']=1         OPT_VAL['l']=1
 
 OPT_NAME['c']='count'    OPT_DESC['c']='combine test pipeline count'
 OPT_HAS_ARG['c']=1         OPT_VAL['c']=2
@@ -102,6 +102,9 @@ do
     pipeline_combine_str="${i//,/ }"
     pipeline_combine_lst=("${pipeline_combine_lst[@]}" "$pipeline_combine_str")
 done
+# This can get pretty big and make the test last a very long time and timeout,
+# especially in NOCODEC configurations. See #706 discussion. So, log that value.
+declare -p pipeline_combine_lst
 [[ ${#pipeline_combine_lst[@]} -eq 0 ]] && dlogw "pipeline combine is empty" && exit 2
 
 func_pause_resume_pipeline()


### PR DESCRIPTION
There is a combinatorial explosion in this test because it tries by default to test all pairs of available pipelines. This typically blows up and times out in NOCODEC configurations see #706 and others for earlier discussions. Internally, this combinatorial explosion issue was raised as early as November 2020! (Issues 40, 581,...)

This tiny commit does not fix the root cause but it makes a dead simple, "quality of life" adjustment: it simply lowers the default number of iterations from 5 to 1. There is no obvious reason why the default should be 5 and every test plan can raise that value back up if it wants to. Unlike #706 which was abandoned because it reduces test coverage, this very small change merely reduces the default test duration without changing any of its logic.

Also, log the combination tested. Sample output:

```
declare -a pipeline_combine_lst=([0]="0 1" [1]="0 2" [2]="0 3" [3]="0 4"
[4]="0 5" [5]="0 6" [6]="0 7" [7]="0 8" [8]="0 9" [9]="0 10" [10]="1 2"
[11]="1 3" [12]="1 4" [13]="1 5" [14]="1 6" [15]="1 7" [16]="1 8"
[17]="1 9" [18]="1 10" [19]="2 3" [20]="2 4" [21]="2 5" [22]="2 6"
[23]="2 7" [24]="2 8" [25]="2 9" [26]="2 10" [27]="3 4" [28]="3 5"
[29]="3 6" [30]="3 7" [31]="3 8" [32]="3 9" [33]="3 10" [34]="4 5"
[35]="4 6" [36]="4 7" [37]="4 8" [38]="4 9" [39]="4 10" [40]="5 6"
[41]="5 7" [42]="5 8" [43]="5 9" [44]="5 10" [45]="6 7" [46]="6 8"
[47]="6 9" [48]="6 10" [49]="7 8" [50]="7 9" [51]="7 10" [52]="8 9"
[53]="8 10" [54]="9 10")
```