### PR TITLE
[SKIP SOF-TEST] .github: upgrade yamllint runner to Ubuntu 24.04

### DIFF
--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -8,7 +8,7 @@ on: [push, pull_request, workflow_dispatch]
 jobs:
 
   yamllint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
       - name: yamllint github actions


### PR DESCRIPTION
Upgrade yamllint runner's Ubuntu from 20.04 to 24.04

Ubuntu 20.04 LTS runner is removed at GitHub since 2025-04-15.
see https://github.com/thesofproject/sof-test/actions/runs/14591728967