### PR TITLE
Add new local_config.bash files to solve device-specific issues

### DIFF
--- a/case-lib/apause.exp
+++ b/case-lib/apause.exp
@@ -1,6 +1,6 @@
 #!/usr/bin/env expect
 
-# If you're new to expect:
+# If you're new to https://wiki.tcl-lang.org/page/Expect
 #
 # - Expect is "only" a Tcl extension and Tcl command.
 #   An "Expect script" is a somewhat misleading shorthand for "a Tcl
@@ -186,7 +186,7 @@ expect {
             # for some unknown reason, then there could be _multiple_
             # volume lines in a single of these buffer iterations and then we
             # could miss some non-zeros.
-            # This is very unlikely though so this is statically good enough.
+            # This is very unlikely though so this is statistically good enough.
             if {! [regexp {\| ( |0)0%} "$buffer_with_lf"]} {
                 set volume_always_zero false
             }

--- a/case-lib/config.sh
+++ b/case-lib/config.sh
@@ -2,6 +2,10 @@
 
 # this file is used for defining global variables
 
+# To change some of these variables without polluting git status/git
+# diff, override them in either /etc/sof/local_config.bash or
+# sof-test/case-lib/local_config.bash
+
 # Some variables need manual configuration
 # Some commands need to access system node, so they need the sudo password
 SUDO_PASSWD=${SUDO_PASSWD:-}

--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -21,6 +21,15 @@ source "$SCRIPT_HOME/case-lib/pipeline.sh"
 # shellcheck source=case-lib/hijack.sh
 source "$SCRIPT_HOME/case-lib/hijack.sh"
 
+# source these last (and in this order) so they win
+for f in /etc/sof/local_config.bash ${SCRIPT_HOME}/case-lib/local_config.bash; do
+    if test -e "$f"; then
+        dlogw "Sourcing local and optional $f"
+        # shellcheck disable=SC1090
+        source "$f"
+    fi
+done
+
 # restrict bash version for some bash feature
 [[ $(echo -e "$BASH_VERSION\n4.1"|sort -V|head -n 1) == '4.1' ]] || {
     dlogw "Bash version: ${BASH_VERSINFO[0]}.${BASH_VERSINFO[1]} should > 4.1"

--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -427,18 +427,15 @@ else
 fi
 
 declare -p cmd
-# check priority err for error message
-if [[ "$ignore_str" ]]; then
-    err=$($cmd --priority=err | grep -vE "$ignore_str")
-else
-    err=$($cmd --priority=err)
-fi
 
-[[ -z "$err" ]] || {
+if err=$($cmd --priority=err |
+             grep -v -E -e "$ignore_str"); then
+
     type journalctl_cmd
     echo "$(date -u '+%Y-%m-%d %T %Z')" "[ERROR]" "Caught kernel log error"
     echo "===========================>>"
     echo "$err"
     echo "<<==========================="
     builtin exit 1
-}
+
+fi


### PR DESCRIPTION
Source additional files /etc/sof/local_config.bash and
sof-test/case-lib/local_config.bash.

This helps solving device-specific issues like https://github.com/thesofproject/sof-test/pull/1233 and many others
before that - for instance git blame the "ignore_str" variable in
sof-kernel-log-check.sh