### PR TITLE
latency tests: Clean up jackd on test setup

### DIFF
--- a/test-case/latency-metrics.sh
+++ b/test-case/latency-metrics.sh
@@ -260,6 +260,7 @@ report_end()
 
 main()
 {
+  pkill jackd || True
   check_latency_options
 
   setup_kernel_check_point


### PR DESCRIPTION
Sometimes when timeout is reached, the latency test does not terminate the jackd process. This commit adds `pkill jackd` on test setup to ensure no instance od `jackd` is running.