### PR TITLE
kmod: remove snd_seq_dummy and snd_hrtimer

### DIFF
--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -338,8 +338,10 @@ remove_module snd_ctl_led
 remove_module snd_seq_midi
 remove_module snd_seq_midi_event
 remove_module snd_rawmidi
+remove_module snd_seq_dummy
 remove_module snd_seq
 remove_module snd_seq_device
+remove_module snd_hrtimer
 remove_module snd_timer
 remove_module snd
 remove_module soundcore


### PR DESCRIPTION
snd_seq_dummy and snd_hrtimer are present while pipewire is enabled in ubuntu 24.04.
Those modules prevent snd_seq and snd_timer from unloading and sof_remove.sh fails.

Failed logs from old version, these errors are not present with this commit applied.

```ini
RMMOD   snd_usb_audio
RMMOD   snd_usbmidi_lib
SKIP    snd_hda_intel   not loaded
RMMOD   snd_sof_pci_intel_tng
RMMOD   snd_sof_pci_intel_skl
RMMOD   snd_sof_pci_intel_apl
RMMOD   snd_sof_pci_intel_tgl
RMMOD   snd_sof_pci_intel_icl
RMMOD   snd_sof_pci_intel_cnl
RMMOD   snd_sof_pci_intel_ptl
RMMOD   snd_sof_pci_intel_lnl
RMMOD   snd_sof_pci_intel_mtl
RMMOD   snd_sof_acpi_intel_byt
RMMOD   snd_sof_acpi_intel_bdw
SKIP    snd_sof_imx8    not loaded
SKIP    snd_sof_imx8m   not loaded
SKIP    snd_soc_catpt   not loaded
SKIP    snd_intel_sst_acpi      not loaded
SKIP    snd_intel_sst_core      not loaded
SKIP    snd_soc_sst_atom_hifi2_platform         not loaded
SKIP    snd_soc_skl     not loaded
SKIP    snd_soc_avs     not loaded
SKIP    snd_soc_hda_codec       not loaded
RMMOD   snd_sof_intel_hda_generic
RMMOD   snd_sof_intel_hda_common
SKIP    soundwire_intel_init    not loaded
SKIP    soundwire_intel         not loaded
SKIP    soundwire_cadence       not loaded
SKIP    soundwire_generic_allocation    not loaded
SKIP    snd_sof_intel_hda_sdw_bpt       not loaded
SKIP    snd_sof_intel_hda_common        not loaded
SKIP    snd_sof_intel_hda       not loaded
SKIP    snd_sof_intel_ipc       not loaded
RMMOD   snd_sof_xtensa_dsp
RMMOD   snd_sof_acpi
RMMOD   snd_sof_pci
RMMOD   snd_sof_intel_atom
SKIP    imx_common      not loaded
SKIP    snd_soc_sof_rt5682      not loaded
SKIP    snd_soc_sof_da7219_max98373     not loaded
SKIP    snd_soc_sof_da7219      not loaded
SKIP    snd_soc_sst_bdw_rt5677_mach     not loaded
SKIP    snd_soc_bdw_rt286       not loaded
SKIP    snd_soc_sst_broadwell   not loaded
SKIP    snd_soc_sst_bxt_da7219_max98357a        not loaded
SKIP    snd_soc_sst_sof_pcm512x         not loaded
SKIP    snd_soc_sst_bxt_rt298   not loaded
SKIP    snd_soc_sst_sof_wm8804          not loaded
SKIP    snd_soc_sst_byt_cht_da7213      not loaded
SKIP    snd_soc_sst_byt_cht_es8316      not loaded
SKIP    snd_soc_sst_bytcr_rt5640        not loaded
SKIP    snd_soc_sst_bytcr_rt5651        not loaded
SKIP    snd_soc_sst_cht_bsw_max98090_ti         not loaded
SKIP    snd_soc_sst_cht_bsw_nau8824     not loaded
SKIP    snd_soc_sst_cht_bsw_rt5645      not loaded
SKIP    snd_soc_sst_cht_bsw_rt5672      not loaded
SKIP    snd_soc_sst_glk_rt5682_max98357a        not loaded
SKIP    snd_soc_cml_rt1011_rt5682       not loaded
SKIP    snd_soc_skl_hda_dsp     not loaded
SKIP    snd_soc_sdw_rt700       not loaded
SKIP    snd_soc_sdw_rt711_rt1308_rt715          not loaded
SKIP    snd_soc_sof_sdw         not loaded
SKIP    snd_soc_sdw_utils       not loaded
SKIP    snd_soc_sof_es8336      not loaded
SKIP    snd_soc_ehl_rt5660      not loaded
SKIP    snd_soc_intel_sof_board_helpers         not loaded
RMMOD   snd_soc_acpi_intel_match
SKIP    snd_soc_intel_hda_dsp_common    not loaded
SKIP    snd_soc_intel_sof_cirrus_common         not loaded
SKIP    snd_soc_intel_sof_maxim_common          not loaded
SKIP    snd_soc_intel_sof_nuvoton_common        not loaded
SKIP    snd_soc_intel_sof_realtek_common        not loaded
RMMOD   snd_sof_probes
SKIP    snd_sof_ipc_test        not loaded
SKIP    snd_sof_ipc_flood_test          not loaded
RMMOD   snd_sof_ipc_msg_injector
SKIP    snd_sof_ipc_kernel_injector     not loaded
SKIP    snd_sof_dma_trace       not loaded
SKIP    snd_sof_of      not loaded
RMMOD   snd_sof_nocodec
RMMOD   snd_sof
SKIP    snd_sof_nocodec         not loaded
RMMOD   snd_sof_utils
SKIP    snd_soc_da7213          not loaded
SKIP    snd_soc_da7219          not loaded
SKIP    snd_soc_pcm512x_i2c     not loaded
SKIP    snd_soc_pcm512x         not loaded
SKIP    snd_soc_cs35l56_sdw     not loaded
SKIP    snd_soc_cs35l56         not loaded
SKIP    snd_soc_wm_adsp         not loaded
SKIP    snd_soc_cs42l42_sdw     not loaded
SKIP    snd_soc_cs42l42         not loaded
SKIP    snd_soc_cs42l43         not loaded
SKIP    snd_soc_cs42l43_sdw     not loaded
SKIP    cs42l43_sdw     not loaded
SKIP    snd_soc_rt274   not loaded
SKIP    snd_soc_rt286   not loaded
SKIP    snd_soc_rt298   not loaded
SKIP    snd_soc_rt700   not loaded
SKIP    snd_soc_rt711   not loaded
SKIP    snd_soc_rt711_sdca      not loaded
SKIP    snd_soc_rt712_sdca      not loaded
SKIP    snd_soc_rt712_sdca_dmic         not loaded
SKIP    snd_soc_rt715   not loaded
SKIP    snd_soc_rt715_sdca      not loaded
SKIP    snd_soc_rt722_sdca      not loaded
SKIP    snd_soc_rt1308          not loaded
SKIP    snd_soc_rt1308_sdw      not loaded
SKIP    snd_soc_rt1316_sdw      not loaded
SKIP    snd_soc_rt1318_sdw      not loaded
SKIP    snd_soc_rt1320_sdw      not loaded
SKIP    snd_soc_rt1011          not loaded
SKIP    snd_soc_rt1017-sdca     not loaded
SKIP    snd_soc_rt5640          not loaded
SKIP    snd_soc_rt5645          not loaded
SKIP    snd_soc_rt5651          not loaded
SKIP    snd_soc_rt5660          not loaded
SKIP    snd_soc_rt5670          not loaded
SKIP    snd_soc_rt5677          not loaded
SKIP    snd_soc_rt5677_spi      not loaded
SKIP    snd_soc_rt5682_sdw      not loaded
SKIP    snd_soc_rt5682_i2c      not loaded
SKIP    snd_soc_rt5682          not loaded
SKIP    snd_soc_rt5682s         not loaded
SKIP    snd_soc_rl6231          not loaded
SKIP    snd_soc_rl6347a         not loaded
SKIP    snd_soc_sdw_mockup      not loaded
SKIP    snd_soc_wm8804_i2c      not loaded
SKIP    snd_soc_wm8804          not loaded
SKIP    snd_soc_es8316          not loaded
SKIP    snd_soc_es8326          not loaded
SKIP    snd_soc_max98090        not loaded
SKIP    snd_soc_ts3a227e        not loaded
SKIP    snd_soc_max98357a       not loaded
SKIP    snd_soc_max98363        not loaded
SKIP    snd_soc_max98373_sdw    not loaded
SKIP    snd_soc_max98373_i2c    not loaded
SKIP    snd_soc_max98373        not loaded
SKIP    snd_soc_max98390        not loaded
SKIP    snd_soc_hdac_hda        not loaded
SKIP    snd_soc_hdac_hdmi       not loaded
SKIP    snd_hda_codec_hdmi      not loaded
SKIP    snd_soc_dmic    not loaded
SKIP    snd_hda_codec_realtek   not loaded
SKIP    snd_hda_codec_generic   not loaded
SKIP    snd_soc_wm8960          not loaded
RMMOD   snd_soc_acpi
RMMOD   snd_intel_dspcfg
SKIP    regmap_sdw      not loaded
SKIP    regmap_sdw_mbq          not loaded
SKIP    soundwire_bus   not loaded
SKIP    snd_intel_sdw_acpi      not loaded
RMMOD   snd_sof_intel_hda_mlink
RMMOD   snd_hda_ext_core
RMMOD   snd_soc_core
SKIP    snd_hda_codec   not loaded
RMMOD   snd_hda_core
RMMOD   snd_hwdep
RMMOD   snd_compress
SKIP    snd_pcm_dmaengine       not loaded
RMMOD   snd_pcm
SKIP    snd_ctl_led     not loaded
RMMOD   snd_seq_midi
RMMOD   snd_seq_midi_event
RMMOD   snd_rawmidi
RMMOD   snd_seq
RMMOD   snd_seq_device
RMMOD   snd_timer
rmmod: ERROR: Module snd_timer is in use by: snd_hrtimer
snd_hrtimer            12288  0
snd_timer              53248  1 snd_hrtimer
snd                   135168  1 snd_timer
soundcore              12288  1 snd
snd_soc_acpi_intel_sdca_quirks    12288  0
snd_soc_sdca           12288  1 snd_soc_acpi_intel_sdca_quirks
drm                   753664  0
./sof-test/tools/kmod/sof_remove.sh FAILED

```

lsmod output
```bash
$ lsmod | grep snd_hrtimer
snd_hrtimer            12288  0
snd_timer              53248  3 snd_seq,snd_hrtimer,snd_pcm

$ lsmod | grep snd_seq_dummy
snd_seq_dummy          12288  0
snd_seq               110592  3 snd_seq_midi,snd_seq_midi_event,snd_seq_dummy
```
