### PR TITLE
fix: tools: sof_perf_analyzer: ignore errors when decoding mtrace file

### DIFF
--- a/case-lib/hijack.sh
+++ b/case-lib/hijack.sh
@@ -169,10 +169,7 @@ function func_exit_handler()
 
     # Only do performance analysis on test passed
     [ "x$exit_status" != "x0" ] || {
-        # On performance analysis return error, set exit code
-        if ! perf_analyze; then
-           exit_status=1
-        fi
+        perf_analyze || dlogw 'perf_analyze failed in exit handler'
     }
 
     # Only run when changing topology was initiated during the test

--- a/case-lib/lib.sh
+++ b/case-lib/lib.sh
@@ -1496,11 +1496,11 @@ perf_analyze()
         fi
         dlogc "$perf_cmd"
         eval "$perf_cmd" || {
-            dloge "SOF component performace analysis tool exit with error"
+            dlogw "SOF component performace analysis tool exit with error"
             return 1
         }
     else
-        dloge "Firmware trace file not found"
+        dlogw "Firmware trace file not found"
         return 1
     fi
 }

--- a/tools/sof_perf_analyzer.py
+++ b/tools/sof_perf_analyzer.py
@@ -173,7 +173,7 @@ def process_trace_file():
     #
     # pylint: disable=C0103
     ts_shift = 0
-    with open(args.filename, 'r', encoding='utf8') as file:
+    with open(args.filename, 'r', encoding='utf8', errors='ignore') as file:
         trace_item_gen = make_trace_item(file)
         trace_prev = None
         try:


### PR DESCRIPTION
Add ignore errors option when decoding mtrace file in sof_perf_analyzer.py script.