### PR TITLE
sof_remove.sh: remove snd_soc_sdca before snd_soc_core

### DIFF
--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -327,6 +327,8 @@ remove_module snd_hda_ext_core
 #-------------------------------------------
 # Remaining core ALSA/ASoC parts
 #-------------------------------------------
+remove_module snd_soc_acpi_intel_sdca_quirks
+remove_module snd_soc_sdca
 remove_module snd_soc_core
 remove_module snd_hda_codec
 remove_module snd_hda_core


### PR DESCRIPTION
snd_soc_sdca is used by snd_soc_core. It should be removed before snd_soc_sdca.