### PR TITLE
Add and start using generic functions fw_reldir() and fw_relfilepath()

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -310,23 +310,14 @@ get_ldc_subdir()
 {
     local strip_arg="$1"
     local subdir='intel/sof' # default
+
     local fw_path
-    local fw_path_info='/sys/kernel/debug/sof/fw_profile/fw_path'
-
-    # either $fw_path_info exists, OR we redefine $fw_path_info with
-    # the backwards-compatible alternative based on kernel parameter
-    sudo test -e $fw_path_info ||
-	fw_path_info='/sys/module/snd_sof_pci/parameters/fw_path'
-
-    if fw_path=$(sudo cat $fw_path_info); then
-	# "cat" was succesful
-        if [ "$fw_path" != '(null)' ]; then
+    if fw_path=$(fw_reldir); then
             subdir=${fw_path%/} # strip any trailing slash
             subdir=${subdir%/community}
             subdir=${subdir%/intel-signed}
             subdir=${subdir%/dbgkey}
             test -z "$strip_arg" || subdir=${subdir%/"$strip_arg"}
-        fi
     fi
     printf '%s' "$subdir"
 }

--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -879,11 +879,6 @@ fw_relfilepath()
     printf '%s' "$from_klogs"
 }
 
-
-# TODO: switch to new debugfs `fw_profile`, see
-# https://github.com/thesofproject/linux/issues/3867 and friends. Keep this existing
-# journalctl_cmd() code as a fallback for older kernels or when the firmware has been
-# unloaded. Fallback similar to the one in commit 646a3b3b71003
 fw_relfilepath_from_klogs()
 {
     local rel_filepath
@@ -906,8 +901,8 @@ is_firmware_file_zephyr()
 {
     local firmware_path znum
 
-    firmware_path=$(fw_relfilepath_from_klogs) ||
-        die 'Firmware path not found.'
+    { firmware_path=$(fw_relfilepath) && test -r /lib/firmware/"$firmware_path"; } ||
+        die "Firmware path ${firmware_path} not found."
 
     znum=$(strings "/lib/firmware/$firmware_path" | grep -c -i zephyr)
     test "$znum" -gt 10


### PR DESCRIPTION
Add two generic functions fw_reldir() and fw_relfilepath() which search in this order:

1. /sys/kernel/debug/sof/fw_profile/
2. /sys/module/snd_sof_pci/parameters/
3. Kernel logs.

The 3., slower, "legacy" option is kept because it's useful with either old kernels or when the modules have been unloaded.

Start using these two generic functions in `is_firmware_file_zephyr()` and `get_ldc_subdir()`.

