### PR TITLE
kmod: add more SoundWire codecs

### DIFF
--- a/tools/kmod/sof_insert.sh
+++ b/tools/kmod/sof_insert.sh
@@ -57,6 +57,16 @@ insert_module snd_soc_rt1308_sdw
 insert_module snd_soc_rt1316_sdw
 insert_module snd_soc_rt1318_sdw
 insert_module snd_soc_rt1320_sdw
+insert_module snd_soc_rt1017_sdw
+
+insert_module snd_soc_cs35l56
+insert_module snd_soc_cs35l56_sdw
+insert_module snd_soc_cs42l42
+insert_module snd_soc_cs42l42_sdw
+#inversion is intentional for cs42l43
+insert_module cs42l43_sdw
+insert_module snd_soc_cs42l43_sdw
+insert_module snd_soc_cs42l43
 
 insert_module snd_soc_sdw_mockup
 

--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -239,6 +239,18 @@ remove_module snd_soc_da7219
 remove_module snd_soc_pcm512x_i2c
 remove_module snd_soc_pcm512x
 
+remove_module snd_soc_cs35l56_sdw
+remove_module snd_soc_cs35l56
+#snd_soc_wm_adsp is used by snd_soc_cs35l56
+remove_module snd_soc_wm_adsp
+remove_module snd_soc_cs42l42_sdw
+remove_module snd_soc_cs42l42
+
+# inversion is intentional for cs42l43
+remove_module snd_soc_cs42l43
+remove_module snd_soc_cs42l43_sdw
+remove_module cs42l43_sdw
+
 remove_module snd_soc_rt274
 remove_module snd_soc_rt286
 remove_module snd_soc_rt298
@@ -255,8 +267,8 @@ remove_module snd_soc_rt1308_sdw
 remove_module snd_soc_rt1316_sdw
 remove_module snd_soc_rt1318_sdw
 remove_module snd_soc_rt1320_sdw
-remove_module snd_soc_sdw_mockup
 remove_module snd_soc_rt1011
+remove_module snd_soc_rt1017-sdca
 remove_module snd_soc_rt5640
 remove_module snd_soc_rt5645
 remove_module snd_soc_rt5651
@@ -270,6 +282,7 @@ remove_module snd_soc_rt5682
 remove_module snd_soc_rt5682s
 remove_module snd_soc_rl6231
 remove_module snd_soc_rl6347a
+remove_module snd_soc_sdw_mockup
 
 remove_module snd_soc_wm8804_i2c
 remove_module snd_soc_wm8804


### PR DESCRIPTION
rt1017-sdca and CirrusLogic missing

The CS42L43 order is inverted, the core calls into the -sdw module