### PR TITLE
FIX: alsa_settings for PTLH_SDW_RT712

### DIFF
--- a/alsa_settings/PTLH_SDW_RT712.sh
+++ b/alsa_settings/PTLH_SDW_RT712.sh
@@ -4,9 +4,14 @@ amixer -c sofsoundwire cset name='Headphone Switch' on
 amixer -c sofsoundwire cset name='rt712 FU05 Playback Volume' 80
 amixer -c sofsoundwire cset name='rt712 FU06 Playback Volume' 80
 
-
-
 # enable headset playback and capture
 amixer -c sofsoundwire cset name='Headset Mic Switch' on
 amixer -c sofsoundwire cset name='rt712 FU0F Capture Switch' on
 amixer -c sofsoundwire cset name='rt712 FU0F Capture Volume' 46
+
+# set default volume levels
+amixer -c sofsoundwire cset name='Pre Mixer Jack Out Playback Volume' 95%
+amixer -c sofsoundwire cset name='Post Mixer Jack Out Playback Volume' 95%
+amixer -c sofsoundwire cset name='Pre Mixer Deepbuffer Jack Out Volume' 95%
+amixer -c sofsoundwire cset name='Pre Mixer Speaker Playback Volume' 95%
+amixer -c sofsoundwire cset name='Post Mixer Speaker Playback Volume' 95%


### PR DESCRIPTION
Add the default volume settings for PTLH SDW RT712. The level sets to 100% for these controls is a reason of failing the check-alsabat-headset-* tests.
The previous test case volume-basic-test-50.sh increrases the volume levels to 100% and do not revert to previous setting.

Jira: https://jira.devtools.intel.com/browse/SOFC2-1031