### PR TITLE
Fix: Set SOF_ALSA_TOOL to default value globally.

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -759,6 +759,7 @@ func_lib_check_pa()
 # before using 'aplay_opts' or 'arecord_opts' function.
 # Default is SOF_ALSA_TOOL='alsa'
 
+: "${SOF_ALSA_TOOL:="alsa"}"
 
 # Function to extract the card number and device number from $dev option (e.g., hw:0,10)
 parse_audio_device() {
@@ -791,7 +792,6 @@ initialize_audio_params()
     type=$(func_pipeline_parse_value "$idx" type)
     snd=$(func_pipeline_parse_value "$idx" snd)
 
-    : "${SOF_ALSA_TOOL:="alsa"}"
     if [[ "$SOF_ALSA_TOOL" = "tinyalsa" ]]; then
        parse_audio_device "$dev"
     fi


### PR DESCRIPTION
Set SOF_ALSA_TOOL variable to a default value globally.
Justification:
After tinyalsa support was added ([PR #1260](https://github.com/thesofproject/sof-test/pull/1260)), the use of SOF_ALSA_TOOL is now required for all tests before calling the aplay_opt or arecord_opt functions from lib.sh.