### PR TITLE
sof_remove: remove snd_hda_codec_alc269 and snd_hda_codec_realtek_lib first

### DIFF
--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -305,7 +305,9 @@ remove_module snd_hda_codec_intelhdmi
 remove_module snd_hda_codec_hdmi
 remove_module snd_soc_dmic
 
+remove_module snd_hda_codec_alc269
 remove_module snd_hda_codec_realtek
+remove_module snd_hda_codec_realtek_lib
 remove_module snd_hda_codec_generic
 
 remove_module snd_soc_wm8960


### PR DESCRIPTION
To fix the rmmod: ERROR: Module snd_hda_codec_generic is in use by: snd_hda_codec_realtek_lib snd_hda_codec_alc269 error