### PR TITLE
TinyAlsa: Add support for tinymix command.

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -952,7 +952,7 @@ is_ipc4()
 logger_disabled()
 {
     # Disable logging when available...
-    if [ ${OPT_VAL['s']} -eq 0 ]; then
+    if [ "${OPT_VAL['s']}" -eq 0 ]; then
         return 0
     fi
 
@@ -1060,18 +1060,63 @@ set_alsa_settings()
     esac
 }
 
+set_sof_volume()
+{
+    local device=$1
+    local control_name=$2
+    local value=$3
+
+    if [[ "$SOF_ALSA_TOOL" = "alsa" ]]; then
+        dlogc "amixer -c$device' -- cset 'name=$control_name' '$value'"
+        amixer -c"$device" cset name="$control_name" "$value" > /dev/null
+    elif [[ "$SOF_ALSA_TOOL" = "tinyalsa" ]]; then
+        dlogc "tinymix -D'$device' set '$control_name' '$value'"
+        tinymix -D"$device" set "$control_name" "$value"  > /dev/null
+    else
+        echo "Unknown alsa tool $SOF_ALSA_TOOL"
+    fi
+}
+
+get_sof_controls()
+{
+    local sofcard=$1
+
+    if [[  "$SOF_ALSA_TOOL" = "alsa" ]]; then
+            amixer -c"$sofcard" controls
+    elif [[ "$SOF_ALSA_TOOL" = "tinyalsa" ]]; then
+            tinymix --card "$sofcard" controls
+    else
+        echo "Unknown alsa tool $SOF_ALSA_TOOL"
+    fi
+
+}
+
 reset_sof_volume()
 {
     # set all PGA* volume to 0dB
-    amixer -Dhw:0 scontrols | sed -e "s/^.*'\(.*\)'.*/\1/" |grep -E 'PGA|gain' |
-    while read -r mixer_name
-    do
-        if is_ipc4; then
-            amixer -Dhw:0 -- sset "$mixer_name" 100%
-        else
-            amixer -Dhw:0 -- sset "$mixer_name" 0dB
-        fi
-    done
+    if [[ "$SOF_ALSA_TOOL" = "alsa" ]]; then
+        amixer -Dhw:0 scontrols | sed -e "s/^.*'\(.*\)'.*/\1/" |grep -E 'PGA|gain' |
+        while read -r mixer_name
+        do
+            if is_ipc4; then
+                amixer -Dhw:0 -- sset "$mixer_name" 100%
+            else
+                amixer -Dhw:0 -- sset "$mixer_name" 0dB
+            fi
+        done
+    elif [[ "$SOF_ALSA_TOOL" = "tinyalsa" ]]; then
+        tinymix -D 0 contorls | sed -e "s/^.*'\(.*\)'.*/\1/" |grep -E 'PGA|gain' |
+        while read -r mixer_name
+        do
+            if is_ipc4; then
+                tinymix -D 0 set "$mixer_name" 100%
+            else
+                tinymix -D 0 set "$mixer_name" 0dB
+            fi
+        done
+    else
+        echo "Unknown alsa tool $SOF_ALSA_TOOL"
+    fi
 }
 
 DO_PERF_ANALYSIS=0

--- a/test-case/volume-basic-test.sh
+++ b/test-case/volume-basic-test.sh
@@ -39,11 +39,39 @@ maxloop=${OPT_VAL['l']}
 
 start_test
 
