### PR TITLE
check-suspend-resume: check process id in each loop for audio test case

### DIFF
--- a/test-case/check-suspend-resume-with-audio.sh
+++ b/test-case/check-suspend-resume-with-audio.sh
@@ -27,34 +27,34 @@ TESTDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/" && pwd)
 source "${TESTDIR}"/../case-lib/lib.sh
 
 OPT_NAME['l']='loop'     OPT_DESC['l']='suspend/resume loop count'
-OPT_HAS_ARG['l']=1         OPT_VAL['l']=3
+OPT_HAS_ARG['l']=1       OPT_VAL['l']=3
 
 OPT_NAME['T']='type'     OPT_DESC['T']="suspend/resume type from /sys/power/mem_sleep"
-OPT_HAS_ARG['T']=1         OPT_VAL['T']=""
+OPT_HAS_ARG['T']=1       OPT_VAL['T']=""
 
 OPT_NAME['S']='sleep'    OPT_DESC['S']='suspend/resume command:rtcwake sleep duration'
-OPT_HAS_ARG['S']=1         OPT_VAL['S']=5
+OPT_HAS_ARG['S']=1       OPT_VAL['S']=5
 
 OPT_NAME['w']='wait'     OPT_DESC['w']='idle time after suspend/resume wakeup'
-OPT_HAS_ARG['w']=1         OPT_VAL['w']=5
+OPT_HAS_ARG['w']=1       OPT_VAL['w']=5
 
 OPT_NAME['r']='random'   OPT_DESC['r']="Randomly setup wait/sleep time, this option will overwrite s & w option"
-OPT_HAS_ARG['r']=0         OPT_VAL['r']=0
+OPT_HAS_ARG['r']=0       OPT_VAL['r']=0
 
 OPT_NAME['m']='mode'     OPT_DESC['m']='alsa application type: playback/capture'
-OPT_HAS_ARG['m']=1         OPT_VAL['m']='playback'
+OPT_HAS_ARG['m']=1       OPT_VAL['m']='playback'
 
 OPT_NAME['t']='tplg'     OPT_DESC['t']="tplg file, default value is env TPLG: $TPLG"
-OPT_HAS_ARG['t']=1         OPT_VAL['t']="$TPLG"
+OPT_HAS_ARG['t']=1       OPT_VAL['t']="$TPLG"
 
 OPT_NAME['s']='sof-logger'   OPT_DESC['s']="Open sof-logger trace the data will store at $LOG_ROOT"
-OPT_HAS_ARG['s']=0             OPT_VAL['s']=1
+OPT_HAS_ARG['s']=0           OPT_VAL['s']=1
 
 OPT_NAME['f']='file'     OPT_DESC['f']='file name'
-OPT_HAS_ARG['f']=1         OPT_VAL['f']=''
+OPT_HAS_ARG['f']=1       OPT_VAL['f']=''
 
-OPT_NAME['P']='pipelines'   OPT_DESC['P']="run test case on specified pipelines"
-OPT_HAS_ARG['P']=1             OPT_VAL['P']="id:any"
+OPT_NAME['P']='pipelines'    OPT_DESC['P']="run test case on specified pipelines"
+OPT_HAS_ARG['P']=1           OPT_VAL['P']="id:any"
 
 func_opt_parse_option "$@"
 setup_kernel_check_point
@@ -110,7 +110,7 @@ do
     # delay for process run
     sleep 1
     # check process status is correct
-    sof-process-state.sh $process_id || {
+    sof-process-state.sh "$process_id" || {
         func_lib_lsof_error_dump "$snd"
         dloge "error process state of $cmd"
         dlogi "dump ps for aplay & arecord"

--- a/test-case/check-suspend-resume-with-audio.sh
+++ b/test-case/check-suspend-resume-with-audio.sh
@@ -119,7 +119,9 @@ do
         ps --ppid $$ -f
         exit 1
     }
-    "${TESTDIR}"/check-suspend-resume.sh "${opt_arr[@]}"  || die "suspend resume failed"
+    # Pass -p $process_id option to check-suspend-resume.sh
+    suspend_opts=("${opt_arr[@]}" -p "$process_id")
+    "${TESTDIR}"/check-suspend-resume.sh "${suspend_opts[@]}"  || die "suspend resume failed"
 
     # check kernel log for each iteration to catch issues
     sof-kernel-log-check.sh "$LOCAL_CHECK_POINT" || die "Caught error in kernel log"

--- a/test-case/check-suspend-resume.sh
+++ b/test-case/check-suspend-resume.sh
@@ -27,22 +27,22 @@ random_min=3    # wait time should >= 3 for other device wakeup from sleep
 random_max=20
 
 OPT_NAME['l']='loop'     OPT_DESC['l']='loop count'
-OPT_HAS_ARG['l']=1         OPT_VAL['l']=5
+OPT_HAS_ARG['l']=1       OPT_VAL['l']=5
 
-OPT_NAME['T']='type'    OPT_DESC['T']="suspend/resume type from /sys/power/mem_sleep"
-OPT_HAS_ARG['T']=1         OPT_VAL['T']=""
+OPT_NAME['T']='type'     OPT_DESC['T']="suspend/resume type from /sys/power/mem_sleep"
+OPT_HAS_ARG['T']=1       OPT_VAL['T']=""
 
 OPT_NAME['S']='sleep'    OPT_DESC['S']='suspend/resume command:rtcwake sleep duration'
-OPT_HAS_ARG['S']=1         OPT_VAL['S']=5
+OPT_HAS_ARG['S']=1       OPT_VAL['S']=5
 
 OPT_NAME['u']='unload-audio'  OPT_DESC['u']='unload audio modules for the test'
 OPT_HAS_ARG['u']=0            OPT_VAL['u']=0
 
 OPT_NAME['w']='wait'     OPT_DESC['w']='idle time after suspend/resume wakeup'
-OPT_HAS_ARG['w']=1         OPT_VAL['w']=5
+OPT_HAS_ARG['w']=1       OPT_VAL['w']=5
 
 OPT_NAME['r']='random'   OPT_DESC['r']="Randomly setup wait/sleep time, range is [$random_min-$random_max], this option will overwrite s & w option"
-OPT_HAS_ARG['r']=0         OPT_VAL['r']=0
+OPT_HAS_ARG['r']=0       OPT_VAL['r']=0
 
 func_opt_parse_option "$@"
 func_lib_check_sudo
@@ -170,7 +170,7 @@ sleep_once()
 {
     local i="$1"
 
-    dlogi "===== Round($i/$loop_count) ====="
+    dlogi "===== Loop($i/$loop_count) ====="
     # set up checkpoint for each iteration
     setup_kernel_check_point
     expected_wakeup_count=$((expected_wakeup_count+1))


### PR DESCRIPTION
check-suspend-resume-with-audio.sh uses check-suspend-resume.sh. process check is in check-suspend-resume-with-audio.sh and check-suspend-resume.sh has the loop. Must check that the process id is available in each loop. TO do so, pass aplay/arecord pid to check-suspend-resume.sh.