### PR TITLE
alsa_settings: PTLH_HDA_AIOC.sh: fix mic source

### DIFF
--- a/alsa_settings/PTLH_HDA_AIOC.sh
+++ b/alsa_settings/PTLH_HDA_AIOC.sh
@@ -9,5 +9,4 @@ amixer -c sofhdadsp cset name='Headphone Playback Volume' 60
 # enable headset capture
 amixer -c sofhdadsp cset name='Capture Switch' on
 amixer -c sofhdadsp cset name='Capture Volume' 30
-~
-
+amixer -c sofhdadsp cset name='Capture Source' 2


### PR DESCRIPTION
Add explicit set for capture source to ensure the capture is done from the headset mic. Test cases (like alsabat) expect the HDA codec to be attached to a analog loopback cable.

Also fix a stray '~' character in the script.