### PR TITLE
alsa_settings: WCL platform settings

### DIFF
--- a/alsa_settings/WCL_HDA_AIOC.state
+++ b/alsa_settings/WCL_HDA_AIOC.state
@@ -1,0 +1,36 @@
+state.sofhdadsp {
+	control.1 {
+		iface MIXER
+		name 'Headphone Playback Volume'
+		value.0 60
+		value.1 60
+	}
+	control.2 {
+		iface MIXER
+		name 'Headphone Playback Switch'
+		value.0 true
+		value.1 true
+	}
+	control.6 {
+		iface MIXER
+		name 'Capture Volume'
+		value.0 30
+		value.1 30
+	}
+	control.7 {
+		iface MIXER
+		name 'Capture Switch'
+		value.0 true
+		value.1 true
+	}
+	control.9 {
+		iface MIXER
+		name 'Master Playback Volume'
+		value 87
+	}
+	control.10 {
+		iface MIXER
+		name 'Master Playback Switch'
+		value true
+	}
+}

--- a/alsa_settings/WCL_RVP_SDW.state
+++ b/alsa_settings/WCL_RVP_SDW.state
@@ -1,0 +1,43 @@
+state.sofsoundwire {
+	control.2 {
+		iface MIXER
+		name 'rt722 FU0F Capture Switch'
+		value.0 true
+		value.1 true
+	}
+	control.3 {
+		iface MIXER
+		name 'rt722 FU0F Capture Volume'
+		value.0 15
+		value.1 15
+	}
+	control.5 {
+		iface MIXER
+		name 'rt722 FU06 Playback Volume'
+		value.0 50
+		value.1 50
+	}
+	control.6 {
+		iface MIXER
+		name 'rt722 FU1E Capture Switch'
+		value.0 true
+		value.1 true
+		value.2 true
+		value.3 true
+	}
+	control.9 {
+		iface MIXER
+		name 'Headphone Switch'
+		value true
+	}
+	control.10 {
+		iface MIXER
+		name 'Headset Mic Switch'
+		value true
+	}
+	control.13 {
+		iface MIXER
+		name 'Speaker Switch'
+		value true
+	}
+}

--- a/alsa_settings/WCL_SDW_RT712.state
+++ b/alsa_settings/WCL_SDW_RT712.state
@@ -1,0 +1,36 @@
+state.sofsoundwire {
+	control.1 {
+		iface MIXER
+		name 'rt712 FU06 Playback Volume'
+		value.0 60
+		value.1 60
+	}
+	control.2 {
+		iface MIXER
+		name 'rt712 FU05 Playback Volume'
+		value.0 60
+		value.1 60
+	}
+	control.3 {
+		iface MIXER
+		name 'rt712 FU0F Capture Switch'
+		value.0 true
+		value.1 true
+	}
+	control.4 {
+		iface MIXER
+		name 'rt712 FU0F Capture Volume'
+		value.0 46
+		value.1 46
+	}
+	control.14 {
+		iface MIXER
+		name 'Headphone Switch'
+		value true
+	}
+	control.15 {
+		iface MIXER
+		name 'Headset Mic Switch'
+		value true
+	}
+}


### PR DESCRIPTION
Create WCL platform ALSA settings state files for:

 * WCL_HDA_AIOC
 * WCL_SDW_RT712
 * WCL_RVP_SDW

The parameters in the state files are explicitly set even if the default values at the appropriate DUT are currently the same.