### PR TITLE
Added "Kernel: ACPI" Error message to ignored string list

### DIFF
--- a/tools/sof-kernel-log-check.sh
+++ b/tools/sof-kernel-log-check.sh
@@ -415,6 +415,8 @@ ignore_str="$ignore_str"'|I/O error, dev loop., sector 0 op 0x0:.READ. flags 0x8
 # https://github.com/thesofproject/sof-test/issues/888
 ignore_str="$ignore_str"'|nvme0: Admin Cmd\(0x[[:digit:]]+\), I/O Error \(sct 0x0 / sc 0x2\)'
 
+# Kernel Boot log check test failure because of the ACPI error 
+ignore_str="$ignore_str""|kernel: ACPI: \\\\: Can't tag data node"
 #
 # SDW related logs
 #


### PR DESCRIPTION
Kernel and Boot log check test failed Due to ACPI bios error and its nothing harm to Audio functionality. Hence i added ACPI error as ignored string.