### PR TITLE
check-ipc-flood.sh: stop asking Zephyr users to use CONFIG_DEBUG

### DIFF
--- a/test-case/check-ipc-flood.sh
+++ b/test-case/check-ipc-flood.sh
@@ -36,16 +36,21 @@ loop_cnt=${OPT_VAL['l']}
 
 start_test
 
+if is_ipc4; then
+    skip_test 'IPC4 detected: see sof-test#1066'
+fi
+
+# See SOF_IPC_INFO_BUILD in linux/sound/soc/sof/ipc3.c:sof_ipc3_validate_fw_version()
 sof-kernel-dump.sh | grep sof-audio | grep -q "Firmware debug" ||
-     skip_test "need debug version firmware"
+     skip_test "CONFIG_DEBUG firmware needed for SOF_IPC_TEST_IPC_FLOOD cmd"
 
 func_lib_check_sudo
 
-dlogi "Check sof debug fs environment"
-if sudo file $ipc_flood_dfs | grep 'No such file'; then
+dlogi "Check $ipc_flood_dfs"
+sudo test -e $ipc_flood_dfs ||
   skip_test "${BASH_SOURCE[0]} need $ipc_flood_dfs to run the test case"
-fi
-dlogi "Checking ipc flood test!"
+
+dlogi "Running ipc flood test!"
 
 for i in $(seq 1 $loop_cnt)
 do


### PR DESCRIPTION
Add is_firmware_file_zephyr() and a new SKIP message to stop telling Zephyr users to build a "debug firmware" because it won't change anything for them: IPC4 has no flood command right now, see https://github.com/thesofproject/sof-test/issues/1066

Also clarify the XTOS skip message + other cosmetic improvements.