### PR TITLE
[SKIP SOF-TEST] sof_perf_analyzer: fix float_format not callable error

### DIFF
--- a/tools/sof_perf_analyzer.py
+++ b/tools/sof_perf_analyzer.py
@@ -263,10 +263,10 @@ def print_perf_info():
         print(stats)
 
     if args.out2csv is not None:
-        stats.to_csv(args.out2csv, sep=',', float_format='%.3f', index=False)
+        stats.to_csv(args.out2csv, sep=',', float_format='{:.3f}'.format, index=False)
 
     if args.out2html is not None:
-        stats.to_html(args.out2html, float_format='%.3f', index=False)
+        stats.to_html(args.out2html, float_format='{:.3f}'.format, index=False)
 
 def parse_args():
     '''Parse command line arguments'''


### PR DESCRIPTION
Fix float_format string passed to pandas to_csv() and to_html() to be a callable object resolving 'TypeError: 'str' object is not callable' observed (with pandas==2.1.4)