### PR TITLE
test-case: Implement one common method for kill process

### DIFF
--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -945,6 +945,30 @@ check_alsa_tool_process()
     esac
 }
 
+kill_process()
+{
+    local pid="$1"
+    local sleep_secs="${2:-1}"
+
+    [[ -n "$pid" ]] || {
+        die "kill_process: missing pid"
+        return 1
+    }
+
+    ps -p "$pid" >/dev/null || return 0
+
+    kill -15 "$pid" || true
+    sleep "$sleep_secs"
+
+    ps -p "$pid" >/dev/null || return 0
+
+    kill -9 "$pid" || true
+
+    ps -p "$pid" >/dev/null && return 1
+
+    return 0
+}
+
 aplay_opts()
 {
     if [[ "$SOF_ALSA_TOOL" = "tinyalsa" ]]; then

--- a/test-case/check-runtime-pm-double-active.sh
+++ b/test-case/check-runtime-pm-double-active.sh
@@ -113,8 +113,9 @@ do
         dlogi "runtime status: $result"
         if [[ $result == active ]]; then
             # stop playback or capture device - check status again
-            dlogc "kill process: kill -9 $pid"
-            kill -9 $pid && wait $pid 2>/dev/null
+            dlogc "kill process: $pid"
+            kill_process "$pid" || true
+            wait "$pid" 2>/dev/null || true
             dlogi "$cmd killed"
 
             # check runtime pm status with maxmium timeout value, it will exit if dsp is not suspended
@@ -125,8 +126,9 @@ do
         else
             dloge "$cmd process for pcm $pcm runtime status is not active as expected"
             # stop playback or capture device otherwise no one will stop this $cmd.
-            dlogc "kill process: kill -9 $pid"
-            kill -9 $pid && wait $pid 2>/dev/null
+            dlogc "kill process: $pid"
+            kill_process "$pid" || true
+            wait "$pid" 2>/dev/null || true
             func_lib_lsof_error_dump $snd
             exit 1
         fi

--- a/test-case/check-runtime-pm-status.sh
+++ b/test-case/check-runtime-pm-status.sh
@@ -109,8 +109,9 @@ do
         dlogi "runtime status: $result"
         if [[ $result == active ]]; then
             # stop playback or capture device - check status again
-            dlogc "kill process: kill -9 $pid"
-            kill -9 $pid && wait $pid 2>/dev/null
+            dlogc "kill process: $pid"
+            kill_process "$pid" || true
+            wait "$pid" 2>/dev/null || true
             dlogi "$cmd killed"
             func_check_dsp_status ${OPT_VAL['d']}
             result=`sof-dump-status.py --dsp_status 0`
@@ -123,8 +124,9 @@ do
         else
             dloge "$cmd process for pcm $pcm runtime status is not active as expected"
             # stop playback or capture device otherwise no one will stop this $cmd.
-            dlogc "kill process: kill -9 $pid"
-            kill -9 $pid && wait $pid 2>/dev/null
+            dlogc "kill process: $pid"
+            kill_process "$pid" || true
+            wait "$pid" 2>/dev/null || true
             func_lib_lsof_error_dump $snd
             exit 1
         fi

--- a/test-case/check-signal-stop-start.sh
+++ b/test-case/check-signal-stop-start.sh
@@ -70,7 +70,7 @@ func_stop_start_pipeline()
         # check aplay/arecord process state
         sof-process-state.sh "$pid" >/dev/null || {
             dloge "$cmd($pid) process is in an abnormal status"
-            kill -9 "$pid"
+            kill_process "$pid" || true
             exit 1
         }
         dlogi "Stop/start count: $i"
@@ -116,8 +116,8 @@ do
     func_stop_start_pipeline
 
     # kill aplay/arecord process
-    dlogc "kill process: kill -9 $pid"
-    kill -9 "$pid"
+    dlogc "kill process: $pid"
+    kill_process "$pid" || true
 done
 
 sof-kernel-log-check.sh "$KERNEL_CHECKPOINT"

--- a/test-case/check-suspend-resume-with-audio.sh
+++ b/test-case/check-suspend-resume-with-audio.sh
@@ -137,6 +137,6 @@ do
         exit 1
     }
     dlogi "Killing $cmd_args"
-    kill -9 $process_id || true
+    kill_process "$process_id" || true
 done
 

--- a/test-case/check-userspace-paplay.sh
+++ b/test-case/check-userspace-paplay.sh
@@ -108,7 +108,7 @@ for round in $(seq 1 $round_cnt); do
             else
                 dlogi "paplay runs successfully"
                 # kill all paplay process
-                kill -9 $pid
+                kill_process "$pid" || true
                 sleep 0.5
             fi
         fi

--- a/test-case/check-userspace-parecord.sh
+++ b/test-case/check-userspace-parecord.sh
@@ -115,7 +115,7 @@ for round in $(seq 1 $round_cnt); do
             else
                 dlogi "parecord runs successfully"
                 # kill all parecord processes
