### PR TITLE
sof_remove: remove snd_hda_codec_alc882 before snd_hda_codec_realtek

### DIFF
--- a/tools/kmod/sof_remove.sh
+++ b/tools/kmod/sof_remove.sh
@@ -306,6 +306,7 @@ remove_module snd_hda_codec_hdmi
 remove_module snd_soc_dmic
 
 remove_module snd_hda_codec_alc269
+remove_module snd_hda_codec_alc882
 remove_module snd_hda_codec_realtek
 remove_module snd_hda_codec_realtek_lib
 remove_module snd_hda_codec_generic


### PR DESCRIPTION
To fix the rmmod: ERROR: Module snd_hda_codec_generic is in use by: snd_hda_codec_realtek_lib snd_hda_codec_alc882 error