### PR TITLE
kmod: Add modules useful for imx platforms

### DIFF
--- a/tools/kmod/sof_insert.sh
+++ b/tools/kmod/sof_insert.sh
@@ -83,9 +83,11 @@ insert_module snd_soc_es8316
 insert_module snd_soc_es8326
 
 insert_module snd_soc_wm8960
+insert_module snd_soc_simple_card
 
 # core SOF driver
 insert_module snd_sof
+insert_module snd_sof_utils
 
 # insert top-level ACPI/PCI SOF drivers. They will register SOF components and
 # load machine drivers as needed. Do not insert any other sort of audio module,

--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -295,6 +295,7 @@ remove_module snd_hda_codec_realtek
 remove_module snd_hda_codec_generic
 
 remove_module snd_soc_wm8960
+remove_module snd_soc_simple_card
 
 #-------------------------------------------
 # Remaining core SOF parts


### PR DESCRIPTION
Add snd_soc_simple_card module for insert/remove testing. Also, snd_sof_utils was missing from sof_insert.sh.