-func_error_exit()
+check_alsa_tool_process()
 {
-    dloge "$*"
-    pkill -9 aplay
-    exit 1
+    sleep 1
+    if [[ "$SOF_ALSA_TOOL" = "alsa" ]]; then
+        # Check if the aplay process is running
+        if [[ ! $(pidof aplay) ]]; then
+            die "aplay process is terminated too early"
+        fi
+    elif [[ "$SOF_ALSA_TOOL" = "tinyalsa" ]]; then
+        # Check if the tinyplay process is running
+        if [[ ! $(pidof tinyplay) ]]; then
+            die "tinyplay process is terminated too early"
+        fi
+    else
+        echo "Unknown alsa tool $SOF_ALSA_TOOL"
+    fi
+}
+
+func_exit()
+{
+
+    if [[ "$SOF_ALSA_TOOL" = "alsa" ]]; then
+        pkill -9 aplay
+    elif [[ "$SOF_ALSA_TOOL" = "tinyalsa" ]]; then
+        pkill -9 tinyplay
+    else
+        echo "Unknown alsa tool $SOF_ALSA_TOOL"
+    fi
+
+    if [[ "$1" -eq 1 ]]; then
+        dloge "$*"
+        exit 1  # error
+    fi
 }
 
 [[ -z $tplg ]] && die "Missing tplg file needed to run"
@@ -51,29 +79,23 @@ func_pipeline_export "$tplg" "type:playback"
 logger_disabled || func_lib_start_log_collect
 
 [[ $PIPELINE_COUNT -eq 0 ]] && die "Missing playback pipeline for aplay to run"
-channel=$(func_pipeline_parse_value 0 channel)
-rate=$(func_pipeline_parse_value 0 rate)
-fmt=$(func_pipeline_parse_value 0 fmt)
-dev=$(func_pipeline_parse_value 0 dev)
-
-dlogc "aplay -D $dev -c $channel -r $rate -f $fmt /dev/zero &"
+duration=50 # Duration of playing white noise while testing under tinyalsa
+initialize_audio_params "0"
 # play into background, this will wake up DSP and IPC. Need to clean after the test
-aplay -D "$dev" -c "$channel" -r "$rate" -f "$fmt" /dev/zero &
-
-sleep 1
-[[ ! $(pidof aplay) ]] && die "aplay process is terminated too early"
-
+# shellcheck disable=SC2154 
+aplay_opts -D "$dev" -c "$channel" -r "$rate" -f "$fmts" -d "$duration" /dev/zero >/dev/null &
+check_alsa_tool_process
 sofcard=${SOFCARD:-0}
 
 # https://mywiki.wooledge.org/BashFAQ/024 why cant I pipe data to read?
 readarray -t pgalist < <("$TOPDIR"/tools/topo_vol_kcontrols.py "$tplg")
 
 # This (1) provides some logging (2) avoids skip_test if amixer fails
-amixer -c"$sofcard" controls
+get_sof_controls "$sofcard"
 dlogi "pgalist number = ${#pgalist[@]}"
 [[ ${#pgalist[@]} -ne 0 ]] || skip_test "No PGA control is available"
 
-for i in $(seq 1 $maxloop)
+for i in $(seq 1 "$maxloop")
 do
     setup_kernel_check_point
     dlogi "===== Round($i/$maxloop) ====="
@@ -83,10 +105,9 @@ do
         dlogi "$volctrl"
 
         for vol in "${volume_array[@]}"; do
-            dlogc "amixer -c$sofcard cset name='$volctrl' $vol"
-            amixer -c"$sofcard" cset name="$volctrl" "$vol" > /dev/null ||
-                              func_error_exit "amixer return error, test failed"
-        done
+            set_sof_volume  "$sofcard"  "$volctrl" "$vol"  ||
+                              func_exit 1 "amixer return error, test failed"
+	done
     done
 
     sleep 1
@@ -96,8 +117,8 @@ do
                       func_error_exit "dmesg has errors!"
 done
 
-#clean up background aplay
-pkill -9 aplay || true
+#clean up background aplay/tinyplay
+func_exit 0
 
 dlogi "Reset all PGA volume to 0dB"
 reset_sof_volume || die "Failed to reset some PGA volume to 0dB."


### PR DESCRIPTION
Refactor the volume_basic_test to use lib.sh instead of calling ALSA commands directly, and add support for the tinymix command from TinyAlsa.

Note: This PR depends on [sof-test#1260](https://github.com/thesofproject/sof-test/pull/1260) and should only be merged after it has been merged.