### PR TITLE
test-case: latency-metrics.sh: Change `True` to lowercase

### DIFF
--- a/test-case/latency-metrics.sh
+++ b/test-case/latency-metrics.sh
@@ -260,7 +260,7 @@ report_end()
 
 main()
 {
-  pkill jackd || True
+  pkill jackd || true
   check_latency_options
 
   setup_kernel_check_point


### PR DESCRIPTION
This fixes the wrong syntax of the bash built-in `true`.