### PR TITLE
tools: kmod: Handle snd_sof_pci_intel_ptl

### DIFF
--- a/tools/kmod/sof_insert.sh
+++ b/tools/kmod/sof_insert.sh
@@ -108,6 +108,7 @@ insert_module snd_sof_pci_intel_icl
 insert_module snd_sof_pci_intel_tgl
 insert_module snd_sof_pci_intel_mtl
 insert_module snd_sof_pci_intel_lnl
+insert_module snd_sof_pci_intel_ptl
 
 # OF driver
 insert_module snd_sof_of

--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -86,8 +86,9 @@ remove_module snd_usbmidi_lib
 #-------------------------------------------
 # Top level devices
 # ACPI is after PCI due to TNG dependencies
-# TGL and ICL depend on CNL, and LNL on MTL,
-# the non-linear order is intentional
+# TGL and ICL depend on CNL, PTL on LNL and
+# LNL on MTL, the non-linear order is
+# intentional
 #-------------------------------------------
 remove_module snd_hda_intel
 remove_module snd_sof_pci_intel_tng
@@ -98,6 +99,7 @@ remove_module snd_sof_pci_intel_tgl
 remove_module snd_sof_pci_intel_icl
 remove_module snd_sof_pci_intel_cnl
 
+remove_module snd_sof_pci_intel_ptl
 remove_module snd_sof_pci_intel_lnl
 remove_module snd_sof_pci_intel_mtl
 


### PR DESCRIPTION
The snd_sof_pci_intel_ptl depends on the LNL module and it blobks removal of snd_sof_pci_intel_lnl.