-                kill -9 $pid
+                kill_process "$pid" || true
                 sleep 0.5
             fi
         fi

--- a/test-case/check-volume-levels.sh
+++ b/test-case/check-volume-levels.sh
@@ -83,7 +83,7 @@ main () {
     # Stop sine playback and do cleanup
     nap
     dlogi "The test procedure is now complete. Killing the aplay process $aplayPID."
-    kill $aplayPID
+    kill_process "$aplayPID" || true
 
     # Measure, delete unnecessary wav files if passed
     if measure_levels; then

--- a/test-case/check-xrun-injection.sh
+++ b/test-case/check-xrun-injection.sh
@@ -72,7 +72,8 @@ func_xrun_injection()
         # check aplay/arecord process state
         sof-process-state.sh "$pid" >/dev/null || {
             dloge "aplay/arecord process is in an abnormal status"
-            kill -9 "$pid" && wait "$pid" 2>/dev/null
+            kill_process "$pid" || true
+            wait "$pid" 2>/dev/null || true
             exit 1
         }
         dlogi "XRUN injection: $i"
@@ -119,8 +120,9 @@ do
     dlogc "echo 1 > $xrun_injection"
     func_xrun_injection
     # kill aplay/arecord process
-    dlogc "kill process: kill -9 $pid"
-    kill -9 $pid && wait $pid 2>/dev/null
+    dlogc "kill process: $pid"
+    kill_process "$pid" || true
+    wait "$pid" 2>/dev/null || true
 done
 
 sof-kernel-log-check.sh "$KERNEL_CHECKPOINT"

--- a/test-case/multiple-pipeline.sh
+++ b/test-case/multiple-pipeline.sh
@@ -127,8 +127,10 @@ func_error_exit()
 {
     dloge "$*"
 
-    pgrep -a aplay   &&  pkill -9 aplay
-    pgrep -a arecord &&  pkill -9 arecord
+    pgrep -a aplay &&
+        while read -r pid; do kill_process "$pid" || true; done < <(pgrep -x aplay)
+    pgrep -a arecord &&
+        while read -r pid; do kill_process "$pid" || true; done < <(pgrep -x arecord)
 
     exit 1
 }
@@ -208,9 +210,9 @@ do
     dlogi "checking pipeline status again"
     ps_checks
 
-    dlogc 'pkill -9 aplay arecord'
-    pkill -9 arecord || true
-    pkill -9 aplay   || true
+    dlogc 'kill_process all aplay/arecord pids'
+    while read -r pid; do kill_process "$pid" || true; done < <(pgrep -x arecord)
+    while read -r pid; do kill_process "$pid" || true; done < <(pgrep -x aplay)
     sleep 1 # try not to pollute the next iteration
 
     if pgrep arecord || pgrep aplay; then

--- a/test-case/simultaneous-playback-capture.sh
+++ b/test-case/simultaneous-playback-capture.sh
@@ -67,8 +67,10 @@ logger_disabled || func_lib_start_log_collect
 func_error_exit()
 {
     dloge "$*"
-    kill -9 "$aplay_pid" && wait "$aplay_pid" 2>/dev/null
-    kill -9 "$arecord_pid" && wait "$arecord_pid" 2>/dev/null
+    kill_process "$aplay_pid" || true
+    wait "$aplay_pid" 2>/dev/null || true
+    kill_process "$arecord_pid" || true
+    wait "$arecord_pid" 2>/dev/null || true
     exit 1
 }
 
@@ -113,8 +115,10 @@ do
 
         # kill all live processes, successful end of test
         dlogc "killing all pipelines"
-        kill -9 $aplay_pid && wait $aplay_pid 2>/dev/null
-        kill -9 $arecord_pid && wait $arecord_pid 2>/dev/null
+        kill_process "$aplay_pid" || true
+        wait "$aplay_pid" 2>/dev/null || true
+        kill_process "$arecord_pid" || true
+        wait "$arecord_pid" 2>/dev/null || true
 
     done
     # check kernel log for each iteration to catch issues

--- a/test-case/test-jack-detection-playback-capture.sh
+++ b/test-case/test-jack-detection-playback-capture.sh
@@ -156,7 +156,7 @@ testing_one_pcm()
         die "Plug $headphone_jack_name jack failed."
     }
 
-    kill -9 $pid_playback > /dev/null 2>&1
+    kill_process "$pid_playback" > /dev/null 2>&1 || true
     wait $pid_playback 2>/dev/null || true
     ps -p "$pid_playback" > /dev/null && {
         dloge "Failed to kill playback process."


### PR DESCRIPTION
This PR replaces all direct usages of kill -9 with a new helper function, kill_process().
The new function introduces a safer and more controlled process‑termination flow, using graceful shutdown attempts before falling back to a forced kill.

Function was tested and it works:
<img width="345" height="191" alt="image" src="https://github.com/user-attachments/assets/0859e06c-0701-449f-bc26-5d5632113660" />


