### PR TITLE
sof_remove.sh: remove snd_hda_codec_intelhdmi before snd_hda_codec_hdmi

### DIFF
--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -301,6 +301,7 @@ remove_module snd_soc_max98390
 
 remove_module snd_soc_hdac_hda
 remove_module snd_soc_hdac_hdmi
+remove_module snd_hda_codec_intelhdmi
 remove_module snd_hda_codec_hdmi
 remove_module snd_soc_dmic
 


### PR DESCRIPTION
snd_hda_codec_intelhdmi was added recently by
commit 73cd0490819d ("ALSA: hda/hdmi: Split vendor codec drivers") and it is used by snd_hda_codec_hdmi. Need to remove it first to avoud error.