### PR TITLE
tinyalsa: fix: format conversion

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -774,9 +774,24 @@ parse_audio_device() {
 # There is passes PCM sample format while using ALSA tool (arecord)
 # While using TinyALSA (tinycap -b) we need to convert PCM sample fomrat to bits.
 extract_format_number() {
-    # (e.g., extracting '16' from 'S16_LE')
-    printf '%s' "$1" | grep '[0-9]\+' -o
-}
+    local format_string="$1"
+    local extracted_num
+
+    if [[ "$format_string" =~ ^[SU][0-9]+(_.*)?$ ]]; then
+        extracted_num=$(printf '%s' "${format_string}" | sed -E 's/^[SU]([0-9]+).*$/\1/')
+        printf '%s' "$extracted_num"
+    elif [[ "$format_string" =~ ^FLOAT[0-9]*$ ]]; then
+        extracted_num=$(printf '%s' "${format_string}" | sed -E 's/^FLOAT([0-9]*).*$/\1/')
+        # If extracted_num is empty (i.e., just "FLOAT"), default to 32
+        if [[ -z "$extracted_num" ]]; then
+            printf '32'
+        else
+            printf '%s' "$extracted_num"
+        fi
+    else
+        die "Error: Unknown format: %s\n"
+    fi
+}  
 
 # Initialize the parameters using for audio testing.
 # shellcheck disable=SC2034


### PR DESCRIPTION
Expand ALSA text to bit depth conversion function with support for FLOAT_LE, U8, MU_LAW, and A_LAW.

Justification.
The check-capture test uses format that doesn't contain the digit. " e.g., FLOAT_LE".
As a result, the converting function returns an empty string, which the shell interprets as 0. This causes the tinycap command to fail with the following error:
` tinycap /dev/null -D 0 -d 0 -c 2 -t 3 -r 48000 -b
0 bits is not supported.`
