### PR TITLE
TinyAlsa: Add support for testing using tinycap and tinyplay.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ expect alsa-utils python3 python3-construct python3-graphviz
 ```
 sudo apt install expect alsa-utils python3 python3-construct python3-graphviz
 ```
+If you would like to use tinyALSA for testing, install tinyALSA and SoX.
+- How to install tinyALSA: https://github.com/tinyalsa/tinyalsa
+- To install SoX run below command:
+```
+sudo apt-install sox
+```
 #### user group
 sudo adm audio
 
@@ -52,12 +58,14 @@ Usage: ./check-playback.sh [OPTION]
 2020-03-19 22:13:32 UTC [COMMAND] aplay -q --fatal-errors  -Dhw:0,0 -r 48000 -c 2 -f S16_LE -d 4 /dev/zero -v -q
     ...
 ```
+Some tests support these environment variables (work in progress):
+  - SOF_ALSA_TOOL is used to select the audio tool for testing.
+  Set this variable to 'alsa' (default value) or 'tinyalsa' to choose between the ALSA and TinyALSA toolsets.
+  - SOF_ALSA_OPTS contains optional parameters passed on both play and record.
+  - SOF_APLAY_OPTS and SOF_ARECORD_OPTS contain optional parameters passed additionally on play and record respectively.
+These options are applied to the selected tool (alsa or tinyalsa) based on the value of SOF_ALSA_TOOL 
 
-Some tests support SOF_ALSA_OPTS, SOF_APLAY_OPTS and SOF_ARECORD_OPTS,
-work in progress. Where supported, optional parameters in SOF_APLAY_OPTS
-and SOF_ARECORD_OPTS are passed to all aplay and arecord
-invocations. SOF_ALSA_OPTS parameters are passed to both aplay and
-arecord. Warning these environments variables do NOT support parameters
+Warning, these environment variables do NOT support parameters
 with whitespace or globbing characters, in other words this does NOT
 work:
 

--- a/env-check.sh
+++ b/env-check.sh
@@ -83,6 +83,9 @@ out_str="" check_res=0
 printf "Checking for some OS packages:\t\t"
 func_check_pkg expect
 func_check_pkg aplay
+func_check_pkg sox
+func_check_pkg tinycap
+func_check_pkg tinyplay
 func_check_pkg python3
 # jq is command-line json parser
 func_check_pkg jq

--- a/test-case/check-capture.sh
+++ b/test-case/check-capture.sh
@@ -64,25 +64,20 @@ setup_kernel_check_point
 func_lib_check_sudo
 func_pipeline_export "$tplg" "type:capture & ${OPT_VAL['S']}"
 
-for round in $(seq 1 $round_cnt)
+for round in $(seq 1 "$round_cnt")
 do
     for idx in $(seq 0 $((PIPELINE_COUNT - 1)))
     do
-        channel=$(func_pipeline_parse_value "$idx" channel)
-        rate=$(func_pipeline_parse_value "$idx" rate)
-        fmt=$(func_pipeline_parse_value "$idx" fmt)
-        dev=$(func_pipeline_parse_value "$idx" dev)
-        pcm=$(func_pipeline_parse_value "$idx" pcm)
-        type=$(func_pipeline_parse_value "$idx" type)
-        snd=$(func_pipeline_parse_value "$idx" snd)
 
-        if [ ${OPT_VAL['F']} = '1' ]; then
-            fmt=$(func_pipeline_parse_value "$idx" fmts)
+        initialize_audio_params "$idx"
+
+        if [ "${OPT_VAL['F']}" = '1' ]; then
+            fmts=$(func_pipeline_parse_value "$idx" fmts)
         fi
 
-        for fmt_elem in $fmt
+        for fmt_elem in $fmts
         do
-            for i in $(seq 1 $loop_cnt)
+            for i in $(seq 1 "$loop_cnt")
             do
                 dlogi "===== Testing: (Round: $round/$round_cnt) (PCM: $pcm [$dev]<$type>) (Loop: $i/$loop_cnt) ====="
                 # get the output file
@@ -90,12 +85,12 @@ do
                     dlogi "no file prefix, use /dev/null as dummy capture output"
                     file=/dev/null
                 else
-                    mkdir -p $out_dir
+                    mkdir -p "$out_dir"
                     file=$out_dir/${file_prefix}_${dev}_${i}.wav
                     dlogi "using $file as capture output"
                 fi
 
-                if ! arecord_opts -D"$dev" -r "$rate" -c "$channel" -f "$fmt_elem" -d $duration "$file" -v -q;
+                if ! arecord_opts -D"$dev" -r "$rate" -c "$channel" -f "$fmt_elem" -d "$duration" "$file" -v -q;
                 then
                     func_lib_lsof_error_dump "$snd"
                     die "arecord on PCM $dev failed at $i/$loop_cnt."

--- a/test-case/check-playback.sh
+++ b/test-case/check-playback.sh
@@ -71,25 +71,20 @@ setup_kernel_check_point
 func_lib_check_sudo
 func_pipeline_export "$tplg" "type:playback & ${OPT_VAL['S']}"
 
-for round in $(seq 1 $round_cnt)
+for round in $(seq 1 "$round_cnt")
 do
     for idx in $(seq 0 $((PIPELINE_COUNT - 1)))
     do
-        channel=$(func_pipeline_parse_value "$idx" channel)
-        rate=$(func_pipeline_parse_value "$idx" rate)
-        fmts=$(func_pipeline_parse_value "$idx" fmt)
-        dev=$(func_pipeline_parse_value "$idx" dev)
-        pcm=$(func_pipeline_parse_value "$idx" pcm)
-        type=$(func_pipeline_parse_value "$idx" type)
-        snd=$(func_pipeline_parse_value "$idx" snd)
 
-        if [ ${OPT_VAL['F']} = '1' ]; then
+        initialize_audio_params "$idx"
+
+        if [ "${OPT_VAL['F']}" = '1' ]; then
             fmts=$(func_pipeline_parse_value "$idx" fmts)
         fi
 
         for fmt_elem in $fmts
         do
-            for i in $(seq 1 $loop_cnt)
+            for i in $(seq 1 "$loop_cnt")
             do
                 dlogi "===== Testing: (Round: $round/$round_cnt) (PCM: $pcm [$dev]<$type>) (Loop: $i/$loop_cnt) ====="
                 aplay_opts -D"$dev" -r "$rate" -c "$channel" -f "$fmt_elem" \

--- a/test-case/tinyalsa-wrapper.sh
+++ b/test-case/tinyalsa-wrapper.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+##
+## Case Name: Wrapper to run a test case given with TinyALSA
+## Preconditions:
+##    TinyALSA and SoX are installed.
+## Description:
+##    This script serves as a wrapper to execute a test case script using TinyALSA.
+##    It expects the test case script file name (without path) as the first parameter,
+##    followed by other parameters required for that test case.
+## Case step:
+##    1. SOF_ALSA_TOOL environment variable is set to TinyALSA
+##    2. The test case script is executed.
+## Expect result:
+##    The test case script is executed using TinyALSA
+##
+
+set -e
+
+# Ensure the test case script file name is provided
+if [ -z "$1" ]; then
+    echo "Error: No test case script file name provided. Exiting..."
+    exit 1
+fi
+
+export SOF_ALSA_TOOL=tinyalsa
+
+TESTDIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+# shellcheck disable=SC2145
+[ -x "$TESTDIR/test-case/$(basename "$1")" ] && exec "$TESTDIR"/test-case/"$@"


### PR DESCRIPTION
Added option `SOF_ALSA_TOOL` to specify whether to use the `TinyASLA` or `ALSA` testing tool. For now, it is only for capturing and playback.
The default tool is ALSA.

This PR introduces also a generic wrapper  `tinyalsa-wrapper.sh` to define `SOF_ALSA_TOOL` in environments where setting environment variables directly is not possible. This is useful for frameworks or systems with limited configuration capabilities.